### PR TITLE
test: Move MacOS (x86) pipelines to post-commit

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -44,6 +44,11 @@ jobs:
         os: [ubuntu-latest]
         java_version: [8, 11, 17]
         test-target: [rust, java]
+        is_push_event:
+          - ${{ github.event_name == 'push' }}
+        exclude: # exclude java 11 for pull_request event
+          - java_version: 11
+            is_push_event: false
       fail-fast: false
     name: ${{ matrix.test-target }} test on ${{ matrix.os }} with java ${{ matrix.java_version }}
     runs-on: ${{ matrix.os }}
@@ -73,12 +78,8 @@ jobs:
         os: [macos-13]
         java_version: [8, 11, 17]
         test-target: [rust, java]
-        is_push_event:
-          - ${{ github.event_name == 'push' }}
-        exclude: # exclude java 11 for pull_request event
-          - java_version: 11
-            is_push_event: false
       fail-fast: false
+    if: github.event_name == 'push'
     name: ${{ matrix.test-target }} test on ${{ matrix.os }} with java ${{ matrix.java_version }}
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

MacOS (x86) tests tend to be very slow, especially in Java 8. This moves them to post-commit to improve test time in PRs.

## What changes are included in this PR?

Moves MacOS (x86) CI pipelines to post-commit.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

N/A