### PR TITLE
feat: Add license header by spotless:apply automatically

### DIFF
--- a/dev/copyright/java-header.txt
+++ b/dev/copyright/java-header.txt
@@ -17,11 +17,3 @@
  * under the License.
  */
 
-package org.apache.spark.sql.comet
-
-import org.apache.spark.sql.execution.SparkPlan
-
-/**
- * The base trait for physical Comet operators.
- */
-trait CometPlan extends SparkPlan

--- a/dev/copyright/scala-header.txt
+++ b/dev/copyright/scala-header.txt
@@ -1,0 +1,1 @@
+java-header.txt

--- a/pom.xml
+++ b/pom.xml
@@ -722,6 +722,9 @@ under the License.
               <importOrder>
                 <order>java|javax,scala,org,org.apache,com,org.apache.comet,\#,\#org.apache.comet</order>
               </importOrder>
+              <licenseHeader>
+                <file>${maven.multiModuleProjectDirectory}/dev/copyright/java-header.txt</file>
+              </licenseHeader>
             </java>
             <scala>
               <toggleOffOn />
@@ -729,6 +732,9 @@ under the License.
                 <version>3.6.1</version>
                 <file>${maven.multiModuleProjectDirectory}/scalafmt.conf</file>
               </scalafmt>
+              <licenseHeader>
+                <file>${maven.multiModuleProjectDirectory}/dev/copyright/scala-header.txt</file>
+              </licenseHeader>
             </scala>
           </configuration>
         </plugin>

--- a/spark/src/test/scala/org/apache/spark/sql/TPCH.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/TPCH.scala
@@ -24,7 +24,7 @@ import org.apache.spark.rdd.RDD
 
 /**
  * Mostly copied from
- * https://github.com/databricks/spark-sql-perf/blob/master/src/main/scala/com/databricks/spark/sql/perf/Tables.scala
+ * https://github.com/databricks/spark-sql-perf/blob/master/src/main/scala/com/databricks/spark/sql/perf/tpch/TPCH.scala
  *
  * TODO: port this back to the upstream Spark similar to TPCDS benchmark
  */

--- a/spark/src/test/scala/org/apache/spark/sql/TPCH.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/TPCH.scala
@@ -17,17 +17,17 @@
  * under the License.
  */
 
-/**
- * Mostly copied from
- * https://github.com/databricks/spark-sql-perf/blob/master/src/main/scala/com/databricks/spark/sql/perf/tpch/TPCH.scala
- *
- * TODO: port this back to the upstream Spark similar to TPCDS benchmark
- */
-
 package org.apache.spark.sql
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
+
+/**
+ * Mostly copied from
+ * https://github.com/databricks/spark-sql-perf/blob/master/src/main/scala/com/databricks/spark/sql/perf/Tables.scala
+ *
+ * TODO: port this back to the upstream Spark similar to TPCDS benchmark
+ */
 
 class Dbgen(dbgenDir: String, params: Seq[String]) extends DataGenerator {
   val dbgen: String = s"$dbgenDir/dbgen"

--- a/spark/src/test/scala/org/apache/spark/sql/Tables.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/Tables.scala
@@ -17,13 +17,6 @@
  * under the License.
  */
 
-/**
- * Mostly copied from
- * https://github.com/databricks/spark-sql-perf/blob/master/src/main/scala/com/databricks/spark/sql/perf/Tables.scala
- *
- * TODO: port this back to the upstream Spark similar to TPCDS benchmark
- */
-
 package org.apache.spark.sql
 
 import scala.util.Try
@@ -35,6 +28,12 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 
+/**
+ * Mostly copied from
+ * https://github.com/databricks/spark-sql-perf/blob/master/src/main/scala/com/databricks/spark/sql/perf/Tables.scala
+ *
+ * TODO: port this back to the upstream Spark similar to TPCDS benchmark
+ */
 trait DataGenerator extends Serializable {
   def generate(
       sparkContext: SparkContext,

--- a/spark/src/test/scala/org/apache/spark/sql/comet/CometPlanStabilitySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/CometPlanStabilitySuite.scala
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.spark.sql.comet
 
 import java.io.File


### PR DESCRIPTION
## Which issue does this PR close?
Closes #.

## Rationale for this change
Add corresponding license header automatically, so developers doesn't need to bother that.

## What changes are included in this PR?
1.  spotless plugin changes to include scala/java license
2. spotless:apply to the existing code

## How are these changes tested?
manual verification