### PR TITLE
fix: Remove duplicate byte array allocation for CometDictionary

### DIFF
--- a/common/src/main/java/org/apache/comet/vector/CometDictionary.java
+++ b/common/src/main/java/org/apache/comet/vector/CometDictionary.java
@@ -156,10 +156,9 @@ public class CometDictionary implements AutoCloseable {
         binaries = new ByteArrayWrapper[numValues];
         for (int i = 0; i < numValues; i++) {
           // Need copying here since we re-use byte array for decimal
-          byte[] bytes = values.getBinaryDecimal(i);
-          byte[] copy = new byte[DECIMAL_BYTE_WIDTH];
-          System.arraycopy(bytes, 0, copy, 0, DECIMAL_BYTE_WIDTH);
-          binaries[i] = new ByteArrayWrapper(copy);
+          byte[] bytes = new byte[DECIMAL_BYTE_WIDTH];
+          bytes = values.copyBinaryDecimal(i, bytes);
+          binaries[i] = new ByteArrayWrapper(bytes);
         }
         break;
       default:

--- a/common/src/main/java/org/apache/comet/vector/CometVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometVector.java
@@ -98,22 +98,30 @@ public abstract class CometVector extends ColumnVector {
     }
   }
 
-  /** Reads a 16-byte byte array which are encoded big-endian for decimal128. */
+  /**
+   * Reads a 16-byte byte array which are encoded big-endian for decimal128 into internal byte
+   * array.
+   */
   byte[] getBinaryDecimal(int i) {
+    return copyBinaryDecimal(i, DECIMAL_BYTES);
+  }
+
+  /** Reads a 16-byte byte array which are encoded big-endian for decimal128. */
+  public byte[] copyBinaryDecimal(int i, byte[] dest) {
     long valueBufferAddress = getValueVector().getDataBuffer().memoryAddress();
     Platform.copyMemory(
         null,
         valueBufferAddress + (long) i * DECIMAL_BYTE_WIDTH,
-        DECIMAL_BYTES,
+        dest,
         Platform.BYTE_ARRAY_OFFSET,
         DECIMAL_BYTE_WIDTH);
     // Decimal is stored little-endian in Arrow, so we need to reverse the bytes here
     for (int j = 0, k = DECIMAL_BYTE_WIDTH - 1; j < DECIMAL_BYTE_WIDTH / 2; j++, k--) {
-      byte tmp = DECIMAL_BYTES[j];
-      DECIMAL_BYTES[j] = DECIMAL_BYTES[k];
-      DECIMAL_BYTES[k] = tmp;
+      byte tmp = dest[j];
+      dest[j] = dest[k];
+      dest[k] = tmp;
     }
-    return DECIMAL_BYTES;
+    return dest;
   }
 
   @Override


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #225.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
