### PR TITLE
fix: Only maps FIXED_LEN_BYTE_ARRAY to String for uuid type

### DIFF
--- a/common/src/main/java/org/apache/comet/parquet/TypeUtil.java
+++ b/common/src/main/java/org/apache/comet/parquet/TypeUtil.java
@@ -196,7 +196,9 @@ public class TypeUtil {
             || canReadAsBinaryDecimal(descriptor, sparkType)
             || sparkType == DataTypes.BinaryType
             // for uuid, since iceberg maps uuid to StringType
-            || sparkType == DataTypes.StringType) {
+            || sparkType == DataTypes.StringType
+                && descriptor.getPrimitiveType().getLogicalTypeAnnotation()
+                    instanceof LogicalTypeAnnotation.UUIDLogicalTypeAnnotation) {
           return;
         }
         break;

--- a/common/src/main/java/org/apache/comet/parquet/TypeUtil.java
+++ b/common/src/main/java/org/apache/comet/parquet/TypeUtil.java
@@ -197,7 +197,7 @@ public class TypeUtil {
             || sparkType == DataTypes.BinaryType
             // for uuid, since iceberg maps uuid to StringType
             || sparkType == DataTypes.StringType
-                && descriptor.getPrimitiveType().getLogicalTypeAnnotation()
+                && logicalTypeAnnotation
                     instanceof LogicalTypeAnnotation.UUIDLogicalTypeAnnotation) {
           return;
         }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

UUID is not a SQL type in Spark, but is supported by Iceberg and is mapped to UTF8String. In order to support UUID, we have mapped FIXED_LEN_BYTE_ARRAY to String, but we can only do this if the FIXED_LEN_BYTE_ARRAY is UUID. This PR adds the check so we only map FIXED_LEN_BYTE_ARRAY to String for UUID type.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
