### PR TITLE
feat: Introduce `CometTaskMemoryManager` and native side memory pool

### DIFF
--- a/common/src/main/java/org/apache/comet/CometOutOfMemoryError.java
+++ b/common/src/main/java/org/apache/comet/CometOutOfMemoryError.java
@@ -1,18 +1,20 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.comet;

--- a/common/src/main/java/org/apache/comet/CometOutOfMemoryError.java
+++ b/common/src/main/java/org/apache/comet/CometOutOfMemoryError.java
@@ -1,0 +1,8 @@
+package org.apache.comet;
+
+/** OOM error specific for Comet memory management */
+public class CometOutOfMemoryError extends OutOfMemoryError {
+  public CometOutOfMemoryError(String msg) {
+    super(msg);
+  }
+}

--- a/common/src/main/java/org/apache/comet/CometOutOfMemoryError.java
+++ b/common/src/main/java/org/apache/comet/CometOutOfMemoryError.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.comet;
 
 /** OOM error specific for Comet memory management */

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -101,7 +101,11 @@ pub enum CometError {
         #[from]
         source: std::num::ParseFloatError,
     },
-
+    #[error(transparent)]
+    BoolFormat {
+        #[from]
+        source: std::str::ParseBoolError,
+    },
     #[error(transparent)]
     Format {
         #[from]

--- a/core/src/execution/jni_api.rs
+++ b/core/src/execution/jni_api.rs
@@ -42,7 +42,7 @@ use jni::{
 };
 use std::{collections::HashMap, sync::Arc, task::Poll};
 
-use super::{serde, utils::SparkArrowConvert};
+use super::{serde, utils::SparkArrowConvert, CometMemoryPool};
 
 use crate::{
     errors::{try_unwrap_or_throw, CometError, CometResult},
@@ -103,6 +103,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
     iterators: jobjectArray,
     serialized_query: jbyteArray,
     metrics_node: JObject,
+    task_memory_manager_obj: JObject,
 ) -> jlong {
     try_unwrap_or_throw(&e, |mut env| {
         // Init JVM classes
@@ -147,11 +148,12 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
             let input_source = Arc::new(jni_new_global_ref!(env, input_source)?);
             input_sources.push(input_source);
         }
+        let task_memory_manager = Arc::new(jni_new_global_ref!(env, task_memory_manager_obj)?);
 
         // We need to keep the session context alive. Some session state like temporary
         // dictionaries are stored in session context. If it is dropped, the temporary
         // dictionaries will be dropped as well.
-        let session = prepare_datafusion_session_context(&configs)?;
+        let session = prepare_datafusion_session_context(&configs, task_memory_manager)?;
 
         let exec_context = Box::new(ExecutionContext {
             id,
@@ -175,6 +177,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
 /// Parse Comet configs and configure DataFusion session context.
 fn prepare_datafusion_session_context(
     conf: &HashMap<String, String>,
+    task_memory_manager: Arc<GlobalRef>,
 ) -> CometResult<SessionContext> {
     // Get the batch size from Comet JVM side
     let batch_size = conf
@@ -186,18 +189,29 @@ fn prepare_datafusion_session_context(
 
     let mut rt_config = RuntimeConfig::new().with_disk_manager(DiskManagerConfig::NewOs);
 
-    // Set up memory limit if specified
-    if conf.contains_key("memory_limit") {
-        let memory_limit = conf.get("memory_limit").unwrap().parse::<usize>()?;
+    let use_unified_memory_manager = conf
+        .get("use_unified_memory_manager")
+        .ok_or(CometError::Internal(
+            "Config 'use_unified_memory_manager' is not specified from Comet JVM side".to_string(),
+        ))?
+        .parse::<bool>()?;
 
-        let memory_fraction = conf
-            .get("memory_fraction")
-            .ok_or(CometError::Internal(
-                "Config 'memory_fraction' is not specified from Comet JVM side".to_string(),
-            ))?
-            .parse::<f64>()?;
-
-        rt_config = rt_config.with_memory_limit(memory_limit, memory_fraction);
+    if use_unified_memory_manager {
+        // Set Comet memory pool for native
+        let memory_pool = CometMemoryPool::new(task_memory_manager);
+        rt_config = rt_config.with_memory_pool(Arc::new(memory_pool));
+    } else {
+        // Use the memory pool from DF
+        if conf.contains_key("memory_limit") {
+            let memory_limit = conf.get("memory_limit").unwrap().parse::<usize>()?;
+            let memory_fraction = conf
+                .get("memory_fraction")
+                .ok_or(CometError::Internal(
+                    "Config 'memory_fraction' is not specified from Comet JVM side".to_string(),
+                ))?
+                .parse::<f64>()?;
+            rt_config = rt_config.with_memory_limit(memory_limit, memory_fraction)
+        }
     }
 
     // Get Datafusion configuration from Spark Execution context

--- a/core/src/execution/memory_pool.rs
+++ b/core/src/execution/memory_pool.rs
@@ -1,0 +1,85 @@
+use std::{
+    fmt::{Debug, Formatter, Result as FmtResult},
+    sync::{
+        atomic::{AtomicUsize, Ordering::Relaxed},
+        Arc,
+    },
+};
+
+use jni::objects::GlobalRef;
+
+use datafusion::{
+    common::DataFusionError,
+    execution::memory_pool::{MemoryPool, MemoryReservation},
+};
+
+use crate::jvm_bridge::{jni_call, JVMClasses};
+
+pub struct CometMemoryPool {
+    task_memory_manager_handle: Arc<GlobalRef>,
+    used: AtomicUsize,
+}
+
+impl Debug for CometMemoryPool {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.debug_struct("CometMemoryPool")
+            .field("used", &self.used.load(Relaxed))
+            .finish()
+    }
+}
+
+impl CometMemoryPool {
+    pub fn new(task_memory_manager_handle: Arc<GlobalRef>) -> CometMemoryPool {
+        Self {
+            task_memory_manager_handle,
+            used: AtomicUsize::new(0),
+        }
+    }
+}
+
+unsafe impl Send for CometMemoryPool {}
+unsafe impl Sync for CometMemoryPool {}
+
+impl MemoryPool for CometMemoryPool {
+    fn grow(&self, _: &MemoryReservation, additional: usize) {
+        self.used.fetch_add(additional, Relaxed);
+    }
+
+    fn shrink(&self, _: &MemoryReservation, size: usize) {
+        let mut env = JVMClasses::get_env();
+        let handle = self.task_memory_manager_handle.as_obj();
+        unsafe {
+            jni_call!(&mut env, comet_task_memory_manager(handle).release_memory(size as i64) -> ())
+                .unwrap();
+        }
+        self.used.fetch_sub(size, Relaxed);
+    }
+
+    fn try_grow(&self, _: &MemoryReservation, additional: usize) -> Result<(), DataFusionError> {
+        if additional > 0 {
+            let mut env = JVMClasses::get_env();
+            let handle = self.task_memory_manager_handle.as_obj();
+            unsafe {
+                let acquired = jni_call!(&mut env,
+                  comet_task_memory_manager(handle).acquire_memory(additional as i64) -> i64)?;
+
+                // If the number of bytes we acquired is less than the requested, return an error,
+                // and hopefully will trigger spilling from the caller side.
+                if acquired < additional as i64 {
+                    return Err(DataFusionError::Execution(format!(
+                        "Failed to acquire {} bytes, only got {}. Reserved: {}",
+                        additional,
+                        acquired,
+                        self.reserved(),
+                    )));
+                }
+            }
+            self.used.fetch_add(additional, Relaxed);
+        }
+        Ok(())
+    }
+
+    fn reserved(&self) -> usize {
+        self.used.load(Relaxed)
+    }
+}

--- a/core/src/execution/memory_pool.rs
+++ b/core/src/execution/memory_pool.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use std::{
     fmt::{Debug, Formatter, Result as FmtResult},
     sync::{

--- a/core/src/execution/mod.rs
+++ b/core/src/execution/mod.rs
@@ -29,6 +29,9 @@ pub(crate) mod sort;
 mod timezone;
 pub(crate) mod utils;
 
+mod memory_pool;
+pub use memory_pool::*;
+
 // Include generated modules from .proto files.
 #[allow(missing_docs)]
 pub mod spark_expression {

--- a/core/src/jvm_bridge/comet_task_memory_manager.rs
+++ b/core/src/jvm_bridge/comet_task_memory_manager.rs
@@ -24,8 +24,8 @@ use jni::{
 
 use crate::jvm_bridge::get_global_jclass;
 
-/// A DataFusion `MemoryPool` implementation for Comet, which delegate to the JVM
-/// side `CometTaskMemoryManager`.
+/// A wrapper which delegate acquire/release memory calls to the
+/// JVM side `CometTaskMemoryManager`.
 #[derive(Debug)]
 pub struct CometTaskMemoryManager<'a> {
     pub class: JClass<'a>,

--- a/core/src/jvm_bridge/comet_task_memory_manager.rs
+++ b/core/src/jvm_bridge/comet_task_memory_manager.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use jni::{
     errors::Result as JniResult,
     objects::{JClass, JMethodID},

--- a/core/src/jvm_bridge/comet_task_memory_manager.rs
+++ b/core/src/jvm_bridge/comet_task_memory_manager.rs
@@ -1,0 +1,45 @@
+use jni::{
+    errors::Result as JniResult,
+    objects::{JClass, JMethodID},
+    signature::{Primitive, ReturnType},
+    JNIEnv,
+};
+
+use crate::jvm_bridge::get_global_jclass;
+
+/// A DataFusion `MemoryPool` implementation for Comet, which delegate to the JVM
+/// side `CometTaskMemoryManager`.
+#[derive(Debug)]
+pub struct CometTaskMemoryManager<'a> {
+    pub class: JClass<'a>,
+    pub method_acquire_memory: JMethodID,
+    pub method_release_memory: JMethodID,
+
+    pub method_acquire_memory_ret: ReturnType,
+    pub method_release_memory_ret: ReturnType,
+}
+
+impl<'a> CometTaskMemoryManager<'a> {
+    pub const JVM_CLASS: &'static str = "org/apache/spark/CometTaskMemoryManager";
+
+    pub fn new(env: &mut JNIEnv<'a>) -> JniResult<CometTaskMemoryManager<'a>> {
+        let class = get_global_jclass(env, Self::JVM_CLASS)?;
+
+        let result = CometTaskMemoryManager {
+            class,
+            method_acquire_memory: env.get_method_id(
+                Self::JVM_CLASS,
+                "acquireMemory",
+                "(J)J".to_string(),
+            )?,
+            method_release_memory: env.get_method_id(
+                Self::JVM_CLASS,
+                "releaseMemory",
+                "(J)V".to_string(),
+            )?,
+            method_acquire_memory_ret: ReturnType::Primitive(Primitive::Long),
+            method_release_memory_ret: ReturnType::Primitive(Primitive::Void),
+        };
+        Ok(result)
+    }
+}

--- a/dev/ensure-jars-have-correct-contents.sh
+++ b/dev/ensure-jars-have-correct-contents.sh
@@ -80,6 +80,8 @@ allowed_expr+="|^org/apache/spark/shuffle/comet/.*$"
 allowed_expr+="|^org/apache/spark/sql/$"
 allowed_expr+="|^org/apache/spark/CometPlugin.class$"
 allowed_expr+="|^org/apache/spark/CometDriverPlugin.*$"
+allowed_expr+="|^org/apache/spark/CometTaskMemoryManager.class$"
+allowed_expr+="|^org/apache/spark/CometTaskMemoryManager.*$"
 
 allowed_expr+=")"
 declare -i bad_artifacts=0

--- a/spark/src/main/java/org/apache/spark/CometTaskMemoryManager.java
+++ b/spark/src/main/java/org/apache/spark/CometTaskMemoryManager.java
@@ -1,0 +1,49 @@
+package org.apache.spark;
+
+import java.io.IOException;
+
+import org.apache.spark.memory.MemoryConsumer;
+import org.apache.spark.memory.MemoryMode;
+import org.apache.spark.memory.TaskMemoryManager;
+
+/**
+ * A adapter class that is used by Comet native to acquire & release memory through Spark's unified
+ * memory manager. This assumes Spark's off-heap memory mode is enabled.
+ */
+public class CometTaskMemoryManager {
+  private final TaskMemoryManager internal;
+  private final NativeMemoryConsumer nativeMemoryConsumer;
+
+  public CometTaskMemoryManager() {
+    this.internal = TaskContext$.MODULE$.get().taskMemoryManager();
+    this.nativeMemoryConsumer = new NativeMemoryConsumer();
+  }
+
+  // Called by Comet native through JNI.
+  // Returns the actual amount of memory (in bytes) granted.
+  public long acquireMemory(long size) {
+    return internal.acquireExecutionMemory(size, nativeMemoryConsumer);
+  }
+
+  // Called by Comet native through JNI
+  public void releaseMemory(long size) {
+    internal.releaseExecutionMemory(size, nativeMemoryConsumer);
+  }
+
+  /**
+   * A dummy memory consumer that does nothing when spilling. At the moment, Comet native doesn't
+   * share the same API as Spark and cannot trigger spill when acquire memory. Therefore, when
+   * acquiring memory from native or JVM, spilling can only be triggered from JVM operators.
+   */
+  private class NativeMemoryConsumer extends MemoryConsumer {
+    protected NativeMemoryConsumer() {
+      super(CometTaskMemoryManager.this.internal, 0, MemoryMode.OFF_HEAP);
+    }
+
+    @Override
+    public long spill(long size, MemoryConsumer trigger) throws IOException {
+      // No spilling
+      return 0;
+    }
+  }
+}

--- a/spark/src/main/java/org/apache/spark/CometTaskMemoryManager.java
+++ b/spark/src/main/java/org/apache/spark/CometTaskMemoryManager.java
@@ -1,18 +1,20 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.spark;

--- a/spark/src/main/java/org/apache/spark/CometTaskMemoryManager.java
+++ b/spark/src/main/java/org/apache/spark/CometTaskMemoryManager.java
@@ -28,10 +28,14 @@ import org.apache.spark.memory.TaskMemoryManager;
  * memory manager. This assumes Spark's off-heap memory mode is enabled.
  */
 public class CometTaskMemoryManager {
+  /** The id uniquely identifies the native plan this memory manager is associated to */
+  private final long id;
+
   private final TaskMemoryManager internal;
   private final NativeMemoryConsumer nativeMemoryConsumer;
 
-  public CometTaskMemoryManager() {
+  public CometTaskMemoryManager(long id) {
+    this.id = id;
     this.internal = TaskContext$.MODULE$.get().taskMemoryManager();
     this.nativeMemoryConsumer = new NativeMemoryConsumer();
   }
@@ -61,6 +65,11 @@ public class CometTaskMemoryManager {
     public long spill(long size, MemoryConsumer trigger) throws IOException {
       // No spilling
       return 0;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("NativeMemoryConsumer(id=%)", id);
     }
   }
 }

--- a/spark/src/main/java/org/apache/spark/CometTaskMemoryManager.java
+++ b/spark/src/main/java/org/apache/spark/CometTaskMemoryManager.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark;
 
 import java.io.IOException;

--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -60,7 +60,7 @@ class CometExecIterator(
       cometBatchIterators,
       protobufQueryPlan,
       nativeMetrics,
-      new CometTaskMemoryManager)
+      new CometTaskMemoryManager(id))
   }
 
   private var nextBatch: Option[ColumnarBatch] = None

--- a/spark/src/main/scala/org/apache/comet/Native.scala
+++ b/spark/src/main/scala/org/apache/comet/Native.scala
@@ -21,6 +21,7 @@ package org.apache.comet
 
 import java.util.Map
 
+import org.apache.spark.CometTaskMemoryManager
 import org.apache.spark.sql.comet.CometMetricNode
 
 class Native extends NativeBase {
@@ -38,6 +39,9 @@ class Native extends NativeBase {
    *   the bytes of serialized SparkPlan.
    * @param metrics
    *   the native metrics of SparkPlan.
+   * @param taskMemoryManager
+   *   the task-level memory manager that is responsible for tracking memory usage across JVM and
+   *   native side.
    * @return
    *   the address to native query plan.
    */
@@ -46,7 +50,8 @@ class Native extends NativeBase {
       configMap: Map[String, String],
       iterators: Array[CometBatchIterator],
       plan: Array[Byte],
-      metrics: CometMetricNode): Long
+      metrics: CometMetricNode,
+      taskMemoryManager: CometTaskMemoryManager): Long
 
   /**
    * Execute a native query plan based on given input Arrow arrays.

--- a/spark/src/test/scala/org/apache/comet/exec/CometColumnarShuffleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometColumnarShuffleSuite.scala
@@ -53,7 +53,8 @@ abstract class CometColumnarShuffleSuite extends CometTestBase with AdaptiveSpar
         CometConf.COMET_EXEC_SHUFFLE_SPILL_THRESHOLD.key -> numElementsForceSpillThreshold.toString,
         CometConf.COMET_EXEC_ENABLED.key -> "false",
         CometConf.COMET_COLUMNAR_SHUFFLE_ENABLED.key -> "true",
-        CometConf.COMET_EXEC_SHUFFLE_ENABLED.key -> "true") {
+        CometConf.COMET_EXEC_SHUFFLE_ENABLED.key -> "true",
+        CometConf.COMET_COLUMNAR_SHUFFLE_MEMORY_SIZE.key -> "1536m") {
         testFun
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/CometTPCDSQuerySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTPCDSQuerySuite.scala
@@ -20,8 +20,7 @@
 package org.apache.spark.sql
 
 import org.apache.spark.SparkConf
-import org.apache.spark.internal.config.{MEMORY_OFFHEAP_ENABLED, MEMORY_OFFHEAP_SIZE, SHUFFLE_MANAGER}
-import org.apache.spark.sql.internal.StaticSQLConf.SPARK_SESSION_EXTENSIONS
+import org.apache.spark.internal.config.{MEMORY_OFFHEAP_ENABLED, MEMORY_OFFHEAP_SIZE}
 
 import org.apache.comet.CometConf
 

--- a/spark/src/test/scala/org/apache/spark/sql/CometTPCDSQuerySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTPCDSQuerySuite.scala
@@ -20,6 +20,8 @@
 package org.apache.spark.sql
 
 import org.apache.spark.SparkConf
+import org.apache.spark.internal.config.{MEMORY_OFFHEAP_ENABLED, MEMORY_OFFHEAP_SIZE, SHUFFLE_MANAGER}
+import org.apache.spark.sql.internal.StaticSQLConf.SPARK_SESSION_EXTENSIONS
 
 import org.apache.comet.CometConf
 
@@ -150,10 +152,11 @@ class CometTPCDSQuerySuite
       "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
     conf.set(CometConf.COMET_ENABLED.key, "true")
     conf.set(CometConf.COMET_EXEC_ENABLED.key, "true")
-    conf.set(CometConf.COMET_MEMORY_OVERHEAD.key, "2g")
     conf.set(CometConf.COMET_EXEC_ALL_OPERATOR_ENABLED.key, "true")
     conf.set(CometConf.COMET_EXEC_ALL_EXPR_ENABLED.key, "true")
     conf.set(CometConf.COMET_EXEC_SHUFFLE_ENABLED.key, "true")
+    conf.set(MEMORY_OFFHEAP_ENABLED.key, "true")
+    conf.set(MEMORY_OFFHEAP_SIZE.key, "2g")
     conf
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/CometTPCHQuerySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTPCHQuerySuite.scala
@@ -25,9 +25,11 @@ import java.nio.file.{Files, Paths}
 import scala.collection.JavaConverters._
 
 import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.internal.config.{MEMORY_OFFHEAP_ENABLED, MEMORY_OFFHEAP_SIZE, SHUFFLE_MANAGER}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.util.{fileToString, resourceToString, stringToFile}
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.StaticSQLConf.SPARK_SESSION_EXTENSIONS
 import org.apache.spark.sql.test.{SharedSparkSession, TestSparkSession}
 
 import org.apache.comet.CometConf
@@ -87,10 +89,11 @@ class CometTPCHQuerySuite extends QueryTest with CometTPCBase with SQLQueryTestH
       "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
     conf.set(CometConf.COMET_ENABLED.key, "true")
     conf.set(CometConf.COMET_EXEC_ENABLED.key, "true")
-    conf.set(CometConf.COMET_MEMORY_OVERHEAD.key, "2g")
     conf.set(CometConf.COMET_EXEC_ALL_OPERATOR_ENABLED.key, "true")
     conf.set(CometConf.COMET_EXEC_ALL_EXPR_ENABLED.key, "true")
     conf.set(CometConf.COMET_EXEC_SHUFFLE_ENABLED.key, "true")
+    conf.set(MEMORY_OFFHEAP_ENABLED.key, "true")
+    conf.set(MEMORY_OFFHEAP_SIZE.key, "2g")
   }
 
   protected override def createSparkSession: TestSparkSession = {

--- a/spark/src/test/scala/org/apache/spark/sql/CometTPCHQuerySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTPCHQuerySuite.scala
@@ -25,11 +25,10 @@ import java.nio.file.{Files, Paths}
 import scala.collection.JavaConverters._
 
 import org.apache.spark.{SparkConf, SparkContext}
-import org.apache.spark.internal.config.{MEMORY_OFFHEAP_ENABLED, MEMORY_OFFHEAP_SIZE, SHUFFLE_MANAGER}
+import org.apache.spark.internal.config.{MEMORY_OFFHEAP_ENABLED, MEMORY_OFFHEAP_SIZE}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.util.{fileToString, resourceToString, stringToFile}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.StaticSQLConf.SPARK_SESSION_EXTENSIONS
 import org.apache.spark.sql.test.{SharedSparkSession, TestSparkSession}
 
 import org.apache.comet.CometConf

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -68,6 +68,8 @@ abstract class CometTestBase
     conf.set(SHUFFLE_MANAGER, shuffleManager)
     conf.set(MEMORY_OFFHEAP_ENABLED.key, "true")
     conf.set(MEMORY_OFFHEAP_SIZE.key, "2g")
+    conf.set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "1g")
+    conf.set(SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key, "1g")
     conf.set(CometConf.COMET_ENABLED.key, "true")
     conf.set(CometConf.COMET_EXEC_ENABLED.key, "true")
     conf.set(CometConf.COMET_EXEC_ALL_OPERATOR_ENABLED.key, "true")


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #34.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently Comet uses the default memory pool implementation in DataFusion, which is not aware of the memory manager on the JVM Spark side. Therefore, in the case when a Spark job has both Spark and Comet operators, we'd need to initialize two memory pools separately for each of them, and make sure there is enough budget in them. In addition, since we cannot trigger spilling from native to JVM, or vise versa, the budget need to be large enough which means Comet typically will need to use more memory than Spark does.

Since Spark already has a `UnifiedMemoryManager`, this PR proposes to create a new memory pool implementation which delegate calls to the JVM side `UnifiedMemoryManager`, which serves as the source of truth and serves memory acquisition and release from both JVM and native side. 

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR introduces a `CometMemoryPool` class on the native side, overriding the default memory pool used by DF. This memory pool dispatches calls to Spark's `TaskMemoryManager` for acquiring and releasing memory. 

The newly added memory pool will only be activated when `spark.memory.offHeap.enabled` is set to `true`. Otherwise, the behavior remains the same as before (and `spark.executor.memoryOverhead` need to be large enough for native execution). In `TestBosonBase`, `spark.memory.offHeap.enabled` is enabled so all the tests within Comet are tested with the new feature.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

All the existing tests are updated to use the new memory manager implementation.