### PR TITLE
feat: Support bitwise aggregate functions

### DIFF
--- a/core/src/execution/datafusion/planner.rs
+++ b/core/src/execution/datafusion/planner.rs
@@ -27,7 +27,7 @@ use datafusion::{
     physical_expr::{
         execution_props::ExecutionProps,
         expressions::{
-            in_list, BinaryExpr, CaseExpr, CastExpr, Column, Count, FirstValue, InListExpr,
+            in_list, BinaryExpr, BitAnd, BitOr, BitXor, CaseExpr, CastExpr, Column, Count, FirstValue, InListExpr,
             IsNotNullExpr, IsNullExpr, LastValue, Literal as DataFusionLiteral, Max, Min,
             NegativeExpr, NotExpr, Sum, UnKnownColumn,
         },
@@ -939,6 +939,21 @@ impl PhysicalPlanner {
                     vec![],
                     vec![],
                 )))
+            }
+            AggExprStruct::BitAndAgg(expr) => {
+                let child = self.create_expr(expr.child.as_ref().unwrap(), schema)?;
+                let datatype = to_arrow_datatype(expr.datatype.as_ref().unwrap());
+                Ok(Arc::new(BitAnd::new(child, "bit_and", datatype)))
+            }
+            AggExprStruct::BitOrAgg(expr) => {
+                let child = self.create_expr(expr.child.as_ref().unwrap(), schema)?;
+                let datatype = to_arrow_datatype(expr.datatype.as_ref().unwrap());
+                Ok(Arc::new(BitOr::new(child, "bit_or", datatype)))
+            }
+            AggExprStruct::BitXorAgg(expr) => {
+                let child = self.create_expr(expr.child.as_ref().unwrap(), schema)?;
+                let datatype = to_arrow_datatype(expr.datatype.as_ref().unwrap());
+                Ok(Arc::new(BitXor::new(child, "bit_xor", datatype)))
             }
         }
     }

--- a/core/src/execution/datafusion/planner.rs
+++ b/core/src/execution/datafusion/planner.rs
@@ -27,9 +27,9 @@ use datafusion::{
     physical_expr::{
         execution_props::ExecutionProps,
         expressions::{
-            in_list, BinaryExpr, BitAnd, BitOr, BitXor, CaseExpr, CastExpr, Column, Count, FirstValue, InListExpr,
-            IsNotNullExpr, IsNullExpr, LastValue, Literal as DataFusionLiteral, Max, Min,
-            NegativeExpr, NotExpr, Sum, UnKnownColumn,
+            in_list, BinaryExpr, BitAnd, BitOr, BitXor, CaseExpr, CastExpr, Column, Count,
+            FirstValue, InListExpr, IsNotNullExpr, IsNullExpr, LastValue,
+            Literal as DataFusionLiteral, Max, Min, NegativeExpr, NotExpr, Sum, UnKnownColumn,
         },
         functions::create_physical_expr,
         AggregateExpr, PhysicalExpr, PhysicalSortExpr, ScalarFunctionExpr,

--- a/core/src/execution/proto/expr.proto
+++ b/core/src/execution/proto/expr.proto
@@ -88,6 +88,9 @@ message AggExpr {
     Avg avg = 6;
     First first = 7;
     Last last = 8;
+    BitAndAgg bitAndAgg = 9;
+    BitOrAgg bitOrAgg = 10;
+    BitXorAgg bitXorAgg = 11;
   }
 }
 
@@ -128,6 +131,21 @@ message Last {
   Expr child = 1;
   DataType datatype = 2;
   bool ignore_nulls = 3;
+}
+
+message BitAndAgg {
+  Expr child = 1;
+  DataType datatype = 2;
+}
+
+message BitOrAgg {
+  Expr child = 1;
+  DataType datatype = 2;
+}
+
+message BitXorAgg {
+  Expr child = 1;
+  DataType datatype = 2;
 }
 
 message Literal {

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -188,7 +188,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde {
 
   private def bitwiseAggTypeSupported(dt: DataType): Boolean = {
     dt match {
-      case _: IntegerType => true
+      case _: IntegerType | LongType | ShortType | ByteType => true
       case _ => false
     }
   }

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -23,7 +23,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Average, Count, Final, First, Last, Max, Min, Partial, Sum}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Average, BitAndAgg, BitOrAgg, BitXorAgg, Count, Final, First, Last, Max, Min, Partial, Sum}
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.optimizer.NormalizeNaNAndZero
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, SinglePartition}
@@ -186,6 +186,13 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde {
     }
   }
 
+  private def bitwiseAggTypeSupported(dt: DataType): Boolean = {
+    dt match {
+      case _: IntegerType => true
+      case _ => false
+    }
+  }
+
   def aggExprToProto(
       aggExpr: AggregateExpression,
       inputs: Seq[Attribute],
@@ -322,6 +329,57 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde {
             ExprOuterClass.AggExpr
               .newBuilder()
               .setLast(lastBuilder)
+              .build())
+        } else {
+          None
+        }
+      case bitAnd @ BitAndAgg(child) if bitwiseAggTypeSupported(bitAnd.dataType) =>
+        val childExpr = exprToProto(child, inputs, binding)
+        val dataType = serializeDataType(bitAnd.dataType)
+
+        if (childExpr.isDefined && dataType.isDefined) {
+          val bitAndBuilder = ExprOuterClass.BitAndAgg.newBuilder()
+          bitAndBuilder.setChild(childExpr.get)
+          bitAndBuilder.setDatatype(dataType.get)
+
+          Some(
+            ExprOuterClass.AggExpr
+              .newBuilder()
+              .setBitAndAgg(bitAndBuilder)
+              .build())
+        } else {
+          None
+        }
+      case bitOr @ BitOrAgg(child) if bitwiseAggTypeSupported(bitOr.dataType) =>
+        val childExpr = exprToProto(child, inputs, binding)
+        val dataType = serializeDataType(bitOr.dataType)
+
+        if (childExpr.isDefined && dataType.isDefined) {
+          val bitOrBuilder = ExprOuterClass.BitOrAgg.newBuilder()
+          bitOrBuilder.setChild(childExpr.get)
+          bitOrBuilder.setDatatype(dataType.get)
+
+          Some(
+            ExprOuterClass.AggExpr
+              .newBuilder()
+              .setBitOrAgg(bitOrBuilder)
+              .build())
+        } else {
+          None
+        }
+      case bitXor @ BitXorAgg(child) if bitwiseAggTypeSupported(bitXor.dataType) =>
+        val childExpr = exprToProto(child, inputs, binding)
+        val dataType = serializeDataType(bitXor.dataType)
+
+        if (childExpr.isDefined && dataType.isDefined) {
+          val bitXorBuilder = ExprOuterClass.BitXorAgg.newBuilder()
+          bitXorBuilder.setChild(childExpr.get)
+          bitXorBuilder.setDatatype(dataType.get)
+
+          Some(
+            ExprOuterClass.AggExpr
+              .newBuilder()
+              .setBitXorAgg(bitXorBuilder)
               .build())
         } else {
           None


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.
Support bitwise  aggregate functions such as `BitAnd`, `BitOr`, `BitXor`

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
