### PR TITLE
build: Fix mvn cache for containerized runners

### DIFF
--- a/.github/actions/java-test/action.yaml
+++ b/.github/actions/java-test/action.yaml
@@ -27,7 +27,9 @@ runs:
     - name: Cache Maven dependencies
       uses: actions/cache@v4
       with:
-        path: ~/.m2/repository
+        path: |
+          ~/.m2/repository
+          /root/.m2/repository # for containerized runners, root is used
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-

--- a/.github/actions/java-test/action.yaml
+++ b/.github/actions/java-test/action.yaml
@@ -29,7 +29,7 @@ runs:
       with:
         path: |
           ~/.m2/repository
-          /root/.m2/repository # for containerized runners, root is used
+          /root/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-

--- a/.github/actions/java-test/action.yaml
+++ b/.github/actions/java-test/action.yaml
@@ -37,9 +37,9 @@ runs:
     - name: Run Maven compile
       shell: bash
       run: |
-        ./mvnw compile test-compile scalafix:scalafix -Psemanticdb
+        ./mvnw -B compile test-compile scalafix:scalafix -Psemanticdb
 
     - name: Run tests
       shell: bash
       run: |
-        SPARK_HOME=`pwd` ./mvnw clean install
+        SPARK_HOME=`pwd` ./mvnw -B clean install

--- a/.github/actions/java-test/action.yaml
+++ b/.github/actions/java-test/action.yaml
@@ -30,9 +30,9 @@ runs:
         path: |
           ~/.m2/repository
           /root/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-java-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-maven-
+          ${{ runner.os }}-java-maven-
 
     - name: Run Maven compile
       shell: bash

--- a/.github/actions/rust-test/action.yaml
+++ b/.github/actions/rust-test/action.yaml
@@ -43,9 +43,9 @@ runs:
         path: |
           ~/.m2/repository
           /root/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-rust-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-maven-
+          ${{ runner.os }}-rust-maven-
 
     - name: Build common module (pre-requisite for Rust tests)
       shell: bash

--- a/.github/actions/rust-test/action.yaml
+++ b/.github/actions/rust-test/action.yaml
@@ -51,7 +51,7 @@ runs:
       shell: bash
       run: |
         cd common
-        ../mvnw clean compile -DskipTests
+        ../mvnw -B clean compile -DskipTests
 
     - name: Run Cargo test
       shell: bash

--- a/.github/actions/rust-test/action.yaml
+++ b/.github/actions/rust-test/action.yaml
@@ -42,7 +42,7 @@ runs:
       with:
         path: |
           ~/.m2/repository
-          /root/.m2/repository # for containerized runners, root is used
+          /root/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-

--- a/.github/actions/rust-test/action.yaml
+++ b/.github/actions/rust-test/action.yaml
@@ -40,7 +40,9 @@ runs:
     - name: Cache Maven dependencies
       uses: actions/cache@v4
       with:
-        path: ~/.m2/repository
+        path: |
+          ~/.m2/repository
+          /root/.m2/repository # for containerized runners, root is used
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-


### PR DESCRIPTION
## Which issue does this PR close?
Closes #33 .

## Rationale for this change
Fix maven cache issues

## What changes are included in this PR?
Modify github action files

## How are these changes tested?
Verified in the CI runs.

* Rust on Ubuntu: 
<img width="1908" alt="image" src="https://github.com/apache/arrow-datafusion-comet/assets/807537/6b7887ea-2abe-476b-ab00-ea9c344b5101">

* Java on Ubuntu:
<img width="1891" alt="image" src="https://github.com/apache/arrow-datafusion-comet/assets/807537/aee242b9-abab-4ddc-ab44-358608cd5d13">

* and Java on Mac:
<img width="1900" alt="image" src="https://github.com/apache/arrow-datafusion-comet/assets/807537/7a31b0f8-9bbf-448a-aa75-87c079cd5f76">

Others CI runs are also cached: https://github.com/apache/arrow-datafusion-comet/actions/runs/7973418479/job/21767221655?pr=48
