### PR TITLE
feat: Add `CometNativeException` for exceptions thrown from the native side

### DIFF
--- a/common/src/main/java/org/apache/comet/CometNativeException.java
+++ b/common/src/main/java/org/apache/comet/CometNativeException.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.comet;
 
 /** Parent class for all exceptions thrown from Comet native side. */

--- a/common/src/main/java/org/apache/comet/CometNativeException.java
+++ b/common/src/main/java/org/apache/comet/CometNativeException.java
@@ -1,0 +1,8 @@
+package org.apache.comet;
+
+/** Parent class for all exceptions thrown from Comet native side. */
+public class CometNativeException extends CometRuntimeException {
+  public CometNativeException(String message) {
+    super(message);
+  }
+}

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -184,7 +184,7 @@ impl jni::errors::ToException for CometError {
                 msg: self.to_string(),
             },
             _other => Exception {
-                class: "org/apache/comet/CometRuntimeException".to_string(),
+                class: "org/apache/comet/CometNativeException".to_string(),
                 msg: self.to_string(),
             },
         }


### PR DESCRIPTION


## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We currently use `CometRuntimeException` for exceptions from both JVM and native side. It's better to have a separate exception class dedicated to the latter.

## What changes are included in this PR?

This introduces another `CometNativeException` dedicated for the latter.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

N/A
