### PR TITLE
build: Add tpcds-sf-1 to license header excluded list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -836,6 +836,7 @@ under the License.
             <exclude>**/benchmarks/*.txt</exclude>
             <exclude>**/inspections/*.txt</exclude>
             <exclude>tpcds-kit/**</exclude>
+            <exclude>tpcds-sf-1/**</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Once the cache of generated tpcds data is used by CI, it will check license header for the files. We should exclude it too.

https://github.com/apache/arrow-datafusion-comet/actions/runs/8034989426/job/21947156559?pr=106

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
