### PR TITLE
feat: Pull based native execution

### DIFF
--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -159,6 +159,15 @@ impl From<CometError> for DataFusionError {
     }
 }
 
+impl From<CometError> for ExecutionError {
+    fn from(value: CometError) -> Self {
+        match value {
+            CometError::Execution { source } => source,
+            _ => ExecutionError::GeneralError(value.to_string()),
+        }
+    }
+}
+
 impl jni::errors::ToException for CometError {
     fn to_exception(&self) -> Exception {
         match self {

--- a/core/src/jvm_bridge/batch_iterator.rs
+++ b/core/src/jvm_bridge/batch_iterator.rs
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use super::get_global_jclass;
+use jni::{
+    errors::Result as JniResult,
+    objects::{JClass, JMethodID},
+    signature::ReturnType,
+    JNIEnv,
+};
+
+/// A struct that holds all the JNI methods and fields for JVM `CometBatchIterator` class.
+pub struct CometBatchIterator<'a> {
+    pub class: JClass<'a>,
+    pub method_next: JMethodID,
+    pub method_next_ret: ReturnType,
+}
+
+impl<'a> CometBatchIterator<'a> {
+    pub const JVM_CLASS: &'static str = "org/apache/comet/CometBatchIterator";
+
+    pub fn new(env: &mut JNIEnv<'a>) -> JniResult<CometBatchIterator<'a>> {
+        // Get the global class reference
+        let class = get_global_jclass(env, Self::JVM_CLASS)?;
+
+        Ok(CometBatchIterator {
+            class,
+            method_next: env.get_method_id(Self::JVM_CLASS, "next", "()[J").unwrap(),
+            method_next_ret: ReturnType::Array,
+        })
+    }
+}

--- a/spark/src/main/java/org/apache/comet/CometBatchIterator.java
+++ b/spark/src/main/java/org/apache/comet/CometBatchIterator.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet;
+
+import scala.collection.Iterator;
+
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+
+import org.apache.comet.vector.NativeUtil;
+
+/**
+ * An iterator that can be used to get batches of Arrow arrays from a Spark iterator of
+ * ColumnarBatch. It will consume input iterator and return Arrow arrays by addresses. This is
+ * called by native code to retrieve Arrow arrays from Spark through JNI.
+ */
+public class CometBatchIterator {
+  final Iterator<ColumnarBatch> input;
+  final NativeUtil nativeUtil;
+
+  CometBatchIterator(Iterator<ColumnarBatch> input, NativeUtil nativeUtil) {
+    this.input = input;
+    this.nativeUtil = nativeUtil;
+  }
+
+  /**
+   * Get the next batches of Arrow arrays. It will consume input iterator and return Arrow arrays by
+   * addresses. If the input iterator is done, it will return a one negative element array
+   * indicating the end of the iterator.
+   */
+  public long[] next() {
+    boolean hasBatch = input.hasNext();
+
+    if (!hasBatch) {
+      return new long[] {-1};
+    }
+
+    return nativeUtil.exportBatch(input.next());
+  }
+}

--- a/spark/src/main/scala/org/apache/comet/Native.scala
+++ b/spark/src/main/scala/org/apache/comet/Native.scala
@@ -31,6 +31,9 @@ class Native extends NativeBase {
    *   The id of the query plan.
    * @param configMap
    *   The Java Map object for the configs of native engine.
+   * @param iterators
+   *   the input iterators to the native query plan. It should be the same number as the number of
+   *   scan nodes in the SparkPlan.
    * @param plan
    *   the bytes of serialized SparkPlan.
    * @param metrics
@@ -41,61 +44,21 @@ class Native extends NativeBase {
   @native def createPlan(
       id: Long,
       configMap: Map[String, String],
+      iterators: Array[CometBatchIterator],
       plan: Array[Byte],
       metrics: CometMetricNode): Long
-
-  /**
-   * Return the native query plan string for the given address of native query plan. For debugging
-   * purpose.
-   *
-   * @param plan
-   *   the address to native query plan.
-   * @return
-   *   the string of native query plan.
-   */
-  @native def getPlanString(plan: Long): String
 
   /**
    * Execute a native query plan based on given input Arrow arrays.
    *
    * @param plan
    *   the address to native query plan.
-   * @param addresses
-   *   the array of addresses of input Arrow arrays. The addresses are exported from Arrow Arrays
-   *   so the number of addresses is always even number in the sequence like [array_address1,
-   *   schema_address1, array_address2, schema_address2, ...]. Note that we can pass empty
-   *   addresses to this API. In this case, it indicates there are no more input arrays to the
-   *   native query plan, but the query plan possibly can still execute to produce output batch
-   *   because it might contain blocking operators such as Sort, Aggregate. When this API returns
-   *   an empty array back, it means the native query plan is finished.
-   * @param finishes
-   *   whether the end of input arrays is reached for each input. If this is set to true, the
-   *   native library will know there is no more inputs. But it doesn't mean the execution is
-   *   finished immediately. For some blocking operators native execution will continue to output.
-   * @param numRows
-   *   the number of rows in the batch.
    * @return
-   *   an array containing: 1) the status flag (0 for pending, 1 for normal returned arrays,
-   * -1 for end of output), 2) (optional) the number of rows if returned flag is 1 3) the
-   * addresses of output Arrow arrays
+   *   an array containing: 1) the status flag (1 for normal returned arrays, -1 for end of
+   *   output) 2) (optional) the number of rows if returned flag is 1 3) the addresses of output
+   *   Arrow arrays
    */
-  @native def executePlan(
-      plan: Long,
-      addresses: Array[Array[Long]],
-      finishes: Array[Boolean],
-      numRows: Int): Array[Long]
-
-  /**
-   * Peeks the next batch of output Arrow arrays from the native query plan without pulling any
-   * input batches.
-   *
-   * @param plan
-   *   the address to native query plan.
-   * @return
-   *   an array containing: 1) the status flag (0 for pending, 1 for normal returned arrays, 2)
-   *   (optional) the number of rows if returned flag is 1 3) the addresses of output Arrow arrays
-   */
-  @native def peekNext(plan: Long): Array[Long]
+  @native def executePlan(plan: Long): Array[Long]
 
   /**
    * Release and drop the native query plan object and context object.

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -42,7 +42,6 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.comet.CometBatchScanExec
 import org.apache.spark.sql.comet.CometScanExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
-import org.apache.spark.sql.execution.datasources.SchemaColumnConvertNotSupportedException
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
@@ -1139,7 +1138,7 @@ abstract class ParquetReadSuite extends CometTestBase {
           .where(s"a < ${Long.MaxValue}")
           .collect()
       }
-      assert(exception.getCause.getCause.isInstanceOf[SchemaColumnConvertNotSupportedException])
+      assert(exception.getMessage.contains("Column: [a], Expected: bigint, Found: INT32"))
     }
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #70.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Comet native execution's scan is not started from native but from JVM. Thus Comet scan is push-based instead of pull-based. Although we pull next input batches from child operator in JVM, this new input is not pulled from native but pushed from JVM side.

For an operator like Expand, one input batch can produces multiple output batches. So we cannot pull next batch directly and push into native without peeking it. We need to "peek" into native side and see if any more output batch there. If so, we take it as next output, if not, we pull next input batch and push into native side to execute on it.

If we pull next input from child operator and push it into native without peek, new input will be ignored.

Not only we cannot have consistent way to get input for native operators. The code of input/output to native execution is harder to understand because we mix push-based and pull-based processing modes. This patch tries to make native execution fully pull-based.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Passed existing tests and e2e tests.
