### PR TITLE
chore: Make CI rules more consistent and reduce PR coverage for Spark 3.4

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -184,6 +184,13 @@ jobs:
         test-target: [java]
         spark-version: ['3.4']
         scala-version: ['2.12', '2.13']
+        is_push_event:
+          - ${{ github.event_name == 'push' }}
+        exclude: # exclude java 11 and  for pull_request event
+          - java_version: 11
+            is_push_event: false
+          - scala-version: '2.12'
+            is_push_event: false
       fail-fast: false
     name: ${{ matrix.os }}/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}-scala-${{matrix.scala-version}}/${{ matrix.test-target }}
     runs-on: ${{ matrix.os }}
@@ -207,8 +214,48 @@ jobs:
         os: [macos-13]
         java_version: [11, 17]
         test-target: [rust, java]
-        spark-version: ['3.4', '3.5']
+        spark-version: ['3.5']
         scala-version: ['2.12', '2.13']
+        is_push_event:
+          - ${{ github.event_name == 'push' }}
+        exclude: # exclude java 11 for pull_request event
+          - java_version: 11
+            is_push_event: false
+      fail-fast: false
+    if: github.event_name == 'push'
+    name: ${{ matrix.os }}/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}-scala-${{matrix.scala-version}}/${{ matrix.test-target }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust & Java toolchain
+        uses: ./.github/actions/setup-macos-builder
+        with:
+          rust-version: ${{env.RUST_VERSION}}
+          jdk-version: ${{ matrix.java_version }}
+      - if: matrix.test-target == 'rust'
+        name: Rust test steps
+        uses: ./.github/actions/rust-test
+      - if: matrix.test-target == 'java'
+        name: Java test steps
+        uses: ./.github/actions/java-test
+        with:
+          maven_opts: -Pspark-${{ matrix.spark-version }},scala-${{ matrix.scala-version }}
+
+  macos-test-old-spark:
+    strategy:
+      matrix:
+        os: [macos-13]
+        java_version: [11, 17]
+        test-target: [rust, java]
+        spark-version: ['3.4']
+        scala-version: ['2.12', '2.13']
+        is_push_event:
+          - ${{ github.event_name == 'push' }}
+        exclude: # exclude java 11 and scala 2.12 for pull_request event
+          - java_version: 11
+            is_push_event: false
+          - scala-version: '2.12'
+            is_push_event: false
       fail-fast: false
     if: github.event_name == 'push'
     name: ${{ matrix.os }}/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}-scala-${{matrix.scala-version}}/${{ matrix.test-target }}
@@ -234,7 +281,7 @@ jobs:
       matrix:
         java_version: [11, 17]
         test-target: [rust, java]
-        spark-version: ['3.4', '3.5']
+        spark-version: [''3.5']
         scala-version: ['2.12', '2.13']
         is_push_event:
           - ${{ github.event_name == 'push' }}
@@ -256,6 +303,36 @@ jobs:
       - if: matrix.test-target == 'rust'
         name: Rust test steps
         uses: ./.github/actions/rust-test
+      - if: matrix.test-target == 'java'
+        name: Java test steps
+        uses: ./.github/actions/java-test
+        with:
+          maven_opts: -Pspark-${{ matrix.spark-version }},scala-${{ matrix.scala-version }}
+
+  macos-aarch64-test-with-old-spark:
+    strategy:
+      matrix:
+        java_version: [11, 17]
+        test-target: [java]
+        spark-version: ['3.4']
+        scala-version: ['2.12', '2.13']
+        exclude: # exclude java 11 and scala 2.12 for pull_request event
+          - java_version: 11
+            is_push_event: false
+          - scala-version: '2.12'
+            is_push_event: false
+      fail-fast: false
+    name: macos-14(Silicon)/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}-scala-${{matrix.scala-version}}/${{ matrix.test-target }}
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust & Java toolchain
+        uses: ./.github/actions/setup-macos-builder
+        with:
+          rust-version: ${{env.RUST_VERSION}}
+          jdk-version: ${{ matrix.java_version }}
+          jdk-architecture: aarch64
+          protoc-architecture: aarch_64
       - if: matrix.test-target == 'java'
         name: Java test steps
         uses: ./.github/actions/java-test
@@ -314,31 +391,4 @@ jobs:
         with:
           maven_opts: -Pspark-${{ matrix.spark-version }}
           upload-test-reports: true
-
-  macos-aarch64-test-with-old-spark:
-    strategy:
-      matrix:
-        java_version: [17]
-        test-target: [java]
-        spark-version: ['3.4']
-        scala-version: ['2.12', '2.13']
-        exclude:
-          - java_version: 8
-      fail-fast: false
-    name: macos-14(Silicon)/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}-scala-${{matrix.scala-version}}/${{ matrix.test-target }}
-    runs-on: macos-14
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Rust & Java toolchain
-        uses: ./.github/actions/setup-macos-builder
-        with:
-          rust-version: ${{env.RUST_VERSION}}
-          jdk-version: ${{ matrix.java_version }}
-          jdk-architecture: aarch64
-          protoc-architecture: aarch_64
-      - if: matrix.test-target == 'java'
-        name: Java test steps
-        uses: ./.github/actions/java-test
-        with:
-          maven_opts: -Pspark-${{ matrix.spark-version }},scala-${{ matrix.scala-version }}
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/1783

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Trying to reduce CI time on each PR.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Fix bug where we were running some Apple Silicon Spark 3.4 workflows twice
- Skip testing Spark 3.4 with Java 11 and Scala 2.12 on PRs (but can still be run manually)

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
