### PR TITLE
feat: Add struct/map as unsupported map key/value for columnar shuffle

### DIFF
--- a/core/src/execution/shuffle/row.rs
+++ b/core/src/execution/shuffle/row.rs
@@ -1758,7 +1758,7 @@ pub(crate) fn append_columns(
                 }
                 _ => {
                     return Err(CometError::Internal(format!(
-                        "Unsupported type: {:?}",
+                        "Unsupported map type: {:?}",
                         field.data_type()
                     )))
                 }
@@ -3182,7 +3182,7 @@ fn make_builders(
 
                 _ => {
                     return Err(CometError::Internal(format!(
-                        "Unsupported type: {:?}",
+                        "Unsupported map type: {:?}",
                         field.data_type()
                     )))
                 }
@@ -3255,7 +3255,7 @@ fn make_builders(
                 }
                 _ => {
                     return Err(CometError::Internal(format!(
-                        "Unsupported type: {:?}",
+                        "Unsupported list type: {:?}",
                         field.data_type()
                     )))
                 }

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -1830,10 +1830,15 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde {
       case StructType(fields) =>
         fields.forall(f => supportedDataType(f.dataType))
       case ArrayType(ArrayType(_, _), _) => false // TODO: nested array is not supported
+      case ArrayType(MapType(_, _, _), _) => false // TODO: map array element is not supported
       case ArrayType(elementType, _) =>
         supportedDataType(elementType)
       case MapType(MapType(_, _, _), _, _) => false // TODO: nested map is not supported
       case MapType(_, MapType(_, _, _), _) => false
+      case MapType(StructType(_), _, _) => false // TODO: struct map key/value is not supported
+      case MapType(_, StructType(_), _) => false
+      case MapType(ArrayType(_, _), _, _) => false // TODO: array map key/value is not supported
+      case MapType(_, ArrayType(_, _), _) => false
       case MapType(keyType, valueType, _) =>
         supportedDataType(keyType) && supportedDataType(valueType)
       case _ =>


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This patch adds more unsupported partitioning types. So user applications can fallback to Spark early without running into error.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
