### PR TITLE
build: Add checker for PR title

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -137,6 +137,7 @@ jobs:
           if ! echo $PR_TITLE | grep -Eq '^(\w+)(\(.+\))?: .+$'; then
             echo "PR title does not follow conventional commit style."
             echo "Please use a title in the format: type: message, or type(scope): message"
+            echo "Example: feat: Add support for sort-merge join"
             exit 1
           fi
 

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -126,3 +126,17 @@ jobs:
       - if: matrix.test-target == 'java'
         name: Java test steps
         uses: ./.github/actions/java-test
+  check-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if ! echo $PR_TITLE | grep -Eq '^(\w+)(\(.+\))?: .+$'; then
+            echo "PR title does not follow conventional commit style."
+            echo "Please use a title in the format: type: message, or type(scope): message"
+            exit 1
+          fi
+


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #75 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

It be useful to add a checker making sure all the PR titles conform to certain format, such as [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Added a Github action to check PR title and fail the PR if it violates the format. At the moment, the format is simply "type: message" or "type(scope): message". We don't restrict the set of valid types or scopes yet.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
