### PR TITLE
chore: Replace deprecated temporal methods

### DIFF
--- a/core/src/execution/datafusion/expressions/utils.rs
+++ b/core/src/execution/datafusion/expressions/utils.rs
@@ -178,7 +178,7 @@ fn pre_timestamp_cast(array: ArrayRef, timezone: String) -> ArrayRef {
                     let datetime = as_datetime::<TimestampMicrosecondType>(value).unwrap();
                     let offset = tz.offset_from_utc_datetime(&datetime).fix();
                     let datetime = datetime + offset;
-                    datetime.timestamp_micros()
+                    datetime.and_utc().timestamp_micros()
                 })
             });
 

--- a/core/src/execution/kernels/temporal.rs
+++ b/core/src/execution/kernels/temporal.rs
@@ -203,7 +203,7 @@ where
     T: Datelike + Timelike + std::ops::Sub<Duration, Output = T> + Copy,
 {
     Some(dt)
-        .map(|d| d - Duration::seconds(60 * 60 * 24 * d.weekday() as i64))
+        .map(|d| d - Duration::try_seconds(60 * 60 * 24 * d.weekday() as i64).unwrap())
         .and_then(|d| d.with_nanosecond(0))
         .and_then(|d| d.with_second(0))
         .and_then(|d| d.with_minute(0))


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

For builds that fail when there are deprecated warnings, this eliminates build failures.

## What changes are included in this PR?

Replaces deprecated methods with equivalent implementations.

## How are these changes tested?

Tested locally