### PR TITLE
minor: Only trigger PR title checker on pull requests

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -188,18 +188,3 @@ jobs:
         with:
           MAVEN_OPTS: -Pspark-${{ matrix.spark-version }}
 
-  check-pr-title:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check PR title
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          if ! echo $PR_TITLE | grep -Eq '^(\w+)(\(.+\))?: .+$'; then
-            echo "PR title does not follow conventional commit style."
-            echo "Please use a title in the format: type: message, or type(scope): message"
-            echo "Example: feat: Add support for sort-merge join"
-            exit 1
-          fi
-

--- a/.github/workflows/pr_title_check.yml
+++ b/.github/workflows/pr_title_check.yml
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Check PR Title
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+jobs:
+  check-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if ! echo $PR_TITLE | grep -Eq '^(\w+)(\(.+\))?: .+$'; then
+            echo "PR title does not follow conventional commit style."
+            echo "Please use a title in the format: type: message, or type(scope): message"
+            echo "Example: feat: Add support for sort-merge join"
+            exit 1
+          fi
+


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

In #151 we checks PR title for both pull-requests and push events. We should only do it for the former. This is a follow-up to fix the behavior.

## What changes are included in this PR?

Fix PR title checker to only trigger on pull requests.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
