### PR TITLE
build: Re-enable Scala style checker and spotless 

### DIFF
--- a/dev/scalastyle-config.xml
+++ b/dev/scalastyle-config.xml
@@ -242,9 +242,9 @@ This file is divided into 3 sections:
       <parameter name="groups">java,scala,org,apache,3rdParty,comet</parameter>
       <parameter name="group.java">javax?\..*</parameter>
       <parameter name="group.scala">scala\..*</parameter>
-      <parameter name="group.org">org\..*</parameter>
-      <parameter name="group.apache">org\.apache\..*</parameter>
-      <parameter name="group.3rdParty">(?!org\.apache\.comet\.).*</parameter>
+      <parameter name="group.org">org\.(?!apache\.comet).*</parameter>
+      <parameter name="group.apache">org\.apache\.(?!comet).*</parameter>
+      <parameter name="group.3rdParty">(?!(javax?\.|scala\.|org\.apache\.comet\.)).*</parameter>
       <parameter name="group.comet">org\.apache\.comet\..*</parameter>
     </parameters>
   </check>
@@ -301,7 +301,8 @@ This file is divided into 3 sections:
   </check>
 
   <check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
-  <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
+  <!-- This rule conflicts with spotless, so disabling it for now -->
+  <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="false"></check>
 
   <!-- This breaks symbolic method names so we don't turn it on. -->
   <!-- Maybe we should update it to allow basic symbolic names, and then we are good to go. -->

--- a/pom.xml
+++ b/pom.xml
@@ -740,7 +740,6 @@ under the License.
       </plugins>
     </pluginManagement>
     <plugins>
-      <!--
       <plugin>
         <groupId>org.scalastyle</groupId>
         <artifactId>scalastyle-maven-plugin</artifactId>
@@ -778,7 +777,6 @@ under the License.
           </execution>
         </executions>
       </plugin>
-      -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>

--- a/scalafmt.conf
+++ b/scalafmt.conf
@@ -36,6 +36,6 @@ rewrite.imports.groups = [
   ["scala\\..*"],
   ["org\\..*"],
   ["org\\.apache\\..*"],
-  ["org\\.apache\\.comet\\..*"],
   ["com\\..*"],
+  ["org\\.apache\\.comet\\..*"],
 ]

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometBatchScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometBatchScanExec.scala
@@ -32,10 +32,10 @@ import org.apache.spark.sql.execution.datasources.v2._
 import org.apache.spark.sql.execution.metric._
 import org.apache.spark.sql.vectorized._
 
+import com.google.common.base.Objects
+
 import org.apache.comet.MetricsSupport
 import org.apache.comet.shims.ShimCometBatchScanExec
-
-import com.google.common.base.Objects
 
 case class CometBatchScanExec(wrapped: BatchScanExec, runtimeFilters: Seq[Expression])
     extends DataSourceV2ScanExecBase

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -33,11 +33,11 @@ import org.apache.spark.sql.execution.{ColumnarToRowExec, ExecSubqueryExpression
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
+import com.google.common.base.Objects
+
 import org.apache.comet.{CometConf, CometExecIterator, CometRuntimeException, CometSparkSessionExtensions}
 import org.apache.comet.CometConf.{COMET_BATCH_SIZE, COMET_DEBUG_ENABLED, COMET_EXEC_MEMORY_FRACTION}
 import org.apache.comet.serde.OperatorOuterClass.Operator
-
-import com.google.common.base.Objects
 
 /**
  * A Comet physical operator

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -47,10 +47,10 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
+import com.google.common.primitives.UnsignedLong
+
 import org.apache.comet.CometConf
 import org.apache.comet.CometSparkSessionExtensions.isSpark34Plus
-
-import com.google.common.primitives.UnsignedLong
 
 abstract class ParquetReadSuite extends CometTestBase {
   import testImplicits._


### PR DESCRIPTION
This PR re-enables Scala style checker and spotless Maven plugin. Now the CI should fail when the code style is incorrect.