### PR TITLE
feat: Add executeColumnarCollectIterator to CometExec to collect Comet operator result

### DIFF
--- a/common/src/main/scala/org/apache/comet/vector/NativeUtil.scala
+++ b/common/src/main/scala/org/apache/comet/vector/NativeUtil.scala
@@ -19,11 +19,16 @@
 
 package org.apache.comet.vector
 
+import java.io.OutputStream
+
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 
 import org.apache.arrow.c.{ArrowArray, ArrowImporter, ArrowSchema, CDataDictionaryProvider, Data}
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector._
+import org.apache.arrow.vector.dictionary.DictionaryProvider
+import org.apache.arrow.vector.ipc.ArrowStreamWriter
 import org.apache.spark.SparkException
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -31,6 +36,71 @@ class NativeUtil {
   private val allocator = new RootAllocator(Long.MaxValue)
   private val dictionaryProvider: CDataDictionaryProvider = new CDataDictionaryProvider
   private val importer = new ArrowImporter(allocator)
+
+  /**
+   * Serializes a list of `ColumnarBatch` into an output stream.
+   *
+   * @param batches
+   *   the output batches, each batch is a list of Arrow vectors wrapped in `CometVector`
+   * @param out
+   *   the output stream
+   */
+  def serializeBatches(batches: Iterator[ColumnarBatch], out: OutputStream): Long = {
+    var schemaRoot: Option[VectorSchemaRoot] = None
+    var writer: Option[ArrowStreamWriter] = None
+    var rowCount = 0
+
+    batches.foreach { batch =>
+      val (fieldVectors, batchProviderOpt) = getBatchFieldVectors(batch)
+      val root = schemaRoot.getOrElse(new VectorSchemaRoot(fieldVectors.asJava))
+      val provider = batchProviderOpt.getOrElse(dictionaryProvider)
+
+      if (writer.isEmpty) {
+        writer = Some(new ArrowStreamWriter(root, provider, out))
+        writer.get.start()
+      }
+      writer.get.writeBatch()
+
+      root.clear()
+      schemaRoot = Some(root)
+
+      rowCount += batch.numRows()
+    }
+
+    writer.map(_.end())
+    schemaRoot.map(_.close())
+
+    rowCount
+  }
+
+  def getBatchFieldVectors(
+      batch: ColumnarBatch): (Seq[FieldVector], Option[DictionaryProvider]) = {
+    var provider: Option[DictionaryProvider] = None
+    val fieldVectors = (0 until batch.numCols()).map { index =>
+      batch.column(index) match {
+        case a: CometVector =>
+          val valueVector = a.getValueVector
+          if (valueVector.getField.getDictionary != null) {
+            if (provider.isEmpty) {
+              provider = Some(a.getDictionaryProvider)
+            } else {
+              if (provider.get != a.getDictionaryProvider) {
+                throw new SparkException(
+                  "Comet execution only takes Arrow Arrays with the same dictionary provider")
+              }
+            }
+          }
+
+          getFieldVector(valueVector)
+
+        case c =>
+          throw new SparkException(
+            "Comet execution only takes Arrow Arrays, but got " +
+              s"${c.getClass}")
+      }
+    }
+    (fieldVectors, provider)
+  }
 
   /**
    * Exports a Comet `ColumnarBatch` into a list of memory addresses that can be consumed by the


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #72.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently except for executing entire query plan by calling `collect`, `show` etc., we don't have a way to collect the result of any Comet operators in the middle of a query. In many cases, we need this feature so we can evaluate a child operator inside another Comet operator. This is also useful for debugging an arbitrary Comet operator.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
