### PR TITLE
build: Show time duration for scala test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -641,6 +641,7 @@ under the License.
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <junitxml>.</junitxml>
             <filereports>SparkTestSuite.txt</filereports>
+            <stdout>D</stdout>
             <stderr/>
             <tagsToExclude>org.apache.comet.IntegrationTestSuite</tagsToExclude>
             <argLine>-ea -Xmx4g -Xss4m ${extraJavaTestArgs}</argLine>


### PR DESCRIPTION
## Which issue does this PR close?
This PR partially resolves #67 

## Rationale for this change
Currently, CI takes a lot of time to finish. This PR adds the ability to output test duration for each test cases. 
The duration info could be valuable to determine which tests cases to be optimized.

## What changes are included in this PR?
Add stdout reporter for scala test in pom.xml

## How are these changes tested?
Manual verification. After this PR, the test cases show duration as follows:
<img width="783" alt="image" src="https://github.com/apache/arrow-datafusion-comet/assets/807537/b3e5679a-ba0d-40bc-a2d9-22c0b90d1892">

