### PR TITLE
build: Avoid confusion by using profile with clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ test-jvm: core
 test: test-rust test-jvm
 clean:
 	cd core && cargo clean
-	./mvnw clean
+	./mvnw clean $(PROFILES)
 	rm -rf .dist
 bench:
 	cd core && RUSTFLAGS="-Ctarget-cpu=native" cargo bench $(filter-out $@,$(MAKECMDGOALS))


### PR DESCRIPTION
## Which issue does this PR close?

## Rationale for this change

The logs can include spark and scala versions that don't match the specified profile, which can lead to confusion.  This change includes the profile when running `make clean` to ensure consistency.

## What changes are included in this PR?

Adds `$(PROFILES)` to the `make clean` task

## How are these changes tested?

Manually
