### PR TITLE
fix: Include active spiller when computing peak shuffle memory

### DIFF
--- a/spark/src/main/java/org/apache/spark/shuffle/sort/CometShuffleExternalSorter.java
+++ b/spark/src/main/java/org/apache/spark/shuffle/sort/CometShuffleExternalSorter.java
@@ -257,7 +257,9 @@ public final class CometShuffleExternalSorter implements CometShuffleChecksumSup
     for (SpillSorter sorter : spillingSorters) {
       totalPageSize += sorter.getMemoryUsage();
     }
-    totalPageSize += activeSpillSorter.getMemoryUsage();
+    if (activeSpillSorter != null) {
+      totalPageSize += activeSpillSorter.getMemoryUsage();
+    }
     return totalPageSize;
   }
 

--- a/spark/src/main/java/org/apache/spark/shuffle/sort/CometShuffleExternalSorter.java
+++ b/spark/src/main/java/org/apache/spark/shuffle/sort/CometShuffleExternalSorter.java
@@ -257,6 +257,7 @@ public final class CometShuffleExternalSorter implements CometShuffleChecksumSup
     for (SpillSorter sorter : spillingSorters) {
       totalPageSize += sorter.getMemoryUsage();
     }
+    totalPageSize += activeSpillSorter.getMemoryUsage();
     return totalPageSize;
   }
 
@@ -274,6 +275,7 @@ public final class CometShuffleExternalSorter implements CometShuffleChecksumSup
   }
 
   private long freeMemory() {
+    updatePeakMemoryUsed();
     long memoryFreed = 0;
     if (isAsync) {
       for (SpillSorter sorter : spillingSorters) {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We should include `activeSpillerSorter` when calculating peak shuffle memory. Otherwise, the stats will be inaccurate.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
