### PR TITLE
fix: Cast string to boolean not compatible with Spark

### DIFF
--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -27,7 +27,7 @@ use arrow::{
     record_batch::RecordBatch,
     util::display::FormatOptions,
 };
-use arrow_array::ArrayRef;
+use arrow_array::{Array, ArrayRef, BooleanArray, GenericStringArray, OffsetSizeTrait};
 use arrow_schema::{DataType, Schema};
 use datafusion::logical_expr::ColumnarValue;
 use datafusion_common::{Result as DataFusionResult, ScalarValue};
@@ -75,8 +75,37 @@ impl Cast {
     fn cast_array(&self, array: ArrayRef) -> DataFusionResult<ArrayRef> {
         let array = array_with_timezone(array, self.timezone.clone(), Some(&self.data_type));
         let from_type = array.data_type();
-        let cast_result = cast_with_options(&array, &self.data_type, &CAST_OPTIONS)?;
-        Ok(spark_cast(cast_result, from_type, &self.data_type))
+        let to_type = &self.data_type;
+        let cast_result = match (from_type, to_type) {
+            (DataType::Utf8, DataType::Boolean) => Self::spark_cast_utf8_to_boolean::<i32>(&array),
+            (DataType::LargeUtf8, DataType::Boolean) => Self::spark_cast_utf8_to_boolean::<i64>(&array),
+            _ => cast_with_options(&array, &self.data_type, &CAST_OPTIONS)?
+        };
+        let result = spark_cast(cast_result, from_type, &self.data_type);
+        Ok(result)
+    }
+
+    fn spark_cast_utf8_to_boolean<OffsetSize>(from: &dyn Array) -> ArrayRef
+        where
+            OffsetSize: OffsetSizeTrait,
+    {
+        let array = from
+            .as_any()
+            .downcast_ref::<GenericStringArray<OffsetSize>>()
+            .unwrap();
+
+        let output_array = array
+            .iter()
+            .map(|value| match value {
+                Some(value) => match value.to_ascii_lowercase().trim() {
+                    "t" | "true" | "y" | "yes" | "1" => Some(true),
+                    "f" | "false" | "n" | "no" | "0" => Some(false),
+                    _ => None
+                },
+                _ => None
+            }).collect::<BooleanArray>();
+
+        Arc::new(output_array)
     }
 }
 

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -78,16 +78,18 @@ impl Cast {
         let to_type = &self.data_type;
         let cast_result = match (from_type, to_type) {
             (DataType::Utf8, DataType::Boolean) => Self::spark_cast_utf8_to_boolean::<i32>(&array),
-            (DataType::LargeUtf8, DataType::Boolean) => Self::spark_cast_utf8_to_boolean::<i64>(&array),
-            _ => cast_with_options(&array, &self.data_type, &CAST_OPTIONS)?
+            (DataType::LargeUtf8, DataType::Boolean) => {
+                Self::spark_cast_utf8_to_boolean::<i64>(&array)
+            }
+            _ => cast_with_options(&array, &self.data_type, &CAST_OPTIONS)?,
         };
         let result = spark_cast(cast_result, from_type, &self.data_type);
         Ok(result)
     }
 
     fn spark_cast_utf8_to_boolean<OffsetSize>(from: &dyn Array) -> ArrayRef
-        where
-            OffsetSize: OffsetSizeTrait,
+    where
+        OffsetSize: OffsetSizeTrait,
     {
         let array = from
             .as_any()
@@ -100,10 +102,11 @@ impl Cast {
                 Some(value) => match value.to_ascii_lowercase().trim() {
                     "t" | "true" | "y" | "yes" | "1" => Some(true),
                     "f" | "false" | "n" | "no" | "0" => Some(false),
-                    _ => None
+                    _ => None,
                 },
-                _ => None
-            }).collect::<BooleanArray>();
+                _ => None,
+            })
+            .collect::<BooleanArray>();
 
         Arc::new(output_array)
     }

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -73,17 +73,17 @@ impl Cast {
     }
 
     fn cast_array(&self, array: ArrayRef) -> DataFusionResult<ArrayRef> {
-        let array = array_with_timezone(array, self.timezone.clone(), Some(&self.data_type));
-        let from_type = array.data_type();
         let to_type = &self.data_type;
+        let array = array_with_timezone(array, self.timezone.clone(), Some(to_type));
+        let from_type = array.data_type();
         let cast_result = match (from_type, to_type) {
             (DataType::Utf8, DataType::Boolean) => Self::spark_cast_utf8_to_boolean::<i32>(&array),
             (DataType::LargeUtf8, DataType::Boolean) => {
                 Self::spark_cast_utf8_to_boolean::<i64>(&array)
             }
-            _ => cast_with_options(&array, &self.data_type, &CAST_OPTIONS)?,
+            _ => cast_with_options(&array, to_type, &CAST_OPTIONS)?,
         };
-        let result = spark_cast(cast_result, from_type, &self.data_type);
+        let result = spark_cast(cast_result, from_type, to_type);
         Ok(result)
     }
 

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1304,26 +1304,26 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("test cast utf8 to boolean as compatible with Spark") {
-    def testConvertedColumn(inputValues: Seq[String]): Unit = {
+    def testCastedColumn(inputValues: Seq[String]): Unit = {
       val table = "test_table"
       withTable(table) {
         val values = inputValues.map(x => s"('$x')").mkString(",")
         sql(s"create table $table(base_column char(20)) using parquet")
         sql(s"insert into $table values $values")
         checkSparkAnswerAndOperator(
-          s"select base_column, cast(base_column as boolean) as converted_column from $table")
+          s"select base_column, cast(base_column as boolean) as casted_column from $table")
       }
     }
 
     // Supported boolean values as true by both Arrow and Spark
-    testConvertedColumn(inputValues = Seq("t", "true", "y", "yes", "1", "T", "TrUe", "Y", "YES"))
+    testCastedColumn(inputValues = Seq("t", "true", "y", "yes", "1", "T", "TrUe", "Y", "YES"))
     // Supported boolean values as false by both Arrow and Spark
-    testConvertedColumn(inputValues = Seq("f", "false", "n", "no", "0", "F", "FaLSe", "N", "No"))
+    testCastedColumn(inputValues = Seq("f", "false", "n", "no", "0", "F", "FaLSe", "N", "No"))
     // Supported boolean values by Arrow but not Spark
-    testConvertedColumn(inputValues =
+    testCastedColumn(inputValues =
       Seq("TR", "FA", "tr", "tru", "ye", "on", "fa", "fal", "fals", "of", "off"))
     // Invalid boolean casting values for Arrow and Spark
-    testConvertedColumn(inputValues = Seq("car", "Truck"))
+    testCastedColumn(inputValues = Seq("car", "Truck"))
   }
 
 }

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -21,13 +21,15 @@ package org.apache.comet
 
 import java.util
 
+import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
+
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{CometTestBase, DataFrame, Row}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
-import org.apache.spark.sql.functions.expr
+import org.apache.spark.sql.functions.{col, expr}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.SESSION_LOCAL_TIMEZONE
-import org.apache.spark.sql.types.{Decimal, DecimalType, StructType}
+import org.apache.spark.sql.types.{DataTypes, Decimal, DecimalType, StructType}
 
 import org.apache.comet.CometSparkSessionExtensions.{isSpark32, isSpark34Plus}
 
@@ -1302,4 +1304,50 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       }
     }
   }
+
+  test("test cast utf8 to boolean as compatible with Spark") {
+    withSQLConf(
+      CometConf.COMET_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_ALL_OPERATOR_ENABLED.key -> "true") {
+      withTable("test_table1", "test_table2", "test_table3", "test_table4") {
+        // Supported boolean values as true by both Arrow and Spark
+        val inputDF = Seq("t", "true", "y", "yes", "1", "T", "TrUe", "Y", "YES").toDF("c1")
+        inputDF.write.format("parquet").saveAsTable("test_table1")
+        val resultDF = this.spark
+          .table("test_table1")
+          .withColumn("converted", col("c1").cast(DataTypes.BooleanType))
+        val resultArr = resultDF.collectAsList().toList
+        resultArr.foreach(x => assert(x.get(1) == true))
+
+        // Supported boolean values as false by both Arrow and Spark
+        val inputDF2 = Seq("f", "false", "n", "no", "0", "F", "FaLSe", "N", "No").toDF("c1")
+        inputDF2.write.format("parquet").saveAsTable("test_table2")
+        val resultDF2 = this.spark
+          .table("test_table2")
+          .withColumn("converted", col("c1").cast(DataTypes.BooleanType))
+        val resultArr2 = resultDF2.collectAsList().toList
+        resultArr2.foreach(x => assert(x.get(1) == false))
+
+        // Supported boolean values by Arrow but not Spark
+        val inputDF3 =
+          Seq("TR", "FA", "tr", "tru", "ye", "on", "fa", "fal", "fals", "of", "off").toDF("c1")
+        inputDF3.write.format("parquet").saveAsTable("test_table3")
+        val resultDF3 = this.spark
+          .table("test_table3")
+          .withColumn("converted", col("c1").cast(DataTypes.BooleanType))
+        val resultArr3 = resultDF3.collectAsList().toList
+        resultArr3.foreach(x => assert(x.get(1) == null))
+
+        // Invalid boolean casting values for Arrow and Spark
+        val inputDF4 = Seq("car", "Truck").toDF("c1")
+        inputDF4.write.format("parquet").saveAsTable("test_table4")
+        val resultDF4 = this.spark
+          .table("test_table4")
+          .withColumn("converted", col("c1").cast(DataTypes.BooleanType))
+        val resultArr4 = resultDF4.collectAsList().toList
+        resultArr4.foreach(x => assert(x.get(1) == null))
+      }
+    }
+  }
+
 }

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -20,6 +20,7 @@
 package org.apache.comet.exec
 
 import scala.collection.JavaConverters._
+import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 import scala.collection.mutable
 import scala.util.Random
 
@@ -37,9 +38,10 @@ import org.apache.spark.sql.execution.{CollectLimitExec, ProjectExec, UnionExec}
 import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec
 import org.apache.spark.sql.execution.joins.{BroadcastNestedLoopJoinExec, CartesianProductExec, SortMergeJoinExec}
 import org.apache.spark.sql.execution.window.WindowExec
-import org.apache.spark.sql.functions.{date_add, expr}
+import org.apache.spark.sql.functions.{col, date_add, expr}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.SESSION_LOCAL_TIMEZONE
+import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.unsafe.types.UTF8String
 
 import org.apache.comet.CometConf
@@ -214,6 +216,51 @@ class CometExecSuite extends CometTestBase {
 
         assert(metrics.contains("output_rows"))
         assert(metrics("output_rows").value == 1L)
+      }
+    }
+  }
+
+  test("test cast utf8 to boolean as compatible with Spark") {
+    withSQLConf(
+      CometConf.COMET_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_ALL_OPERATOR_ENABLED.key -> "true") {
+      withTable("test_table1", "test_table2", "test_table3", "test_table4") {
+        // Supported boolean values as true by both Arrow and Spark
+        val inputDF = Seq("t", "true", "y", "yes", "1", "T", "TrUe", "Y", "YES").toDF("c1")
+        inputDF.write.format("parquet").saveAsTable("test_table1")
+        val resultDF = this.spark
+          .table("test_table1")
+          .withColumn("converted", col("c1").cast(DataTypes.BooleanType))
+        val resultArr = resultDF.collectAsList().toList
+        resultArr.foreach(x => assert(x.get(1) == true))
+
+        // Supported boolean values as false by both Arrow and Spark
+        val inputDF2 = Seq("f", "false", "n", "no", "0", "F", "FaLSe", "N", "No").toDF("c1")
+        inputDF2.write.format("parquet").saveAsTable("test_table2")
+        val resultDF2 = this.spark
+          .table("test_table2")
+          .withColumn("converted", col("c1").cast(DataTypes.BooleanType))
+        val resultArr2 = resultDF2.collectAsList().toList
+        resultArr2.foreach(x => assert(x.get(1) == false))
+
+        // Supported boolean values by Arrow but not Spark
+        val inputDF3 =
+          Seq("TR", "FA", "tr", "tru", "ye", "on", "fa", "fal", "fals", "of", "off").toDF("c1")
+        inputDF3.write.format("parquet").saveAsTable("test_table3")
+        val resultDF3 = this.spark
+          .table("test_table3")
+          .withColumn("converted", col("c1").cast(DataTypes.BooleanType))
+        val resultArr3 = resultDF3.collectAsList().toList
+        resultArr3.foreach(x => assert(x.get(1) == null))
+
+        // Invalid boolean casting values for Arrow and Spark
+        val inputDF4 = Seq("car", "Truck").toDF("c1")
+        inputDF4.write.format("parquet").saveAsTable("test_table4")
+        val resultDF4 = this.spark
+          .table("test_table4")
+          .withColumn("converted", col("c1").cast(DataTypes.BooleanType))
+        val resultArr4 = resultDF4.collectAsList().toList
+        resultArr4.foreach(x => assert(x.get(1) == null))
       }
     }
   }


### PR DESCRIPTION
## Which issue does this PR close?
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
Closes #17.

## Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Comet needs to be compatible with Spark on string to boolean casting results.

## What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Currently, Spark supports following boolean values and Comet also needs to compatible with Spark.
```
trueStrings => "t", "true", "y", "yes", "1"
falseStrings => "f", "false", "n", "no", "0"
```
Spark Reference API:
https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala#L74
https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala#L585
Note: I will also add `spark.sql.ansi.enabled` case support.

## How are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Added new UT.
