### PR TITLE
feat: Upgrade to `jni-rs` 0.21

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1087,7 +1087,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1336,7 +1336,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1436,7 +1436,7 @@ checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
  "hermit-abi",
  "rustix",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1473,17 +1473,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
-name = "jni"
-version = "0.19.0"
+name = "java-locator"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+checksum = "90003f2fd9c52f212c21d8520f1128da0080bad6fff16b68fe6e7f2f0c3780c2"
+dependencies = [
+ "glob",
+ "lazy_static",
+]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
+ "cfg-if",
  "combine",
+ "java-locator",
  "jni-sys",
+ "libloading",
  "log",
  "thiserror",
  "walkdir",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1585,6 +1599,16 @@ name = "libc"
 version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "libm"
@@ -2319,7 +2343,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2602,7 +2626,7 @@ dependencies = [
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3011,11 +3035,35 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3050,6 +3098,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -3059,6 +3113,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3074,6 +3134,12 @@ checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
@@ -3083,6 +3149,12 @@ name = "windows_i686_gnu"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3098,6 +3170,12 @@ checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -3110,6 +3188,12 @@ checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -3119,6 +3203,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -48,7 +48,7 @@ serde = { version = "1", features = ["derive"] }
 lazy_static = "1.4.0"
 prost = "0.12.1"
 thrift = "0.17"
-jni = "0.19"
+jni = "0.21"
 byteorder = "1.4.3"
 snap = "1.1"
 brotli = "3.3"
@@ -81,7 +81,7 @@ prost-build = "0.9.0"
 [dev-dependencies]
 pprof = { version = "0.13.0", features = ["flamegraph"] }
 criterion = "0.5.1"
-jni = { version = "0.19", features = ["invocation"] }
+jni = { version = "0.21", features = ["invocation"] }
 lazy_static = "1.4"
 assertables = "7"
 

--- a/core/src/jvm_bridge/comet_exec.rs
+++ b/core/src/jvm_bridge/comet_exec.rs
@@ -18,7 +18,7 @@
 use jni::{
     errors::Result as JniResult,
     objects::{JClass, JStaticMethodID},
-    signature::{JavaType, Primitive},
+    signature::{Primitive, ReturnType},
     JNIEnv,
 };
 
@@ -27,75 +27,83 @@ use super::get_global_jclass;
 /// A struct that holds all the JNI methods and fields for JVM CometExec object.
 pub struct CometExec<'a> {
     pub class: JClass<'a>,
-    pub method_get_bool: JStaticMethodID<'a>,
-    pub method_get_bool_ret: JavaType,
-    pub method_get_byte: JStaticMethodID<'a>,
-    pub method_get_byte_ret: JavaType,
-    pub method_get_short: JStaticMethodID<'a>,
-    pub method_get_short_ret: JavaType,
-    pub method_get_int: JStaticMethodID<'a>,
-    pub method_get_int_ret: JavaType,
-    pub method_get_long: JStaticMethodID<'a>,
-    pub method_get_long_ret: JavaType,
-    pub method_get_float: JStaticMethodID<'a>,
-    pub method_get_float_ret: JavaType,
-    pub method_get_double: JStaticMethodID<'a>,
-    pub method_get_double_ret: JavaType,
-    pub method_get_decimal: JStaticMethodID<'a>,
-    pub method_get_decimal_ret: JavaType,
-    pub method_get_string: JStaticMethodID<'a>,
-    pub method_get_string_ret: JavaType,
-    pub method_get_binary: JStaticMethodID<'a>,
-    pub method_get_binary_ret: JavaType,
-    pub method_is_null: JStaticMethodID<'a>,
-    pub method_is_null_ret: JavaType,
+    pub method_get_bool: JStaticMethodID,
+    pub method_get_bool_ret: ReturnType,
+    pub method_get_byte: JStaticMethodID,
+    pub method_get_byte_ret: ReturnType,
+    pub method_get_short: JStaticMethodID,
+    pub method_get_short_ret: ReturnType,
+    pub method_get_int: JStaticMethodID,
+    pub method_get_int_ret: ReturnType,
+    pub method_get_long: JStaticMethodID,
+    pub method_get_long_ret: ReturnType,
+    pub method_get_float: JStaticMethodID,
+    pub method_get_float_ret: ReturnType,
+    pub method_get_double: JStaticMethodID,
+    pub method_get_double_ret: ReturnType,
+    pub method_get_decimal: JStaticMethodID,
+    pub method_get_decimal_ret: ReturnType,
+    pub method_get_string: JStaticMethodID,
+    pub method_get_string_ret: ReturnType,
+    pub method_get_binary: JStaticMethodID,
+    pub method_get_binary_ret: ReturnType,
+    pub method_is_null: JStaticMethodID,
+    pub method_is_null_ret: ReturnType,
 }
 
 impl<'a> CometExec<'a> {
     pub const JVM_CLASS: &'static str = "org/apache/spark/sql/comet/CometScalarSubquery";
 
-    pub fn new(env: &JNIEnv<'a>) -> JniResult<CometExec<'a>> {
+    pub fn new(env: &mut JNIEnv<'a>) -> JniResult<CometExec<'a>> {
         // Get the global class reference
         let class = get_global_jclass(env, Self::JVM_CLASS)?;
 
         Ok(CometExec {
-            class,
             method_get_bool: env
-                .get_static_method_id(class, "getBoolean", "(JJ)Z")
+                .get_static_method_id(Self::JVM_CLASS, "getBoolean", "(JJ)Z")
                 .unwrap(),
-            method_get_bool_ret: JavaType::Primitive(Primitive::Boolean),
-            method_get_byte: env.get_static_method_id(class, "getByte", "(JJ)B").unwrap(),
-            method_get_byte_ret: JavaType::Primitive(Primitive::Byte),
+            method_get_bool_ret: ReturnType::Primitive(Primitive::Boolean),
+            method_get_byte: env
+                .get_static_method_id(Self::JVM_CLASS, "getByte", "(JJ)B")
+                .unwrap(),
+            method_get_byte_ret: ReturnType::Primitive(Primitive::Byte),
             method_get_short: env
-                .get_static_method_id(class, "getShort", "(JJ)S")
+                .get_static_method_id(Self::JVM_CLASS, "getShort", "(JJ)S")
                 .unwrap(),
-            method_get_short_ret: JavaType::Primitive(Primitive::Short),
-            method_get_int: env.get_static_method_id(class, "getInt", "(JJ)I").unwrap(),
-            method_get_int_ret: JavaType::Primitive(Primitive::Int),
-            method_get_long: env.get_static_method_id(class, "getLong", "(JJ)J").unwrap(),
-            method_get_long_ret: JavaType::Primitive(Primitive::Long),
+            method_get_short_ret: ReturnType::Primitive(Primitive::Short),
+            method_get_int: env
+                .get_static_method_id(Self::JVM_CLASS, "getInt", "(JJ)I")
+                .unwrap(),
+            method_get_int_ret: ReturnType::Primitive(Primitive::Int),
+            method_get_long: env
+                .get_static_method_id(Self::JVM_CLASS, "getLong", "(JJ)J")
+                .unwrap(),
+            method_get_long_ret: ReturnType::Primitive(Primitive::Long),
             method_get_float: env
-                .get_static_method_id(class, "getFloat", "(JJ)F")
+                .get_static_method_id(Self::JVM_CLASS, "getFloat", "(JJ)F")
                 .unwrap(),
-            method_get_float_ret: JavaType::Primitive(Primitive::Float),
+            method_get_float_ret: ReturnType::Primitive(Primitive::Float),
             method_get_double: env
-                .get_static_method_id(class, "getDouble", "(JJ)D")
+                .get_static_method_id(Self::JVM_CLASS, "getDouble", "(JJ)D")
                 .unwrap(),
-            method_get_double_ret: JavaType::Primitive(Primitive::Double),
+            method_get_double_ret: ReturnType::Primitive(Primitive::Double),
             method_get_decimal: env
-                .get_static_method_id(class, "getDecimal", "(JJ)[B")
+                .get_static_method_id(Self::JVM_CLASS, "getDecimal", "(JJ)[B")
                 .unwrap(),
-            method_get_decimal_ret: JavaType::Array(Box::new(JavaType::Primitive(Primitive::Byte))),
+            method_get_decimal_ret: ReturnType::Array,
             method_get_string: env
-                .get_static_method_id(class, "getString", "(JJ)Ljava/lang/String;")
+                .get_static_method_id(Self::JVM_CLASS, "getString", "(JJ)Ljava/lang/String;")
                 .unwrap(),
-            method_get_string_ret: JavaType::Object("java/lang/String".to_owned()),
+            method_get_string_ret: ReturnType::Object,
             method_get_binary: env
-                .get_static_method_id(class, "getBinary", "(JJ)[B")
+                .get_static_method_id(Self::JVM_CLASS, "getBinary", "(JJ)[B")
                 .unwrap(),
-            method_get_binary_ret: JavaType::Array(Box::new(JavaType::Primitive(Primitive::Byte))),
-            method_is_null: env.get_static_method_id(class, "isNull", "(JJ)Z").unwrap(),
-            method_is_null_ret: JavaType::Primitive(Primitive::Boolean),
+            method_get_binary_ret: ReturnType::Array,
+            method_is_null: env
+                .get_static_method_id(Self::JVM_CLASS, "isNull", "(JJ)Z")
+                .unwrap(),
+            method_is_null_ret: ReturnType::Primitive(Primitive::Boolean),
+            class,
         })
     }
 }

--- a/core/src/jvm_bridge/comet_metric_node.rs
+++ b/core/src/jvm_bridge/comet_metric_node.rs
@@ -18,7 +18,7 @@
 use jni::{
     errors::Result as JniResult,
     objects::{JClass, JMethodID},
-    signature::{JavaType, Primitive},
+    signature::{Primitive, ReturnType},
     JNIEnv,
 };
 
@@ -27,33 +27,33 @@ use super::get_global_jclass;
 /// A struct that holds all the JNI methods and fields for JVM CometMetricNode class.
 pub struct CometMetricNode<'a> {
     pub class: JClass<'a>,
-    pub method_get_child_node: JMethodID<'a>,
-    pub method_get_child_node_ret: JavaType,
-    pub method_add: JMethodID<'a>,
-    pub method_add_ret: JavaType,
+    pub method_get_child_node: JMethodID,
+    pub method_get_child_node_ret: ReturnType,
+    pub method_add: JMethodID,
+    pub method_add_ret: ReturnType,
 }
 
 impl<'a> CometMetricNode<'a> {
     pub const JVM_CLASS: &'static str = "org/apache/spark/sql/comet/CometMetricNode";
 
-    pub fn new(env: &JNIEnv<'a>) -> JniResult<CometMetricNode<'a>> {
+    pub fn new(env: &mut JNIEnv<'a>) -> JniResult<CometMetricNode<'a>> {
         // Get the global class reference
         let class = get_global_jclass(env, Self::JVM_CLASS)?;
 
         Ok(CometMetricNode {
-            class,
             method_get_child_node: env
                 .get_method_id(
-                    class,
+                    Self::JVM_CLASS,
                     "getChildNode",
                     format!("(I)L{:};", Self::JVM_CLASS).as_str(),
                 )
                 .unwrap(),
-            method_get_child_node_ret: JavaType::Object(Self::JVM_CLASS.to_owned()),
+            method_get_child_node_ret: ReturnType::Object,
             method_add: env
-                .get_method_id(class, "add", "(Ljava/lang/String;J)V")
+                .get_method_id(Self::JVM_CLASS, "add", "(Ljava/lang/String;J)V")
                 .unwrap(),
-            method_add_ret: JavaType::Primitive(Primitive::Void),
+            method_add_ret: ReturnType::Primitive(Primitive::Void),
+            class,
         })
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -45,7 +45,7 @@ use once_cell::sync::OnceCell;
 
 pub use data_type::*;
 
-use crate::errors::{try_unwrap_or_throw, CometError, CometResult};
+use errors::{try_unwrap_or_throw, CometError, CometResult};
 
 #[macro_use]
 mod errors;
@@ -64,15 +64,15 @@ static JAVA_VM: OnceCell<JavaVM> = OnceCell::new();
 
 #[no_mangle]
 pub extern "system" fn Java_org_apache_comet_NativeBase_init(
-    env: JNIEnv,
+    e: JNIEnv,
     _: JClass,
     log_conf_path: JString,
 ) {
     // Initialize the error handling to capture panic backtraces
     errors::init();
 
-    try_unwrap_or_throw(env, || {
-        let path: String = env.get_string(log_conf_path)?.into();
+    try_unwrap_or_throw(&e, |mut env| {
+        let path: String = env.get_string(&log_conf_path)?.into();
 
         // empty path means there is no custom log4rs config file provided, so fallback to use
         // the default configuration

--- a/core/src/parquet/mod.rs
+++ b/core/src/parquet/mod.rs
@@ -41,7 +41,7 @@ use jni::{
 
 use crate::execution::utils::SparkArrowConvert;
 use arrow::buffer::{Buffer, MutableBuffer};
-use jni::objects::ReleaseMode;
+use jni::objects::{JBooleanArray, JLongArray, JPrimitiveArray, ReleaseMode};
 use read::ColumnReader;
 use util::jni::{convert_column_descriptor, convert_encoding};
 
@@ -58,7 +58,7 @@ struct Context {
 
 #[no_mangle]
 pub extern "system" fn Java_org_apache_comet_parquet_Native_initColumnReader(
-    env: JNIEnv,
+    e: JNIEnv,
     _jclass: JClass,
     primitive_type: jint,
     logical_type: jint,
@@ -78,9 +78,9 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_initColumnReader(
     use_decimal_128: jboolean,
     use_legacy_date_timestamp: jboolean,
 ) -> jlong {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&e, |mut env| {
         let desc = convert_column_descriptor(
-            &env,
+            &mut env,
             primitive_type,
             logical_type,
             max_dl,
@@ -111,66 +111,74 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_initColumnReader(
     })
 }
 
+/// # Safety
+/// This function is inheritly unsafe since it deals with raw pointers passed from JNI.
 #[no_mangle]
 pub extern "system" fn Java_org_apache_comet_parquet_Native_setDictionaryPage(
-    env: JNIEnv,
+    e: JNIEnv,
     _jclass: JClass,
     handle: jlong,
     page_value_count: jint,
     page_data: jbyteArray,
     encoding: jint,
 ) {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&e, |env| {
         let reader = get_reader(handle)?;
 
         // convert value encoding ordinal to the native encoding definition
         let encoding = convert_encoding(encoding);
 
         // copy the input on-heap buffer to native
-        let page_len = env.get_array_length(page_data)?;
+        let page_data_array = unsafe { JPrimitiveArray::from_raw(page_data) };
+        let page_len = env.get_array_length(&page_data_array)?;
         let mut buffer = MutableBuffer::from_len_zeroed(page_len as usize);
-        env.get_byte_array_region(page_data, 0, from_u8_slice(buffer.as_slice_mut()))?;
+        env.get_byte_array_region(&page_data_array, 0, from_u8_slice(buffer.as_slice_mut()))?;
 
         reader.set_dictionary_page(page_value_count as usize, buffer.into(), encoding);
         Ok(())
     })
 }
 
+/// # Safety
+/// This function is inheritly unsafe since it deals with raw pointers passed from JNI.
 #[no_mangle]
-pub extern "system" fn Java_org_apache_comet_parquet_Native_setPageV1(
-    env: JNIEnv,
+pub unsafe extern "system" fn Java_org_apache_comet_parquet_Native_setPageV1(
+    e: JNIEnv,
     _jclass: JClass,
     handle: jlong,
     page_value_count: jint,
     page_data: jbyteArray,
     value_encoding: jint,
 ) {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&e, |env| {
         let reader = get_reader(handle)?;
 
         // convert value encoding ordinal to the native encoding definition
         let encoding = convert_encoding(value_encoding);
 
         // copy the input on-heap buffer to native
-        let page_len = env.get_array_length(page_data)?;
+        let page_data_array = unsafe { JPrimitiveArray::from_raw(page_data) };
+        let page_len = env.get_array_length(&page_data_array)?;
         let mut buffer = MutableBuffer::from_len_zeroed(page_len as usize);
-        env.get_byte_array_region(page_data, 0, from_u8_slice(buffer.as_slice_mut()))?;
+        env.get_byte_array_region(&page_data_array, 0, from_u8_slice(buffer.as_slice_mut()))?;
 
         reader.set_page_v1(page_value_count as usize, buffer.into(), encoding);
         Ok(())
     })
 }
 
+/// # Safety
+/// This function is inheritly unsafe since it deals with raw pointers passed from JNI.
 #[no_mangle]
-pub extern "system" fn Java_org_apache_comet_parquet_Native_setPageBufferV1(
-    env: JNIEnv,
+pub unsafe extern "system" fn Java_org_apache_comet_parquet_Native_setPageBufferV1(
+    e: JNIEnv,
     _jclass: JClass,
     handle: jlong,
     page_value_count: jint,
     buffer: jobject,
     value_encoding: jint,
 ) {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&e, |env| {
         let ctx = get_context(handle)?;
         let reader = &mut ctx.column_reader;
 
@@ -178,19 +186,20 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_setPageBufferV1(
         let encoding = convert_encoding(value_encoding);
 
         // Get slices from Java DirectByteBuffer
-        let jbuffer = JByteBuffer::from(buffer);
+        let jbuffer = unsafe { JByteBuffer::from_raw(buffer) };
 
         // Convert the page to global reference so it won't get GC'd by Java. Also free the last
         // page if there is any.
-        ctx.last_data_page = Some(env.new_global_ref(jbuffer)?);
+        ctx.last_data_page = Some(env.new_global_ref(&jbuffer)?);
 
-        let buf_slice = env.get_direct_buffer_address(jbuffer)?;
+        let buf_slice = env.get_direct_buffer_address(&jbuffer)?;
+        let buf_capacity = env.get_direct_buffer_capacity(&jbuffer)?;
 
         unsafe {
-            let page_ptr = NonNull::new_unchecked(buf_slice.as_ptr() as *mut u8);
+            let page_ptr = NonNull::new_unchecked(buf_slice);
             let buffer = Buffer::from_custom_allocation(
                 page_ptr,
-                buf_slice.len(),
+                buf_capacity,
                 Arc::new(FFI_ArrowArray::empty()),
             );
             reader.set_page_v1(page_value_count as usize, buffer, encoding);
@@ -199,9 +208,11 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_setPageBufferV1(
     })
 }
 
+/// # Safety
+/// This function is inheritly unsafe since it deals with raw pointers passed from JNI.
 #[no_mangle]
-pub extern "system" fn Java_org_apache_comet_parquet_Native_setPageV2(
-    env: JNIEnv,
+pub unsafe extern "system" fn Java_org_apache_comet_parquet_Native_setPageV2(
+    e: JNIEnv,
     _jclass: JClass,
     handle: jlong,
     page_value_count: jint,
@@ -210,24 +221,27 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_setPageV2(
     value_data: jbyteArray,
     value_encoding: jint,
 ) {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&e, |env| {
         let reader = get_reader(handle)?;
 
         // convert value encoding ordinal to the native encoding definition
         let encoding = convert_encoding(value_encoding);
 
         // copy the input on-heap buffer to native
-        let dl_len = env.get_array_length(def_level_data)?;
+        let def_level_array = unsafe { JPrimitiveArray::from_raw(def_level_data) };
+        let dl_len = env.get_array_length(&def_level_array)?;
         let mut dl_buffer = MutableBuffer::from_len_zeroed(dl_len as usize);
-        env.get_byte_array_region(def_level_data, 0, from_u8_slice(dl_buffer.as_slice_mut()))?;
+        env.get_byte_array_region(&def_level_array, 0, from_u8_slice(dl_buffer.as_slice_mut()))?;
 
-        let rl_len = env.get_array_length(rep_level_data)?;
+        let rep_level_array = unsafe { JPrimitiveArray::from_raw(rep_level_data) };
+        let rl_len = env.get_array_length(&rep_level_array)?;
         let mut rl_buffer = MutableBuffer::from_len_zeroed(rl_len as usize);
-        env.get_byte_array_region(rep_level_data, 0, from_u8_slice(rl_buffer.as_slice_mut()))?;
+        env.get_byte_array_region(&rep_level_array, 0, from_u8_slice(rl_buffer.as_slice_mut()))?;
 
-        let v_len = env.get_array_length(value_data)?;
+        let value_array = unsafe { JPrimitiveArray::from_raw(value_data) };
+        let v_len = env.get_array_length(&value_array)?;
         let mut v_buffer = MutableBuffer::from_len_zeroed(v_len as usize);
-        env.get_byte_array_region(value_data, 0, from_u8_slice(v_buffer.as_slice_mut()))?;
+        env.get_byte_array_region(&value_array, 0, from_u8_slice(v_buffer.as_slice_mut()))?;
 
         reader.set_page_v2(
             page_value_count as usize,
@@ -246,7 +260,7 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_setNull(
     _jclass: JClass,
     handle: jlong,
 ) {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&env, |_| {
         let reader = get_reader(handle)?;
         reader.set_null();
         Ok(())
@@ -260,7 +274,7 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_setBoolean(
     handle: jlong,
     value: jboolean,
 ) {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&env, |_| {
         let reader = get_reader(handle)?;
         reader.set_boolean(value != 0);
         Ok(())
@@ -274,7 +288,7 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_setByte(
     handle: jlong,
     value: jbyte,
 ) {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&env, |_| {
         let reader = get_reader(handle)?;
         reader.set_fixed::<i8>(value);
         Ok(())
@@ -288,7 +302,7 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_setShort(
     handle: jlong,
     value: jshort,
 ) {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&env, |_| {
         let reader = get_reader(handle)?;
         reader.set_fixed::<i16>(value);
         Ok(())
@@ -302,7 +316,7 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_setInt(
     handle: jlong,
     value: jint,
 ) {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&env, |_| {
         let reader = get_reader(handle)?;
         reader.set_fixed::<i32>(value);
         Ok(())
@@ -316,7 +330,7 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_setLong(
     handle: jlong,
     value: jlong,
 ) {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&env, |_| {
         let reader = get_reader(handle)?;
         reader.set_fixed::<i64>(value);
         Ok(())
@@ -330,7 +344,7 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_setFloat(
     handle: jlong,
     value: jfloat,
 ) {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&env, |_| {
         let reader = get_reader(handle)?;
         reader.set_fixed::<f32>(value);
         Ok(())
@@ -344,44 +358,50 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_setDouble(
     handle: jlong,
     value: jdouble,
 ) {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&env, |_| {
         let reader = get_reader(handle)?;
         reader.set_fixed::<f64>(value);
         Ok(())
     })
 }
 
+/// # Safety
+/// This function is inheritly unsafe since it deals with raw pointers passed from JNI.
 #[no_mangle]
-pub extern "system" fn Java_org_apache_comet_parquet_Native_setBinary(
-    env: JNIEnv,
+pub unsafe extern "system" fn Java_org_apache_comet_parquet_Native_setBinary(
+    e: JNIEnv,
     _jclass: JClass,
     handle: jlong,
     value: jbyteArray,
 ) {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&e, |env| {
         let reader = get_reader(handle)?;
 
-        let len = env.get_array_length(value)?;
+        let value_array = unsafe { JPrimitiveArray::from_raw(value) };
+        let len = env.get_array_length(&value_array)?;
         let mut buffer = MutableBuffer::from_len_zeroed(len as usize);
-        env.get_byte_array_region(value, 0, from_u8_slice(buffer.as_slice_mut()))?;
+        env.get_byte_array_region(&value_array, 0, from_u8_slice(buffer.as_slice_mut()))?;
         reader.set_binary(buffer);
         Ok(())
     })
 }
 
+/// # Safety
+/// This function is inheritly unsafe since it deals with raw pointers passed from JNI.
 #[no_mangle]
-pub extern "system" fn Java_org_apache_comet_parquet_Native_setDecimal(
-    env: JNIEnv,
+pub unsafe extern "system" fn Java_org_apache_comet_parquet_Native_setDecimal(
+    e: JNIEnv,
     _jclass: JClass,
     handle: jlong,
     value: jbyteArray,
 ) {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&e, |env| {
         let reader = get_reader(handle)?;
 
-        let len = env.get_array_length(value)?;
+        let value_array = unsafe { JPrimitiveArray::from_raw(value) };
+        let len = env.get_array_length(&value_array)?;
         let mut buffer = MutableBuffer::from_len_zeroed(len as usize);
-        env.get_byte_array_region(value, 0, from_u8_slice(buffer.as_slice_mut()))?;
+        env.get_byte_array_region(&value_array, 0, from_u8_slice(buffer.as_slice_mut()))?;
         reader.set_decimal_flba(buffer);
         Ok(())
     })
@@ -395,26 +415,29 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_setPosition(
     value: jlong,
     size: jint,
 ) {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&env, |_| {
         let reader = get_reader(handle)?;
         reader.set_position(value, size as usize);
         Ok(())
     })
 }
 
+/// # Safety
+/// This function is inheritly unsafe since it deals with raw pointers passed from JNI.
 #[no_mangle]
-pub extern "system" fn Java_org_apache_comet_parquet_Native_setIndices(
-    env: JNIEnv,
+pub unsafe extern "system" fn Java_org_apache_comet_parquet_Native_setIndices(
+    e: JNIEnv,
     _jclass: JClass,
     handle: jlong,
     offset: jlong,
     batch_size: jint,
     indices: jlongArray,
 ) -> jlong {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&e, |mut env| {
         let reader = get_reader(handle)?;
-        let indices = env.get_long_array_elements(indices, ReleaseMode::NoCopyBack)?;
-        let len = indices.size()? as usize;
+        let indice_array = unsafe { JLongArray::from_raw(indices) };
+        let indices = unsafe { env.get_array_elements(&indice_array, ReleaseMode::NoCopyBack)? };
+        let len = indices.len();
         // paris alternately contains start index and length of continuous indices
         let pairs = unsafe { core::slice::from_raw_parts_mut(indices.as_ptr(), len) };
         let mut skipped = 0;
@@ -437,19 +460,22 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_setIndices(
     })
 }
 
+/// # Safety
+/// This function is inheritly unsafe since it deals with raw pointers passed from JNI.
 #[no_mangle]
-pub extern "system" fn Java_org_apache_comet_parquet_Native_setIsDeleted(
-    env: JNIEnv,
+pub unsafe extern "system" fn Java_org_apache_comet_parquet_Native_setIsDeleted(
+    e: JNIEnv,
     _jclass: JClass,
     handle: jlong,
     is_deleted: jbooleanArray,
 ) {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&e, |env| {
         let reader = get_reader(handle)?;
 
-        let len = env.get_array_length(is_deleted)?;
+        let is_deleted_array = unsafe { JBooleanArray::from_raw(is_deleted) };
+        let len = env.get_array_length(&is_deleted_array)?;
         let mut buffer = MutableBuffer::from_len_zeroed(len as usize);
-        env.get_boolean_array_region(is_deleted, 0, buffer.as_slice_mut())?;
+        env.get_boolean_array_region(&is_deleted_array, 0, buffer.as_slice_mut())?;
         reader.set_is_deleted(buffer);
         Ok(())
     })
@@ -461,7 +487,7 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_resetBatch(
     _jclass: JClass,
     handle: jlong,
 ) {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&env, |_| {
         let reader = get_reader(handle)?;
         reader.reset_batch();
         Ok(())
@@ -470,20 +496,20 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_resetBatch(
 
 #[no_mangle]
 pub extern "system" fn Java_org_apache_comet_parquet_Native_readBatch(
-    env: JNIEnv,
+    e: JNIEnv,
     _jclass: JClass,
     handle: jlong,
     batch_size: jint,
     null_pad_size: jint,
 ) -> jintArray {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&e, |env| {
         let reader = get_reader(handle)?;
         let (num_values, num_nulls) =
             reader.read_batch(batch_size as usize, null_pad_size as usize);
         let res = env.new_int_array(2)?;
         let buf: [i32; 2] = [num_values as i32, num_nulls as i32];
-        env.set_int_array_region(res, 0, &buf)?;
-        Ok(res)
+        env.set_int_array_region(&res, 0, &buf)?;
+        Ok(res.into_raw())
     })
 }
 
@@ -495,7 +521,7 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_skipBatch(
     batch_size: jint,
     discard: jboolean,
 ) -> jint {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&env, |_| {
         let reader = get_reader(handle)?;
         Ok(reader.skip_batch(batch_size as usize, discard == 0) as jint)
     })
@@ -503,11 +529,11 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_skipBatch(
 
 #[no_mangle]
 pub extern "system" fn Java_org_apache_comet_parquet_Native_currentBatch(
-    env: JNIEnv,
+    e: JNIEnv,
     _jclass: JClass,
     handle: jlong,
 ) -> jlongArray {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&e, |env| {
         let ctx = get_context(handle)?;
         let reader = &mut ctx.column_reader;
         let data = reader.current_batch();
@@ -520,9 +546,9 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_currentBatch(
 
             let res = env.new_long_array(2)?;
             let buf: [i64; 2] = [array, schema];
-            env.set_long_array_region(res, 0, &buf)
+            env.set_long_array_region(&res, 0, &buf)
                 .expect("set long array region failed");
-            Ok(res)
+            Ok(res.into_raw())
         }
     })
 }
@@ -547,7 +573,7 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_closeColumnReader(
     _jclass: JClass,
     handle: jlong,
 ) {
-    try_unwrap_or_throw(env, || {
+    try_unwrap_or_throw(&env, |_| {
         unsafe {
             let ctx = handle as *mut Context;
             let _ = Box::from_raw(ctx);

--- a/core/src/parquet/mod.rs
+++ b/core/src/parquet/mod.rs
@@ -114,7 +114,7 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_initColumnReader(
 /// # Safety
 /// This function is inheritly unsafe since it deals with raw pointers passed from JNI.
 #[no_mangle]
-pub extern "system" fn Java_org_apache_comet_parquet_Native_setDictionaryPage(
+pub unsafe extern "system" fn Java_org_apache_comet_parquet_Native_setDictionaryPage(
     e: JNIEnv,
     _jclass: JClass,
     handle: jlong,

--- a/core/src/parquet/util/mod.rs
+++ b/core/src/parquet/util/mod.rs
@@ -22,7 +22,5 @@ pub mod memory;
 
 mod buffer;
 pub use buffer::*;
-mod jni_buffer;
-pub use jni_buffer::*;
 
 pub mod test_common;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #49.

## Rationale for this change

Comet currently use `jni-rs` 0.19 which is a bit out-dated. The latest version `0.21.x` provides more improvements including updated safety, better JVM handling, less data copying, etc. On the other hand, it also introduced many API changes. In the long term, we should update to `0.21`+ to get continuous improvements from `jni-rs`.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR upgrades `jni-rs` from 0.19 to 0.21. There are many API changes between the two versions and hence many places need to be updated as well in the repo.

Most notably, many method calls in `jni-rs` now requires a `&mut JNIEnv` as parameter, while it used to be `&JNIEnv`.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests.