### PR TITLE
feat: Reduce memory consumption when writing sorted shuffle files

### DIFF
--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -215,6 +215,13 @@ object CometConf {
         "Ensure that Comet shuffle memory overhead factor is a double greater than 0")
       .createWithDefault(1.0)
 
+  val COMET_COLUMNAR_SHUFFLE_BATCH_SIZE: ConfigEntry[Int] =
+    conf("spark.comet.columnar.shuffle.batch.size")
+      .internal()
+      .doc("Batch size when writing out sorted spill files on the native side.")
+      .intConf
+      .createWithDefault(8192)
+
   val COMET_SHUFFLE_PREFER_DICTIONARY_RATIO: ConfigEntry[Double] = conf(
     "spark.comet.shuffle.preferDictionary.ratio")
     .doc("The ratio of total values to distinct values in a string column to decide whether to " +

--- a/core/benches/row_columnar.rs
+++ b/core/benches/row_columnar.rs
@@ -23,6 +23,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use tempfile::Builder;
 
 const NUM_ROWS: usize = 10000;
+const BATCH_SIZE: usize = 5000;
 const NUM_COLS: usize = 100;
 const ROW_SIZE: usize = SparkUnsafeRow::get_row_bitset_width(NUM_COLS) + NUM_COLS * 8;
 
@@ -67,6 +68,7 @@ fn benchmark(c: &mut Criterion) {
 
             process_sorted_row_partition(
                 NUM_ROWS,
+                BATCH_SIZE,
                 row_address_ptr,
                 row_size_ptr,
                 &schema,

--- a/core/src/execution/jni_api.rs
+++ b/core/src/execution/jni_api.rs
@@ -438,6 +438,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_writeSortedFileNative
     serialized_datatypes: jobjectArray,
     file_path: jstring,
     prefer_dictionary_ratio: jdouble,
+    batch_size: jlong,
     checksum_enabled: jboolean,
     checksum_algo: jint,
     current_checksum: jlong,
@@ -470,6 +471,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_writeSortedFileNative
 
         let (written_bytes, checksum) = process_sorted_row_partition(
             row_num,
+            batch_size as usize,
             row_addresses_ptr,
             row_sizes_ptr,
             &data_types,

--- a/core/src/execution/shuffle/row.rs
+++ b/core/src/execution/shuffle/row.rs
@@ -20,7 +20,7 @@
 use crate::{
     errors::CometError,
     execution::{
-        datafusion::shuffle_writer::{compute_checksum, write_ipc_compressed, ChecksumAlgorithm},
+        datafusion::shuffle_writer::{write_ipc_compressed, Checksum},
         shuffle::{
             list::{append_list_element, SparkUnsafeArray},
             map::{append_map_elements, get_map_key_value_dt, SparkUnsafeMap},
@@ -3191,6 +3191,7 @@ fn make_builders(
 #[allow(clippy::too_many_arguments)]
 pub fn process_sorted_row_partition(
     row_num: usize,
+    batch_size: usize,
     row_addresses_ptr: *mut jlong,
     row_sizes_ptr: *mut jint,
     schema: &Vec<DataType>,
@@ -3198,79 +3199,86 @@ pub fn process_sorted_row_partition(
     prefer_dictionary_ratio: f64,
     checksum_enabled: bool,
     checksum_algo: i32,
-    current_checksum: Option<u32>,
+    // This is the checksum value passed in from Spark side, and is getting updated for
+    // each shuffle partition Spark processes. It is called "initial" here to indicate
+    // this is the initial checksum for this method, as it also gets updated iteratively
+    // inside the loop within the method across batches.
+    initial_checksum: Option<u32>,
 ) -> Result<(i64, Option<u32>), CometError> {
-    let mut data_builders: Vec<Box<dyn ArrayBuilder>> = vec![];
-    schema.iter().try_for_each(|dt| {
-        make_builders(dt, row_num, prefer_dictionary_ratio)
-            .map(|builder| data_builders.push(builder))?;
-        Ok::<(), CometError>(())
-    })?;
-
-    // Appends rows to the array builders.
-    let mut row_start: usize = 0;
     // TODO: We can tune this parameter automatically based on row size and cache size.
     let row_step = 10;
-    while row_start < row_num {
-        let row_end = std::cmp::min(row_start + row_step, row_num);
 
-        // For each column, iterating over rows and appending values to corresponding array builder.
-        for (idx, builder) in data_builders.iter_mut().enumerate() {
-            append_columns(
-                row_addresses_ptr,
-                row_sizes_ptr,
-                row_start,
-                row_end,
-                schema,
-                idx,
-                builder,
-                prefer_dictionary_ratio,
-            )?;
-        }
-
-        row_start = row_end;
-    }
-
-    // Writes a record batch generated from the array builders to the output file.
-    let array_refs: Result<Vec<ArrayRef>, _> = data_builders
-        .iter_mut()
-        .zip(schema.iter())
-        .map(|(builder, datatype)| builder_to_array(builder, datatype, prefer_dictionary_ratio))
-        .collect();
-    let batch = make_batch(array_refs?);
-
-    let mut frozen: Vec<u8> = vec![];
-    let mut cursor = Cursor::new(&mut frozen);
-    cursor.seek(SeekFrom::End(0))?;
-    let written = write_ipc_compressed(&batch, &mut cursor)?;
-
-    let checksum = if checksum_enabled {
-        let checksum = match checksum_algo {
-            0 => ChecksumAlgorithm::CRC32(current_checksum),
-            1 => ChecksumAlgorithm::Adler32(current_checksum),
-            _ => {
-                return Err(CometError::Internal(
-                    "Unsupported checksum algorithm".to_string(),
-                ))
-            }
-        };
-
-        match compute_checksum(&mut cursor, &checksum)? {
-            ChecksumAlgorithm::CRC32(checksum) => checksum,
-            ChecksumAlgorithm::Adler32(checksum) => checksum,
-        }
+    // The current row number we are reading
+    let mut current_row = 0;
+    // Total number of bytes written
+    let mut written = 0;
+    // The current checksum value. This is updated incrementally in the following loop.
+    let mut current_checksum = if checksum_enabled {
+        Some(Checksum::try_new(checksum_algo, initial_checksum)?)
     } else {
         None
     };
 
-    let mut output_data = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(output_path)?;
+    while current_row < row_num {
+        let n = std::cmp::min(batch_size, row_num - current_row);
 
-    output_data.write_all(&frozen)?;
+        let mut data_builders: Vec<Box<dyn ArrayBuilder>> = vec![];
+        schema.iter().try_for_each(|dt| {
+            make_builders(dt, n, prefer_dictionary_ratio)
+                .map(|builder| data_builders.push(builder))?;
+            Ok::<(), CometError>(())
+        })?;
 
-    Ok((written as i64, checksum))
+        // Appends rows to the array builders.
+        let mut row_start: usize = current_row;
+        while row_start < current_row + n {
+            let row_end = std::cmp::min(row_start + row_step, current_row + n);
+
+            // For each column, iterating over rows and appending values to corresponding array
+            // builder.
+            for (idx, builder) in data_builders.iter_mut().enumerate() {
+                append_columns(
+                    row_addresses_ptr,
+                    row_sizes_ptr,
+                    row_start,
+                    row_end,
+                    schema,
+                    idx,
+                    builder,
+                    prefer_dictionary_ratio,
+                )?;
+            }
+
+            row_start = row_end;
+        }
+
+        // Writes a record batch generated from the array builders to the output file.
+        let array_refs: Result<Vec<ArrayRef>, _> = data_builders
+            .iter_mut()
+            .zip(schema.iter())
+            .map(|(builder, datatype)| builder_to_array(builder, datatype, prefer_dictionary_ratio))
+            .collect();
+        let batch = make_batch(array_refs?);
+
+        let mut frozen: Vec<u8> = vec![];
+        let mut cursor = Cursor::new(&mut frozen);
+        cursor.seek(SeekFrom::End(0))?;
+        written += write_ipc_compressed(&batch, &mut cursor)?;
+
+        if let Some(checksum) = &mut current_checksum {
+            checksum.update(&mut cursor)?;
+        }
+
+        let mut output_data = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&output_path)?;
+
+        output_data.write_all(&frozen)?;
+        current_row += n;
+    }
+
+    Ok((written as i64, current_checksum.map(|c| c.finalize())))
 }
 
 fn builder_to_array(

--- a/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
+++ b/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
@@ -36,6 +36,7 @@ import org.apache.spark.shuffle.sort.RowPartition;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.memory.MemoryBlock;
 
+import org.apache.comet.CometConf;
 import org.apache.comet.Native;
 import org.apache.comet.serde.QueryPlanSerde$;
 
@@ -178,6 +179,7 @@ public abstract class SpillWriter {
     long currentChecksum = checksumEnabled ? checksum : 0L;
 
     long start = System.nanoTime();
+    int batchSize = (int) CometConf.COMET_COLUMNAR_SHUFFLE_BATCH_SIZE().get();
     long[] results =
         nativeLib.writeSortedFileNative(
             addresses,
@@ -185,6 +187,7 @@ public abstract class SpillWriter {
             dataTypes,
             file.getAbsolutePath(),
             preferDictionaryRatio,
+            batchSize,
             checksumEnabled,
             checksumAlgo,
             currentChecksum);

--- a/spark/src/main/scala/org/apache/comet/Native.scala
+++ b/spark/src/main/scala/org/apache/comet/Native.scala
@@ -83,6 +83,9 @@ class Native extends NativeBase {
    *   the ratio of total values to distinct values in a string column that makes the writer to
    *   prefer dictionary encoding. If it is larger than the specified ratio, dictionary encoding
    *   will be used when writing columns of string type.
+   * @param batchSize
+   *   the batch size on the native side to buffer outputs during the row to columnar conversion
+   *   before writing them out to disk.
    * @param checksumEnabled
    *   whether to compute checksum of written file.
    * @param checksumAlgo
@@ -99,6 +102,7 @@ class Native extends NativeBase {
       datatypes: Array[Array[Byte]],
       file: String,
       preferDictionaryRatio: Double,
+      batchSize: Int,
       checksumEnabled: Boolean,
       checksumAlgo: Int,
       currentChecksum: Long): Array[Long]


### PR DESCRIPTION

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently in columnar shuffle, when spills are triggered, Comet will write sorted shuffle data to disk on the native side. As part of the process, it will also do row to columnar conversion, and write out the shuffle data in Arrow format. However, the row to columnar conversion will try to buffer all the shuffle data in memory before writing them to disk. This will potentially cause OOM since spills usually are triggered when memory is under pressure, and the Spark executor may not have enough memory left.

Instead, this PR changes the logic so it no longer buffers all shuffle data in memory. Instead, it immediately flushes out the data to disk once a certain threshold has been reached. A (internal) config parameter `spark.comet.columnar.shuffle.batch.size` is introduced to control the threshold, and by default it is 8K. 

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Changed the logic of writing sorted shuffle data to no longer buffer all data in memory, but instead batch by batch.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
