### PR TITLE
fix: Fix compilation error for CometBroadcastExchangeExec

### DIFF
--- a/spark/src/main/scala/org/apache/comet/shims/ShimCometBroadcastExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/comet/shims/ShimCometBroadcastExchangeExec.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.shims
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.SparkContext
+import org.apache.spark.broadcast.Broadcast
+
+trait ShimCometBroadcastExchangeExec {
+  // TODO: remove after dropping Spark 3.2 and 3.3 support
+  protected def doBroadcast[T: ClassTag](sparkContext: SparkContext, value: T): Broadcast[Any] = {
+    // Spark 3.4 has new API `broadcastInternal` to broadcast the relation without caching the
+    // unserialized object.
+    val classTag = implicitly[ClassTag[T]]
+    val broadcasted = sparkContext.getClass.getDeclaredMethods
+      .filter(_.getName == "broadcastInternal")
+      .map { a => a.setAccessible(true); a }
+      .map { method =>
+        method
+          .invoke(
+            sparkContext.asInstanceOf[Object],
+            value.asInstanceOf[Object],
+            true.asInstanceOf[Object],
+            classTag.asInstanceOf[Object])
+          .asInstanceOf[Broadcast[Any]]
+      }
+      .headOption
+    // Fallback to the old API if the new API is not available.
+    broadcasted
+      .getOrElse(sparkContext.broadcast(value.asInstanceOf[Object]))
+      .asInstanceOf[Broadcast[Any]]
+  }
+}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->


There are some compilation error on `CometBroadcastExchangeExec ` in Spark 3.2/3.2:
    
```
17:38:27.154 [�[1;31mERROR�[m] 
/spark/src/main/scala/org/apache/spark/sql/comet/CometBroadcastExchangeExec.scala:115: value broadcastInternal is not a member of org.apache.spark.SparkContext
    17:38:27.154 possible cause: maybe a semicolon is missing before `value broadcastInternal'?
    17:38:27.154 [�[1;31mERROR�[m] 
/spark/src/main/scala/org/apache/spark/sql/b comet oson/CometBroadcastExchangeExec.scala:115: not found: value serializedOnly
```
    
This is due to [SPARK-39983](https://issues.apache.org/jira/browse/SPARK-39983) which is 3.4 only patch.
And, `QueryExecutionErrors.notEnoughMemoryToBuildAndBroadcastTableError` adds a parameter in Spark 3.4.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
