### PR TITLE
build: Add CI for MacOS (x64 and aarch64)

### DIFF
--- a/.github/actions/java-test/action.yaml
+++ b/.github/actions/java-test/action.yaml
@@ -18,7 +18,7 @@
 runs:
   using: "composite"
   steps:
-    - name: Run cargo build
+    - name: Run Cargo build
       shell: bash
       run: |
         cd core

--- a/.github/actions/java-test/action.yaml
+++ b/.github/actions/java-test/action.yaml
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run cargo build
+      shell: bash
+      run: |
+        cd core
+        cargo build
+
+    - name: Cache Maven dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
+    - name: Run Maven compile
+      shell: bash
+      run: |
+        ./mvnw compile test-compile scalafix:scalafix -Psemanticdb
+
+    - name: Run tests
+      shell: bash
+      run: |
+        SPARK_HOME=`pwd` ./mvnw clean install

--- a/.github/actions/rust-test/action.yaml
+++ b/.github/actions/rust-test/action.yaml
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check cargo fmt
+      shell: bash
+      run: |
+        cd core
+        cargo fmt --all -- --check --color=never
+
+    - name: Check cargo clippy
+      shell: bash
+      run: |
+        cd core
+        cargo clippy --color=never -- -D warnings
+
+    - name: Check compilation
+      shell: bash
+      run: |
+        cd core
+        cargo check --benches
+
+    - name: Cache Maven dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
+    - name: Build common module (pre-requisite for Rust tests)
+      shell: bash
+      run: |
+        cd common
+        ../mvnw clean compile -DskipTests
+
+    - name: Run cargo test
+      shell: bash
+      run: |
+        cd core
+        # This is required to run some JNI related tests on the Rust side
+        RUST_BACKTRACE=1 \
+        LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$JAVA_HOME/lib:$JAVA_HOME/lib/server:$JAVA_HOME/lib/jli \
+        DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$JAVA_HOME/lib:$JAVA_HOME/lib/server:$JAVA_HOME/lib/jli \
+        cargo test
+

--- a/.github/actions/rust-test/action.yaml
+++ b/.github/actions/rust-test/action.yaml
@@ -19,13 +19,13 @@
 runs:
   using: "composite"
   steps:
-    - name: Check cargo fmt
+    - name: Check Cargo fmt
       shell: bash
       run: |
         cd core
         cargo fmt --all -- --check --color=never
 
-    - name: Check cargo clippy
+    - name: Check Cargo clippy
       shell: bash
       run: |
         cd core
@@ -51,7 +51,7 @@ runs:
         cd common
         ../mvnw clean compile -DskipTests
 
-    - name: Run cargo test
+    - name: Run Cargo test
       shell: bash
       run: |
         cd core

--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -39,7 +39,7 @@ runs:
       uses: actions/setup-java@v4
       with:
         distribution: 'adopt'
-        java-version: '17'
+        java-version: ${{inputs.jdk-version}}
 
     - name: Set JAVA_HOME
       shell: bash

--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -35,7 +35,7 @@ runs:
         apt-get update
         apt-get install -y protobuf-compiler
 
-    - name: Install JDK 17
+    - name: Install JDK ${{inputs.jdk-version}}
       uses: actions/setup-java@v4
       with:
         distribution: 'adopt'

--- a/.github/actions/setup-macos-builder/action.yaml
+++ b/.github/actions/setup-macos-builder/action.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Prepare Builder
+name: Prepare Builder for MacOS
 description: 'Prepare Build Environment'
 inputs:
   rust-version:
@@ -26,20 +26,31 @@ inputs:
     description: 'jdk version to install (e.g., 17)'
     required: true
     default: '17'
+  architecture:
+    description: 'OS architecture for the JDK'
+    required: true
+    default: 'x64'
 runs:
   using: "composite"
   steps:
     - name: Install Build Dependencies
       shell: bash
       run: |
-        apt-get update
-        apt-get install -y protobuf-compiler
+        # Install protobuf
+        mkdir -p $HOME/d/protoc
+        cd $HOME/d/protoc
+        export PROTO_ZIP="protoc-21.4-osx-aarch_64.zip"
+        curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.4/$PROTO_ZIP
+        unzip $PROTO_ZIP
+        echo "$HOME/d/protoc/bin" >> $GITHUB_PATH
+        export PATH=$PATH:$HOME/d/protoc/bin
 
     - name: Install JDK 17
       uses: actions/setup-java@v4
       with:
         distribution: 'adopt'
         java-version: '17'
+        architecture: ${{inputs.architecture}}
 
     - name: Set JAVA_HOME
       shell: bash

--- a/.github/actions/setup-macos-builder/action.yaml
+++ b/.github/actions/setup-macos-builder/action.yaml
@@ -26,10 +26,15 @@ inputs:
     description: 'jdk version to install (e.g., 17)'
     required: true
     default: '17'
-  architecture:
+  jdk-architecture:
     description: 'OS architecture for the JDK'
     required: true
     default: 'x64'
+  protoc-architecture:
+    description: 'OS architecture for protobuf compiler'
+    required: true
+    default: 'x86_64'
+
 runs:
   using: "composite"
   steps:
@@ -39,7 +44,7 @@ runs:
         # Install protobuf
         mkdir -p $HOME/d/protoc
         cd $HOME/d/protoc
-        export PROTO_ZIP="protoc-21.4-osx-aarch_64.zip"
+        export PROTO_ZIP="protoc-21.4-osx-${{inputs.protoc-architecture}}.zip"
         curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.4/$PROTO_ZIP
         unzip $PROTO_ZIP
         echo "$HOME/d/protoc/bin" >> $GITHUB_PATH
@@ -49,8 +54,8 @@ runs:
       uses: actions/setup-java@v4
       with:
         distribution: 'adopt'
-        java-version: '17'
-        architecture: ${{inputs.architecture}}
+        java-version: ${{inputs.jdk-version}}
+        architecture: ${{inputs.jdk-architecture}}
 
     - name: Set JAVA_HOME
       shell: bash

--- a/.github/actions/setup-macos-builder/action.yaml
+++ b/.github/actions/setup-macos-builder/action.yaml
@@ -50,7 +50,7 @@ runs:
         echo "$HOME/d/protoc/bin" >> $GITHUB_PATH
         export PATH=$PATH:$HOME/d/protoc/bin
 
-    - name: Install JDK 17
+    - name: Install JDK ${{inputs.jdk-version}}
       uses: actions/setup-java@v4
       with:
         distribution: 'adopt'

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -51,39 +51,9 @@ jobs:
           rust-version: nightly
           jdk-version: ${{env.JAVA_VERSION}}
 
-      - name: Check cargo fmt
-        run: |
-          cd core
-          cargo fmt --all -- --check --color=never
-
-      - name: Check cargo clippy
-        run: |
-          cd core
-          cargo clippy --color=never -- -D warnings
-
-      - name: Check compilation
-        run: |
-          cd core
-          cargo check --benches
-
-      - name: Cache Maven dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: Build common module (pre-requisite for Rust tests)
-        run: |
-          cd common
-          ../mvnw clean compile -DskipTests
-
-      - name: Run cargo test
-        run: |
-          cd core
-          # This is required to run some JNI related tests on the Rust side
-          RUST_BACKTRACE=1 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$JAVA_HOME/lib:$JAVA_HOME/lib/server:$JAVA_HOME/lib/jli cargo test
+      - uses: actions/checkout@v4
+      - name: Rust test steps
+        uses: ./.github/actions/rust-test
 
   linux-java-test:
     name: Java test (amd64)
@@ -97,27 +67,12 @@ jobs:
         with:
           rust-version: nightly
           jdk-version: ${{env.JAVA_VERSION}}
+          architecture: x64
 
-      - name: Run cargo build
-        run: |
-          cd core
-          cargo build
+      - uses: actions/checkout@v4
+      - name: Java test steps
+        uses: ./.github/actions/java-test
 
-      - name: Cache Maven dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: Run Maven compile
-        run: |
-          ./mvnw compile test-compile scalafix:scalafix -Psemanticdb
-
-      - name: Run tests
-        run: |
-          SPARK_HOME=`pwd` ./mvnw clean install
 
   macos-rust-test:
     name: Rust test (macos)
@@ -131,39 +86,9 @@ jobs:
           jdk-version: ${{env.JAVA_VERSION}}
           architecture: x64
 
-      - name: Check cargo fmt
-        run: |
-          cd core
-          cargo fmt --all -- --check --color=never
-
-      - name: Check cargo clippy
-        run: |
-          cd core
-          cargo clippy --color=never -- -D warnings
-
-      - name: Check compilation
-        run: |
-          cd core
-          cargo check --benches
-
-      - name: Cache Maven dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: Build common module (pre-requisite for Rust tests)
-        run: |
-          cd common
-          ../mvnw clean compile -DskipTests
-
-      - name: Run cargo test
-        run: |
-          cd core
-          # This is required to run some JNI related tests on the Rust side
-          RUST_BACKTRACE=1 DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$JAVA_HOME/lib:$JAVA_HOME/lib/server:$JAVA_HOME/lib/jli cargo test
+      - uses: actions/checkout@v4
+      - name: Rust test steps
+        uses: ./.github/actions/rust-test
 
   macos-java-test:
     name: Java test (macos)
@@ -177,26 +102,9 @@ jobs:
           jdk-version: ${{env.JAVA_VERSION}}
           architecture: x64
 
-      - name: Run cargo build
-        run: |
-          cd core
-          cargo build
-
-      - name: Cache Maven dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: Run Maven compile
-        run: |
-          ./mvnw compile test-compile scalafix:scalafix -Psemanticdb
-
-      - name: Run tests
-        run: |
-          SPARK_HOME=`pwd` ./mvnw clean install
+      - uses: actions/checkout@v4
+      - name: Java test steps
+        uses: ./.github/actions/java-test
 
   macos-aarch64-rust-test:
     name: Rust test (macos-aarch64)
@@ -210,39 +118,9 @@ jobs:
           jdk-version: ${{env.JAVA_VERSION}}
           architecture: aarch64
 
-      - name: Check cargo fmt
-        run: |
-          cd core
-          cargo fmt --all -- --check --color=never
-
-      - name: Check cargo clippy
-        run: |
-          cd core
-          cargo clippy --color=never -- -D warnings
-
-      - name: Check compilation
-        run: |
-          cd core
-          cargo check --benches
-
-      - name: Cache Maven dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: Build common module (pre-requisite for Rust tests)
-        run: |
-          cd common
-          ../mvnw clean compile -DskipTests
-
-      - name: Run cargo test
-        run: |
-          cd core
-          # This is required to run some JNI related tests on the Rust side
-          RUST_BACKTRACE=1 DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$JAVA_HOME/lib:$JAVA_HOME/lib/server:$JAVA_HOME/lib/jli cargo test
+      - uses: actions/checkout@v4
+      - name: Rust test steps
+        uses: ./.github/actions/rust-test
 
   macos-aarch64-java-test:
     name: Java test (macos-aarch64)
@@ -256,23 +134,6 @@ jobs:
           jdk-version: ${{env.JAVA_VERSION}}
           architecture: aarch64
 
-      - name: Run cargo build
-        run: |
-          cd core
-          cargo build
-
-      - name: Cache Maven dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: Run Maven compile
-        run: |
-          ./mvnw compile test-compile scalafix:scalafix -Psemanticdb
-
-      - name: Run tests
-        run: |
-          SPARK_HOME=`pwd` ./mvnw clean install
+      - uses: actions/checkout@v4
+      - name: Java test steps
+        uses: ./.github/actions/java-test

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -36,6 +36,7 @@ on:
 
 env:
   JAVA_VERSION: 17
+  RUST_VERSION: nightly
 
 jobs:
   linux-rust-test:
@@ -48,7 +49,7 @@ jobs:
       - name: Setup Rust & Java toolchain
         uses: ./.github/actions/setup-builder
         with:
-          rust-version: nightly
+          rust-version: ${{env.RUST_VERSION}}
           jdk-version: ${{env.JAVA_VERSION}}
 
       - uses: actions/checkout@v4
@@ -65,9 +66,8 @@ jobs:
       - name: Setup Rust & Java toolchain
         uses: ./.github/actions/setup-builder
         with:
-          rust-version: nightly
+          rust-version: ${{env.RUST_VERSION}}
           jdk-version: ${{env.JAVA_VERSION}}
-          architecture: x64
 
       - uses: actions/checkout@v4
       - name: Java test steps
@@ -82,9 +82,8 @@ jobs:
       - name: Setup Rust & Java toolchain
         uses: ./.github/actions/setup-macos-builder
         with:
-          rust-version: nightly
+          rust-version: ${{env.RUST_VERSION}}
           jdk-version: ${{env.JAVA_VERSION}}
-          architecture: x64
 
       - uses: actions/checkout@v4
       - name: Rust test steps
@@ -98,9 +97,8 @@ jobs:
       - name: Setup Rust & Java toolchain
         uses: ./.github/actions/setup-macos-builder
         with:
-          rust-version: nightly
+          rust-version: ${{env.RUST_VERSION}}
           jdk-version: ${{env.JAVA_VERSION}}
-          architecture: x64
 
       - uses: actions/checkout@v4
       - name: Java test steps
@@ -114,9 +112,10 @@ jobs:
       - name: Setup Rust & Java toolchain
         uses: ./.github/actions/setup-macos-builder
         with:
-          rust-version: nightly
+          rust-version: ${{env.RUST_VERSION}}
           jdk-version: ${{env.JAVA_VERSION}}
-          architecture: aarch64
+          jdk-architecture: aarch64
+          protoc-architecture: aarch_64
 
       - uses: actions/checkout@v4
       - name: Rust test steps
@@ -130,9 +129,10 @@ jobs:
       - name: Setup Rust & Java toolchain
         uses: ./.github/actions/setup-macos-builder
         with:
-          rust-version: nightly
+          rust-version: ${{env.RUST_VERSION}}
           jdk-version: ${{env.JAVA_VERSION}}
-          architecture: aarch64
+          jdk-architecture: aarch64
+          protoc-architecture: aarch_64
 
       - uses: actions/checkout@v4
       - name: Java test steps

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -66,10 +66,6 @@ jobs:
           cd core
           cargo check --benches
 
-      - name: Setup JAVA_HOME
-        run: |
-          echo "JAVA_HOME=/usr/lib/jvm/java-${{env.JAVA_VERSION}}-openjdk-amd64" >> $GITHUB_ENV
-
       - name: Cache Maven dependencies
         uses: actions/cache@v4
         with:
@@ -87,7 +83,7 @@ jobs:
         run: |
           cd core
           # This is required to run some JNI related tests on the Rust side
-          RUST_BACKTRACE=1 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$JAVA_HOME/lib:$JAVA_HOME/lib/server cargo test
+          RUST_BACKTRACE=1 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$JAVA_HOME/lib:$JAVA_HOME/lib/server:$JAVA_HOME/lib/jli cargo test
 
   linux-java-test:
     name: Java test (amd64)
@@ -107,9 +103,163 @@ jobs:
           cd core
           cargo build
 
-      - name: Setup JAVA_HOME
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Run Maven compile
         run: |
-          echo "JAVA_HOME=/usr/lib/jvm/java-${{env.JAVA_VERSION}}-openjdk-amd64" >> $GITHUB_ENV
+          ./mvnw compile test-compile scalafix:scalafix -Psemanticdb
+
+      - name: Run tests
+        run: |
+          SPARK_HOME=`pwd` ./mvnw clean install
+
+  macos-rust-test:
+    name: Rust test (macos)
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust & Java toolchain
+        uses: ./.github/actions/setup-macos-builder
+        with:
+          rust-version: nightly
+          jdk-version: ${{env.JAVA_VERSION}}
+          architecture: x64
+
+      - name: Check cargo fmt
+        run: |
+          cd core
+          cargo fmt --all -- --check --color=never
+
+      - name: Check cargo clippy
+        run: |
+          cd core
+          cargo clippy --color=never -- -D warnings
+
+      - name: Check compilation
+        run: |
+          cd core
+          cargo check --benches
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build common module (pre-requisite for Rust tests)
+        run: |
+          cd common
+          ../mvnw clean compile -DskipTests
+
+      - name: Run cargo test
+        run: |
+          cd core
+          # This is required to run some JNI related tests on the Rust side
+          RUST_BACKTRACE=1 DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$JAVA_HOME/lib:$JAVA_HOME/lib/server:$JAVA_HOME/lib/jli cargo test
+
+  macos-java-test:
+    name: Java test (macos)
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust & Java toolchain
+        uses: ./.github/actions/setup-macos-builder
+        with:
+          rust-version: nightly
+          jdk-version: ${{env.JAVA_VERSION}}
+          architecture: x64
+
+      - name: Run cargo build
+        run: |
+          cd core
+          cargo build
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Run Maven compile
+        run: |
+          ./mvnw compile test-compile scalafix:scalafix -Psemanticdb
+
+      - name: Run tests
+        run: |
+          SPARK_HOME=`pwd` ./mvnw clean install
+
+  macos-aarch64-rust-test:
+    name: Rust test (macos-aarch64)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust & Java toolchain
+        uses: ./.github/actions/setup-macos-builder
+        with:
+          rust-version: nightly
+          jdk-version: ${{env.JAVA_VERSION}}
+          architecture: aarch64
+
+      - name: Check cargo fmt
+        run: |
+          cd core
+          cargo fmt --all -- --check --color=never
+
+      - name: Check cargo clippy
+        run: |
+          cd core
+          cargo clippy --color=never -- -D warnings
+
+      - name: Check compilation
+        run: |
+          cd core
+          cargo check --benches
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build common module (pre-requisite for Rust tests)
+        run: |
+          cd common
+          ../mvnw clean compile -DskipTests
+
+      - name: Run cargo test
+        run: |
+          cd core
+          # This is required to run some JNI related tests on the Rust side
+          RUST_BACKTRACE=1 DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$JAVA_HOME/lib:$JAVA_HOME/lib/server:$JAVA_HOME/lib/jli cargo test
+
+  macos-aarch64-java-test:
+    name: Java test (macos-aarch64)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust & Java toolchain
+        uses: ./.github/actions/setup-macos-builder
+        with:
+          rust-version: nightly
+          jdk-version: ${{env.JAVA_VERSION}}
+          architecture: aarch64
+
+      - name: Run cargo build
+        run: |
+          cd core
+          cargo build
 
       - name: Cache Maven dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #9.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Add CI for MacOS, including both `x86_64` and `aarch64`. This increases our test coverage and make sure the library is tested in more platforms & architectures. Many people uses Spark on their Mac as well.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add CI for MacOS, including both `x86_64` and `aarch64`. Since the existing workflows largely share the same logic, this also creates two common actions: `java-test` and `rust-test`, that are used by the main `pr_build` workflows.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
