### PR TITLE
fix: Reduce RowPartition memory allocation

### DIFF
--- a/spark/src/main/scala/org/apache/spark/shuffle/sort/RowPartition.scala
+++ b/spark/src/main/scala/org/apache/spark/shuffle/sort/RowPartition.scala
@@ -22,8 +22,8 @@ package org.apache.spark.shuffle.sort
 import scala.collection.mutable.ArrayBuffer
 
 class RowPartition(initialSize: Int) {
-  private val rowAddresses: ArrayBuffer[Long] = new ArrayBuffer[Long](initialSize)
-  private val rowSizes: ArrayBuffer[Int] = new ArrayBuffer[Int](initialSize)
+  private var rowAddresses: ArrayBuffer[Long] = new ArrayBuffer[Long](initialSize)
+  private var rowSizes: ArrayBuffer[Int] = new ArrayBuffer[Int](initialSize)
 
   def addRow(addr: Long, size: Int): Unit = {
     rowAddresses += addr
@@ -36,7 +36,7 @@ class RowPartition(initialSize: Int) {
   def getRowSizes: Array[Int] = rowSizes.toArray
 
   def reset(): Unit = {
-    rowAddresses.clear()
-    rowSizes.clear()
+    rowAddresses = new ArrayBuffer[Long](initialSize)
+    rowSizes = new ArrayBuffer[Int](initialSize)
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

`RowPartition` allocates memory for storing row addresses and sizes. We call `ArrayBuffer.clear` in `RowPartition.reset` method to clean up the memory allocation. But `ArrayBuffer.clear` doesn't actually deallocate the internal array but just initiates its content.

When we insert elements into the array, it will ensure the array size by doubling the array size every time if the space is not enough. So the array grows. That's said if the arrow grows, `clear` cannot deallocate the array after spilling but still uses unnecessary size of array.

This patch fixes it.

Besides, as we limit columnar batch size in native writer, it doesn't make sense to have JVM row buffer larger than the size. In this patch, it uses `COMET_COLUMNAR_SHUFFLE_BATCH_SIZE` as the initial size of `RowPartition`.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
