### PR TITLE
chore: Skip some Spark SQL test runs on PRs

### DIFF
--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -64,7 +64,7 @@ jobs:
     container:
       image: amd64/rust
     steps:
-      - name: Skip Spark 3.5.5 and 3.5.6 on pull_request
+      - name: Skip older Spark 3.5.x versions on pull_request
         if: ${{ github.event_name == 'pull_request' && (matrix.spark-version.full == '3.5.4' || matrix.spark-version.full == '3.5.5') }}
         run: echo "Skipping for PR with Spark version ${{ matrix.spark-version.full }}" && exit 0
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We want to limit the number of Spark SQL runs on PRs to reduce development overhead.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Stop running Spark SQL tests with Spark versions 3.5.4 and 3.5.5 on PRs and just test with 3.5.6. We still test all versions on the main branch after PRs are merged.

Note that Iceberg main branch now uses Spark 3.5.6

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
