### PR TITLE
chore: upgrade to DataFusion 49.0.1

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1385,8 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4539076347adb068dd1950f64c6437e946dd3449b8284c971bd05f025a2e648"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -1434,8 +1435,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ae252e9dd4b0ee0e505fecc94dc74d08eb71dbb47bd252bc27dfeac4ab1fd4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1459,8 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f836ede0cbe4555b47e324fc185a1d5e7816fdc73e40c7669e257834fc488afa"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1570,8 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39569c76b0e43ab487fa7ab8d43f9609c013d8da381b093b67e7d12de818271b"
 dependencies = [
  "ahash",
  "arrow",
@@ -1593,8 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68742dd360aaa0746b54f834b9621f3836967359158b1fa13d97b21b8a1defa0"
 dependencies = [
  "futures",
  "log",
@@ -1603,8 +1608,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec6180c4ddfee5bc384c50ca066e5363a4da7e5d6acf5ac2ac1ddaea5d2cdcb"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1632,8 +1638,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c71c8e924db8eae39fd9c1203a8836bd9f2232831e2d07fd8428afe9ba314a2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1656,8 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb282c51182b741e3cb583fcf419f75928bb89742d1b3ac6c1ad9b188ef1d6d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1680,8 +1688,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "822d18a53a86a5354716828116dd541389838e73ff069149a6f09bd14bcfd2fa"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1711,13 +1720,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d50e710c1a4b944fa75e5a184eafe4a70bc1016413f0388949e8be3383f218"
 
 [[package]]
 name = "datafusion-execution"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed30edd30710767642f5d78e2c568354a51c342713874305d8281bcf64895a7d"
 dependencies = [
  "arrow",
  "dashmap",
@@ -1734,8 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50af1197648e4c860414d1871aa73f1cadf547ed65dc7a88720e961f9def5a9f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1754,8 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f492ba3c522d103690c84c3d38039d83d4b2cf26aab7f0038f77e47298aad5ef"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1766,8 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ef6ad5fde3f35e5da5848653936e6a75f565e8551a24da952cb26036f9babd"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1794,8 +1808,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5fa9ca2f7097b7716094de7a9f70635cd56881476dd274a1f96f30f199efaed"
 dependencies = [
  "ahash",
  "arrow",
@@ -1814,8 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c782fca3f8fcd82bbef57f39a6581c807dae961e85853f413161775d77ab39"
 dependencies = [
  "ahash",
  "arrow",
@@ -1826,8 +1842,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a85e8e1856a93aa4ae7c0c909d12c9384809739d53556023ae184e708f51f4f"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -1847,8 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-table"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5325b42aa4f775f3789310b8760681027460c2407579f2d213bca03e29ecf75b"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1862,8 +1880,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa2129e59f63dc15ea827da07d291093361df380135b86589d946b4ef76547ba"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1879,8 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b60f56521ffc46e093eceec9eec4da2ae604d37aaf15dbcb6c812403173b49f"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -1888,8 +1908,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "553cd882a5a8e3ecb1b1af1b33bbb898ddd3459020e2eff87fb177146447dee4"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -1898,8 +1919,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbe958375ac1bb4a81749dda9712d6a7572b3d3f0bec4e23134fa68d6546b5b5"
 dependencies = [
  "arrow",
  "chrono",
@@ -1916,8 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50077fd5b584d7f3bf3a9687e34213c36945300e8348d0bb14d2a5a8af38ffd"
 dependencies = [
  "ahash",
  "arrow",
@@ -1937,8 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acea27a3897b793c1eb54c7ab9b6eea1827a0263e88029ca04a6d08b1e2a4c6a"
 dependencies = [
  "ahash",
  "arrow",
@@ -1950,8 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06da58128f25036526783830c5d7dea85fffa48bbff3f640aa1f90c1e184e803"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1968,8 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35085e346acb5348733ed31696a639ef12788bc1cb09abfcebb66f5cd283fba6"
 dependencies = [
  "ahash",
  "arrow",
@@ -1998,7 +2024,8 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391a457b9d23744c53eeb89edd1027424cba100581488d89800ed841182df905"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2014,8 +2041,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-session"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b475806da727769daa1e667891c4e3b3e4353b49a3cd492a90c443b71230b19"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2037,8 +2065,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-spark"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb79eea6c20b8ca82cd8125356bd5eddf39a822eda91e6e548c90c455787b51"
 dependencies = [
  "arrow",
  "datafusion-catalog",
@@ -2052,8 +2081,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "49.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-49#9cfb9cd013f33bcdae25360790da7101ee33266f"
+version = "49.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0834fda1f2834d21b7bedb663c458e1e240e4f9053db86b69003edabdd2baa"
 dependencies = [
  "arrow",
  "bigdecimal",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -38,8 +38,8 @@ arrow = { version = "55.2.0", features = ["prettyprint", "ffi", "chrono-tz"] }
 async-trait = { version = "0.1" }
 bytes = { version = "1.10.0" }
 parquet = { version = "55.2.0", default-features = false, features = ["experimental"] }
-datafusion = { git = "https://github.com/apache/datafusion.git", branch = "branch-49", default-features = false, features = ["unicode_expressions", "crypto_expressions", "nested_expressions", "parquet"] }
-datafusion-spark = { git = "https://github.com/apache/datafusion.git", branch = "branch-49" }
+datafusion = { version = "49.0.1", default-features = false, features = ["unicode_expressions", "crypto_expressions", "nested_expressions", "parquet"] }
+datafusion-spark = { version = "49.0.1" }
 datafusion-comet-spark-expr = { path = "spark-expr" }
 datafusion-comet-proto = { path = "proto" }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/native/core/Cargo.toml
+++ b/native/core/Cargo.toml
@@ -84,7 +84,7 @@ jni = { version = "0.21", features = ["invocation"] }
 lazy_static = "1.4"
 assertables = "9"
 hex = "0.4.3"
-datafusion-functions-nested = { git = "https://github.com/apache/datafusion.git", branch = "branch-49" }
+datafusion-functions-nested = { version = "49.0.1" }
 
 [features]
 default = []


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

`SchemaAdapter` emits a WARN message that the API is deprecated and will be removed, but its replacement (`PhysicalExprAdapter`) does not support all of the functionality that Comet needs yet: namely projections on un-filtered default value columns. See https://github.com/apache/datafusion/issues/16800#issuecomment-3155626148.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

[DataFusion is preparing a 49.0.1 release](https://github.com/apache/datafusion/issues/17036), and the commit we need has already been backported to `branch-49`. This PR switches the DF dependency from the released 49.0.0 version to the branch which has 49.0.1 changes.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

CI tests.