### PR TITLE
build: Fix potential libcrypto lib loading issue for X86 mac runners

### DIFF
--- a/.github/actions/setup-macos-builder/action.yaml
+++ b/.github/actions/setup-macos-builder/action.yaml
@@ -49,6 +49,10 @@ runs:
         unzip $PROTO_ZIP
         echo "$HOME/d/protoc/bin" >> $GITHUB_PATH
         export PATH=$PATH:$HOME/d/protoc/bin
+        # install openssl to work with potential issues with libcrypto.dylib loading
+        # see https://stackoverflow.com/questions/58272830/python-crashing-on-macos-10-15-beta-19a582a-with-usr-lib-libcrypto-dylib for more details
+        brew install openssl
+        export DYLD_LIBRARY_PATH=/usr/local/opt/openssl/lib:$DYLD_LIBRARY_PATH
 
     - name: Install JDK ${{inputs.jdk-version}}
       uses: actions/setup-java@v4

--- a/.github/actions/setup-macos-builder/action.yaml
+++ b/.github/actions/setup-macos-builder/action.yaml
@@ -49,10 +49,12 @@ runs:
         unzip $PROTO_ZIP
         echo "$HOME/d/protoc/bin" >> $GITHUB_PATH
         export PATH=$PATH:$HOME/d/protoc/bin
-        # install openssl to work with potential issues with libcrypto.dylib loading
-        # see https://stackoverflow.com/questions/58272830/python-crashing-on-macos-10-15-beta-19a582a-with-usr-lib-libcrypto-dylib for more details
+        # install openssl and setup DYLD_LIBRARY_PATH to work with libcrypto.dylib loading issues with x86_64 mac runners
+        # see PR https://github.com/apache/arrow-datafusion-comet/pull/55 for more details
         brew install openssl
-        export DYLD_LIBRARY_PATH=/usr/local/opt/openssl/lib:$DYLD_LIBRARY_PATH
+        OPENSSL_LIB_PATH=$(dirname `brew list openssl | grep 'lib/libcrypto.dylib'`)
+        echo "openssl lib path is: ${OPENSSL_LIB_PATH}"
+        export DYLD_LIBRARY_PATH=$OPENSSL_LIB_PATH:$DYLD_LIBRARY_PATH
 
     - name: Install JDK ${{inputs.jdk-version}}
       uses: actions/setup-java@v4


### PR DESCRIPTION
## Which issue does this PR close?
Closes #41 

## Rationale for this change
Another attempt to fix libcrypto loading issues.  
Currently, CIs are still failing randomly with the following logging, for example:
`WARNING: /Users/runner/hostedtoolcache/Java_Adopt_jdk/17.0.10-7/x64/Contents/Home/bin/java is loading libcrypto in an unsafe way`

## What changes are included in this PR?
install openssl for mac runners and setup corresponding DYLD_LIBRARY_PATH

## How are these changes tested?
Existed CI workflow