### PR TITLE
feat: Enable min/max for boolean type

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -181,7 +181,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde {
 
   private def minMaxDataTypeSupported(dt: DataType): Boolean = {
     dt match {
-      case _: NumericType | DateType | TimestampType => true
+      case _: NumericType | DateType | TimestampType | BooleanType => true
       case _ => false
     }
   }

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -902,7 +902,7 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
                 sql(s"insert into $table values(true, 3)")
                 // Spark maps BOOL_AND to MIN and BOOL_OR to MAX
                 checkSparkAnswerAndNumOfAggregates(
-                  s"SELECT MIN(a), MIN(b), BOOL_AND(a), BOOL_OR(a) FROM $table",
+                  s"SELECT MIN(a), MAX(a), BOOL_AND(a), BOOL_OR(a) FROM $table",
                   2)
               }
             }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

Enable `min/max` for `BooleanType`. This is also for `bool_and` and `bool_or` since Spark maps `bool_and` to `min` and `bool_or` to `max`.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

new test
