### PR TITLE
fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ On a high level, Comet aims to support:
 
 The following diagram illustrates the architecture of Comet:
 
-<a href="url"><img src="doc/comet-overview.png" align="center" height="600" width="750" ></a>
+<a href="doc/comet-overview.png"><img src="doc/comet-overview.png" align="center" height="600" width="750" ></a>
 
 ## Current Status
 


### PR DESCRIPTION
url was going to empty "url" instead of expanding image size

## Which issue does this PR close?

n/a, very minor typo fix

Closes #.

## Rationale for this change

link doesn't work

## What changes are included in this PR?

fix url

## How are these changes tested?

github preview of updated readme