### PR TITLE
chore: Fix warnings in both compiler and test environments

### DIFF
--- a/common/src/main/java/org/apache/comet/parquet/BatchReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/BatchReader.java
@@ -517,6 +517,7 @@ public class BatchReader extends RecordReader<Void, ColumnarBatch> implements Cl
     }
   }
 
+  @SuppressWarnings("deprecation")
   private boolean loadNextRowGroupIfNecessary() throws Throwable {
     // More rows can be read from loaded row group. No need to load next one.
     if (rowsRead != totalRowsLoaded) return true;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,7 +34,7 @@ use jni::{
 };
 use log::{info, LevelFilter};
 use log4rs::{
-    append::console::ConsoleAppender,
+    append::console::{ConsoleAppender, Target},
     config::{load_config_file, Appender, Deserializers, Root},
     encode::pattern::PatternEncoder,
     Config,
@@ -99,6 +99,7 @@ const LOG_PATTERN: &str = "{d(%y/%m/%d %H:%M:%S)} {l} {f}: {m}{n}";
 // Creates a default log4rs config, which logs to console with `INFO` level.
 fn default_logger_config() -> CometResult<Config> {
     let console_append = ConsoleAppender::builder()
+        .target(Target::Stderr)
         .encoder(Box::new(PatternEncoder::new(LOG_PATTERN)))
         .build();
     let appender = Appender::builder().build("console", Box::new(console_append));

--- a/pom.xml
+++ b/pom.xml
@@ -711,9 +711,9 @@ under the License.
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.1.0</version>
           <configuration>
-            <systemProperties>
+            <systemPropertyVariables>
               <log4j.configurationFile>file:src/test/resources/log4j2.properties</log4j.configurationFile>
-            </systemProperties>
+            </systemPropertyVariables>
             <argLine>-ea -Xmx4g -Xss4m ${extraJavaTestArgs}</argLine>
           </configuration>
         </plugin>

--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -115,7 +115,7 @@ class CometSparkSessionExtensions
           // data source V1
           case scanExec @ FileSourceScanExec(
                 HadoopFsRelation(_, partitionSchema, _, _, _: ParquetFileFormat, _),
-                _: Seq[AttributeReference],
+                _: Seq[_],
                 requiredSchema,
                 _,
                 _,

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -1472,14 +1472,14 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde {
       // With Spark 3.4, CharVarcharCodegenUtils.readSidePadding gets called to pad spaces for char
       // types. Use rpad to achieve the behavior. See https://github.com/apache/spark/pull/38151
       case StaticInvoke(
-            _: Class[CharVarcharCodegenUtils],
+            clz: Class[_],
             _: StringType,
             "readSidePadding",
             arguments,
             _,
             true,
             false,
-            true) if arguments.size == 2 =>
+            true) if clz == classOf[CharVarcharCodegenUtils] && arguments.size == 2 =>
         val argsExpr = Seq(
           exprToProtoInternal(Cast(arguments(0), StringType), inputs),
           exprToProtoInternal(arguments(1), inputs))

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometCollectLimitExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometCollectLimitExec.scala
@@ -19,8 +19,6 @@
 
 package org.apache.spark.sql.comet
 
-import java.util.Objects
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.sql.catalyst.InternalRow
@@ -28,6 +26,8 @@ import org.apache.spark.sql.comet.execution.shuffle.{CometShuffledBatchRDD, Come
 import org.apache.spark.sql.execution.{ColumnarToRowExec, SparkPlan, UnaryExecNode, UnsafeRowSerializer}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics, SQLShuffleReadMetricsReporter, SQLShuffleWriteMetricsReporter}
 import org.apache.spark.sql.vectorized.ColumnarBatch
+
+import com.google.common.base.Objects
 
 /**
  * Comet physical plan node for Spark `CollectLimitExec`.

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -291,7 +291,6 @@ class CometExecSuite extends CometTestBase {
         val exchanges = stripAQEPlan(df.queryExecution.executedPlan).collect {
           case s: CometShuffleExchangeExec if s.shuffleType == CometColumnarShuffle =>
             s
-            s
         }
         assert(exchanges.length == 4)
       }

--- a/spark/src/test/scala/org/apache/spark/sql/CometTPCHQuerySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTPCHQuerySuite.scala
@@ -271,7 +271,7 @@ class CometTPCHQuerySuite extends QueryTest with CometTPCBase with SQLQueryTestH
   }
 
   // TODO: remove once Spark 3.2 & 3.3 is no longer supported
-  private val shouldRegenerateGoldenFiles: Boolean =
+  private def shouldRegenerateGoldenFiles: Boolean =
     System.getenv("SPARK_GENERATE_GOLDEN_FILES") == "1"
 }
 


### PR DESCRIPTION
## Which issue does this PR close?
Closes #.

## Rationale for this change
When build comet locally, I noticed various warnings. Some are compiler warnings, some are test environment warnings. 
Related code should be refactored for better code quality

## What changes are included in this PR?
Fixes various warning in the compiler and test environments

## How are these changes tested?
Manually verify the output of maven test