### PR TITLE
feat: Handle exception thrown from native side

### DIFF
--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -122,6 +122,9 @@ pub enum CometError {
         #[from]
         source: DataFusionError,
     },
+
+    #[error("{class}: {msg}")]
+    JavaException { class: String, msg: String },
 }
 
 pub fn init() {

--- a/core/src/execution/datafusion/expressions/subquery.rs
+++ b/core/src/execution/datafusion/expressions/subquery.rs
@@ -93,7 +93,7 @@ impl PhysicalExpr for Subquery {
         let mut env = JVMClasses::get_env();
 
         unsafe {
-            let is_null = jni_static_call!(env,
+            let is_null = jni_static_call!(&mut env,
                 comet_exec.is_null(self.exec_context_id, self.id) -> jboolean
             )?;
 
@@ -105,50 +105,50 @@ impl PhysicalExpr for Subquery {
 
             match &self.data_type {
                 DataType::Boolean => {
-                    let r = jni_static_call!(env,
+                    let r = jni_static_call!(&mut env,
                         comet_exec.get_bool(self.exec_context_id, self.id) -> jboolean
                     )?;
                     Ok(ColumnarValue::Scalar(ScalarValue::Boolean(Some(r > 0))))
                 }
                 DataType::Int8 => {
-                    let r = jni_static_call!(env,
+                    let r = jni_static_call!(&mut env,
                         comet_exec.get_byte(self.exec_context_id, self.id) -> jbyte
                     )?;
                     Ok(ColumnarValue::Scalar(ScalarValue::Int8(Some(r))))
                 }
                 DataType::Int16 => {
-                    let r = jni_static_call!(env,
+                    let r = jni_static_call!(&mut env,
                         comet_exec.get_short(self.exec_context_id, self.id) -> jshort
                     )?;
                     Ok(ColumnarValue::Scalar(ScalarValue::Int16(Some(r))))
                 }
                 DataType::Int32 => {
-                    let r = jni_static_call!(env,
+                    let r = jni_static_call!(&mut env,
                         comet_exec.get_int(self.exec_context_id, self.id) -> jint
                     )?;
                     Ok(ColumnarValue::Scalar(ScalarValue::Int32(Some(r))))
                 }
                 DataType::Int64 => {
-                    let r = jni_static_call!(env,
+                    let r = jni_static_call!(&mut env,
                         comet_exec.get_long(self.exec_context_id, self.id) -> jlong
                     )?;
                     Ok(ColumnarValue::Scalar(ScalarValue::Int64(Some(r))))
                 }
                 DataType::Float32 => {
-                    let r = jni_static_call!(env,
+                    let r = jni_static_call!(&mut env,
                         comet_exec.get_float(self.exec_context_id, self.id) -> f32
                     )?;
                     Ok(ColumnarValue::Scalar(ScalarValue::Float32(Some(r))))
                 }
                 DataType::Float64 => {
-                    let r = jni_static_call!(env,
+                    let r = jni_static_call!(&mut env,
                         comet_exec.get_double(self.exec_context_id, self.id) -> f64
                     )?;
 
                     Ok(ColumnarValue::Scalar(ScalarValue::Float64(Some(r))))
                 }
                 DataType::Decimal128(p, s) => {
-                    let bytes = jni_static_call!(env,
+                    let bytes = jni_static_call!(&mut env,
                         comet_exec.get_decimal(self.exec_context_id, self.id) -> BinaryWrapper
                     )?;
                     let bytes: &JByteArray = bytes.get().into();
@@ -161,14 +161,14 @@ impl PhysicalExpr for Subquery {
                     )))
                 }
                 DataType::Date32 => {
-                    let r = jni_static_call!(env,
+                    let r = jni_static_call!(&mut env,
                         comet_exec.get_int(self.exec_context_id, self.id) -> jint
                     )?;
 
                     Ok(ColumnarValue::Scalar(ScalarValue::Date32(Some(r))))
                 }
                 DataType::Timestamp(TimeUnit::Microsecond, timezone) => {
-                    let r = jni_static_call!(env,
+                    let r = jni_static_call!(&mut env,
                         comet_exec.get_long(self.exec_context_id, self.id) -> jlong
                     )?;
 
@@ -178,7 +178,7 @@ impl PhysicalExpr for Subquery {
                     )))
                 }
                 DataType::Utf8 => {
-                    let string = jni_static_call!(env,
+                    let string = jni_static_call!(&mut env,
                         comet_exec.get_string(self.exec_context_id, self.id) -> StringWrapper
                     )?;
 
@@ -186,7 +186,7 @@ impl PhysicalExpr for Subquery {
                     Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(string))))
                 }
                 DataType::Binary => {
-                    let bytes = jni_static_call!(env,
+                    let bytes = jni_static_call!(&mut env,
                         comet_exec.get_binary(self.exec_context_id, self.id) -> BinaryWrapper
                     )?;
                     let bytes: &JByteArray = bytes.get().into();


### PR DESCRIPTION

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently when invoking JVM methods from the native side, we do not handle potential exceptions being thrown as part of the process. Ideally, we should catch them and propagate the error to the JVM side to make them visible to the users.

## What changes are included in this PR?

This PR catches exceptions thrown from native side via calling Java methods, and convert them into a `CometError::JavaException` which can then be properly propagated to the JVM.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

It is a bit hard to add a unit test for this. I tested it manually instead.
