### PR TITLE
fix: Fix the UnionExec match branches in CometExecRule

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -327,6 +327,8 @@ class CometSparkSessionExtensions
             case Some(nativeOp) =>
               val cometOp = CometUnionExec(u, u.children)
               CometSinkPlaceHolder(nativeOp, u, cometOp)
+            case None =>
+              u
           }
 
         // Native shuffle for Comet operators


### PR DESCRIPTION
## Which issue does this PR close?

Plan match issue in CometExecRule

## Rationale for this change

Bug fix

## What changes are included in this PR?

Add default match branch for UnionExec in  CometExecRule

## How are these changes tested?

Local test
