### PR TITLE
fix: map parquet field_id correctly (native_iceberg_compat)

### DIFF
--- a/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
@@ -486,14 +486,14 @@ public class NativeBatchReader extends RecordReader<Void, ColumnarBatch> impleme
   private String getMatchingNameById(
       StructField f,
       Map<Integer, List<Type>> idToParquetFieldMap,
-      Map<String, List<Type>> nameToParquetFieldMap /*, Map<String, String> nameMap*/,
+      Map<String, List<Type>> nameToParquetFieldMap,
       boolean isCaseSensitive) {
     Type matched =
         getMatchingParquetFieldById(f, idToParquetFieldMap, nameToParquetFieldMap, isCaseSensitive);
 
     // When there is no ID match, we use a fake name to avoid a name match by accident
     // We need this name to be unique as well, otherwise there will be type conflicts
-    if (matched == null /*|| matched.isEmpty()*/) {
+    if (matched == null) {
       return CometParquetReadSupport.generateFakeColumnName();
     } else {
       return matched.getName();


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion-comet/issues/1542

## Rationale for this change

Parquet files may have field id's and native_iceberg_compat should use them  instead of names to identify columns

## What changes are included in this PR?

The call to clipParquetSchema produces a ParquetSchema that maps the field ids correct. This change simply converts the result back to a SparkSchema than can be passed in to native code.

## How are these changes tested?

Existing Spark SQL tests