### PR TITLE
fix: Fix corrupted AggregateMode when transforming plan parameters

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -237,7 +237,13 @@ class CometSparkSessionExtensions
           val newOp = transform1(op)
           newOp match {
             case Some(nativeOp) =>
-              CometProjectExec(nativeOp, op, op.projectList, op.output, op.child, None)
+              CometProjectExec(
+                nativeOp,
+                op,
+                op.projectList,
+                op.output,
+                op.child,
+                SerializedPlan(None))
             case None =>
               op
           }
@@ -246,7 +252,7 @@ class CometSparkSessionExtensions
           val newOp = transform1(op)
           newOp match {
             case Some(nativeOp) =>
-              CometFilterExec(nativeOp, op, op.condition, op.child, None)
+              CometFilterExec(nativeOp, op, op.condition, op.child, SerializedPlan(None))
             case None =>
               op
           }
@@ -255,7 +261,7 @@ class CometSparkSessionExtensions
           val newOp = transform1(op)
           newOp match {
             case Some(nativeOp) =>
-              CometSortExec(nativeOp, op, op.sortOrder, op.child, None)
+              CometSortExec(nativeOp, op, op.sortOrder, op.child, SerializedPlan(None))
             case None =>
               op
           }
@@ -264,7 +270,7 @@ class CometSparkSessionExtensions
           val newOp = transform1(op)
           newOp match {
             case Some(nativeOp) =>
-              CometLocalLimitExec(nativeOp, op, op.limit, op.child, None)
+              CometLocalLimitExec(nativeOp, op, op.limit, op.child, SerializedPlan(None))
             case None =>
               op
           }
@@ -273,7 +279,7 @@ class CometSparkSessionExtensions
           val newOp = transform1(op)
           newOp match {
             case Some(nativeOp) =>
-              CometGlobalLimitExec(nativeOp, op, op.limit, op.child, None)
+              CometGlobalLimitExec(nativeOp, op, op.limit, op.child, SerializedPlan(None))
             case None =>
               op
           }
@@ -282,7 +288,7 @@ class CometSparkSessionExtensions
           val newOp = transform1(op)
           newOp match {
             case Some(nativeOp) =>
-              CometExpandExec(nativeOp, op, op.projections, op.child, None)
+              CometExpandExec(nativeOp, op, op.projections, op.child, SerializedPlan(None))
             case None =>
               op
           }
@@ -305,7 +311,7 @@ class CometSparkSessionExtensions
                 child.output,
                 if (modes.nonEmpty) Some(modes.head) else None,
                 child,
-                None)
+                SerializedPlan(None))
             case None =>
               op
           }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -150,7 +150,7 @@ abstract class CometNativeExec extends CometExec {
    * The serialized native query plan, optional. This is only defined when the current node is the
    * "boundary" node between native and Spark.
    *
-   * Note that derived classes of `BosonNativeExec` must have `serializedPlanOpt` in last product
+   * Note that derived classes of `CometNativeExec` must have `serializedPlanOpt` in last product
    * parameter.
    */
   def serializedPlanOpt: Option[Array[Byte]]
@@ -280,10 +280,11 @@ abstract class CometNativeExec extends CometExec {
   }
 
   /**
-   * Maps through product elements except the last one. The last element will be transformed using
-   * the provided function. This is used to transform `serializedPlanOpt` parameter in case
-   * classes of Boson native operator where the `serializedPlanOpt` is always the last produce
-   * element. That is because we cannot match `Option[Array[Byte]]` due to type erase.
+   * Copies product elements to the output array except the last one. The last element will be
+   * transformed using the provided function. This is used to transform `serializedPlanOpt`
+   * parameter in case classes of Comet native operator where the `serializedPlanOpt` is always
+   * the last produce element. That is because we cannot match `Option[Array[Byte]]` due to type
+   * erase.
    */
   private def mapProduct(f: Any => AnyRef): Array[AnyRef] = {
     val arr = Array.ofDim[AnyRef](productArity)

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -22,8 +22,10 @@ package org.apache.comet.exec
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.Random
+
 import org.scalactic.source.Position
 import org.scalatest.Tag
+
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{AnalysisException, Column, CometTestBase, DataFrame, DataFrameWriter, Row, SaveMode}
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -40,6 +42,7 @@ import org.apache.spark.sql.functions.{date_add, expr, sum}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.SESSION_LOCAL_TIMEZONE
 import org.apache.spark.unsafe.types.UTF8String
+
 import org.apache.comet.CometConf
 
 class CometExecSuite extends CometTestBase {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

While working on sort merge join, we encountered some failures in TPCDSQueryTestSuite, they look like:

```
- q14a *** FAILED ***                                                                                                                                       
  java.lang.Exception: class [B cannot be cast to class org.apache.spark.sql.catalyst.expressions.aggregate.AggregateMode ([B is in module java.base of load
er 'bootstrap'; org.apache.spark.sql.catalyst.expressions.aggregate.AggregateMode is in unnamed module of loader 'app')                                     Error using configs:                                                                                                                                        
spark.sql.autoBroadcastJoinThreshold=-1                                                                                                                     
spark.sql.join.preferSortMergeJoin=true                                                                                                                     
  at org.apache.spark.sql.TPCDSQueryTestSuite.$anonfun$runQuery$1(TPCDSQueryTestSuite.scala:170)                                                            
  at org.apache.spark.sql.catalyst.plans.SQLHelper.withSQLConf(SQLHelper.scala:54)                                                                          
  at org.apache.spark.sql.catalyst.plans.SQLHelper.withSQLConf$(SQLHelper.scala:38)                                                                         
  at org.apache.spark.sql.TPCDSQueryTestSuite.org$apache$spark$sql$test$SQLTestUtilsBase$$super$withSQLConf(TPCDSQueryTestSuite.scala:58)                   
  at org.apache.spark.sql.test.SQLTestUtilsBase.withSQLConf(SQLTestUtils.scala:266)                                                                         
  at org.apache.spark.sql.test.SQLTestUtilsBase.withSQLConf$(SQLTestUtils.scala:264)                                                                        
  at org.apache.spark.sql.TPCDSQueryTestSuite.withSQLConf(TPCDSQueryTestSuite.scala:58)                                                                     
  at org.apache.spark.sql.TPCDSQueryTestSuite.runQuery(TPCDSQueryTestSuite.scala:109)                                                                       
  at org.apache.spark.sql.TPCDSQueryTestSuite.$anonfun$new$6(TPCDSQueryTestSuite.scala:214)                                                                 
  at org.apache.spark.sql.TPCDSQueryTestSuite.$anonfun$new$6$adapted(TPCDSQueryTestSuite.scala:212)                                                         
  ...                                                                                                                                                       
  Cause: java.lang.ClassCastException: class [B cannot be cast to class org.apache.spark.sql.catalyst.expressions.aggregate.AggregateMode ([B is in module j
ava.base of loader 'bootstrap'; org.apache.spark.sql.catalyst.expressions.aggregate.AggregateMode is in unnamed module of loader 'app')                     
  at org.apache.comet.serde.QueryPlanSerde$$anonfun$1.applyOrElse(QueryPlanSerde.scala:1739)                                                                 
```

This is because we produce corrupted `mode` during transforming plan parameters. During the transformation, we match `Option[Array[Byte]]` but we cannot do that due to type erase in Scala. So if there are other `Option` parameter (e.g., `CometHashAggregateExec` has `mode: Option[AggregateMode]`), we will produce corrupted `mode` by assigning it a byte array.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
