### PR TITLE
fix: Fix wrong children expression order in IfExpr

### DIFF
--- a/core/src/execution/datafusion/expressions/if_expr.rs
+++ b/core/src/execution/datafusion/expressions/if_expr.rs
@@ -112,8 +112,8 @@ impl PhysicalExpr for IfExpr {
 
     fn children(&self) -> Vec<Arc<dyn PhysicalExpr>> {
         vec![
-            self.true_expr.clone(),
             self.if_expr.clone(),
+            self.true_expr.clone(),
             self.false_expr.clone(),
         ]
     }
@@ -217,5 +217,19 @@ mod tests {
         assert_eq!(expected, result);
 
         Ok(())
+    }
+
+    #[test]
+    fn test_if_children() {
+        let if_expr = lit(true);
+        let true_expr = lit(123i32);
+        let false_expr = lit(999i32);
+
+        let expr = if_fn(if_expr, true_expr, false_expr);
+        let children = expr.unwrap().children();
+        assert_eq!(children.len(), 3);
+        assert_eq!(children[0].to_string(), "true");
+        assert_eq!(children[1].to_string(), "123");
+        assert_eq!(children[2].to_string(), "999");
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

While working on #95, some queries in `CometTPCDSQuerySuite` are failed on incorrect child expression in `IfExpr`. It is because `IfExpr.children` returns incorrect order of children expressions.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
