### PR TITLE
fix: Deallocate row addresses and size arrays after exporting

### DIFF
--- a/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
+++ b/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
@@ -175,6 +175,10 @@ public abstract class SpillWriter {
     long[] addresses = rowPartition.getRowAddresses();
     int[] sizes = rowPartition.getRowSizes();
 
+    // We exported the addresses and sizes, reset the row partition
+    // to release the memory as soon as possible.
+    rowPartition.reset();
+
     boolean checksumEnabled = checksum != -1;
     long currentChecksum = checksumEnabled ? checksum : 0L;
 
@@ -194,8 +198,6 @@ public abstract class SpillWriter {
 
     long written = results[0];
     checksum = results[1];
-
-    rowPartition.reset();
 
     // Update metrics
     // Other threads may be updating the metrics at the same time, so we need to synchronize it.

--- a/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
+++ b/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
@@ -175,10 +175,6 @@ public abstract class SpillWriter {
     long[] addresses = rowPartition.getRowAddresses();
     int[] sizes = rowPartition.getRowSizes();
 
-    // We exported the addresses and sizes, reset the row partition
-    // to release the memory as soon as possible.
-    rowPartition.reset();
-
     boolean checksumEnabled = checksum != -1;
     long currentChecksum = checksumEnabled ? checksum : 0L;
 
@@ -198,6 +194,8 @@ public abstract class SpillWriter {
 
     long written = results[0];
     checksum = results[1];
+
+    rowPartition.reset();
 
     // Update metrics
     // Other threads may be updating the metrics at the same time, so we need to synchronize it.

--- a/spark/src/main/scala/org/apache/spark/shuffle/sort/RowPartition.scala
+++ b/spark/src/main/scala/org/apache/spark/shuffle/sort/RowPartition.scala
@@ -32,8 +32,17 @@ class RowPartition(initialSize: Int) {
 
   def getNumRows: Int = rowAddresses.size
 
-  def getRowAddresses: Array[Long] = rowAddresses.toArray
-  def getRowSizes: Array[Int] = rowSizes.toArray
+  def getRowAddresses: Array[Long] = {
+    val array = rowAddresses.toArray
+    rowAddresses = null
+    array
+  }
+
+  def getRowSizes: Array[Int] = {
+    val array = rowSizes.toArray
+    rowSizes = null
+    array
+  }
 
   def reset(): Unit = {
     rowAddresses = new ArrayBuffer[Long](initialSize)

--- a/spark/src/main/scala/org/apache/spark/shuffle/sort/RowPartition.scala
+++ b/spark/src/main/scala/org/apache/spark/shuffle/sort/RowPartition.scala
@@ -32,17 +32,9 @@ class RowPartition(initialSize: Int) {
 
   def getNumRows: Int = rowAddresses.size
 
-  def getRowAddresses: Array[Long] = {
-    val array = rowAddresses.toArray
-    rowAddresses = null
-    array
-  }
+  def getRowAddresses: Array[Long] = rowAddresses.toArray
 
-  def getRowSizes: Array[Int] = {
-    val array = rowSizes.toArray
-    rowSizes = null
-    array
-  }
+  def getRowSizes: Array[Int] = rowSizes.toArray
 
   def reset(): Unit = {
     rowAddresses = new ArrayBuffer[Long](initialSize)

--- a/spark/src/main/scala/org/apache/spark/shuffle/sort/RowPartition.scala
+++ b/spark/src/main/scala/org/apache/spark/shuffle/sort/RowPartition.scala
@@ -32,9 +32,17 @@ class RowPartition(initialSize: Int) {
 
   def getNumRows: Int = rowAddresses.size
 
-  def getRowAddresses: Array[Long] = rowAddresses.toArray
+  def getRowAddresses: Array[Long] = {
+    val array = rowAddresses.toArray
+    rowAddresses = null
+    array
+  }
 
-  def getRowSizes: Array[Int] = rowSizes.toArray
+  def getRowSizes: Array[Int] = {
+    val array = rowSizes.toArray
+    rowSizes = null
+    array
+  }
 
   def reset(): Unit = {
     rowAddresses = new ArrayBuffer[Long](initialSize)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When we export row addresses and sizes to native, they are copied to separate arrays. We should deallocate array buffers after exporting them to reduce memory allocation.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
