### PR TITLE
chore: Rust 1.89-related fixes (warnings and clippy)

### DIFF
--- a/native/core/src/execution/operators/filter.rs
+++ b/native/core/src/execution/operators/filter.rs
@@ -549,7 +549,7 @@ impl RecordBatchStream for FilterExecStream {
 }
 
 /// Return the equals Column-Pairs and Non-equals Column-Pairs
-fn collect_columns_from_predicate(predicate: &Arc<dyn PhysicalExpr>) -> EqualAndNonEqual {
+fn collect_columns_from_predicate(predicate: &Arc<dyn PhysicalExpr>) -> EqualAndNonEqual<'_> {
     let mut eq_predicate_columns = Vec::<PhysicalExprPairRef>::new();
     let mut ne_predicate_columns = Vec::<PhysicalExprPairRef>::new();
 

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -2535,10 +2535,10 @@ impl TreeNodeRewriter for JoinFilterRewriter<'_> {
                     new_index + self.left_field_indices.len(),
                 ))))
             } else {
-                return Err(DataFusionError::Internal(format!(
+                Err(DataFusionError::Internal(format!(
                     "Column index {} out of range",
                     column.index()
-                )));
+                )))
             }
         } else {
             Ok(Transformed::no(node))

--- a/native/core/src/execution/shuffle/shuffle_writer.rs
+++ b/native/core/src/execution/shuffle/shuffle_writer.rs
@@ -1061,7 +1061,7 @@ impl PartitionedBatchesProducer {
         }
     }
 
-    fn produce(&mut self, partition_id: usize) -> PartitionedBatchIterator {
+    fn produce(&mut self, partition_id: usize) -> PartitionedBatchIterator<'_> {
         PartitionedBatchIterator::new(
             &self.partition_indices[partition_id],
             &self.buffered_batches,

--- a/native/core/src/jvm_bridge/mod.rs
+++ b/native/core/src/jvm_bridge/mod.rs
@@ -115,7 +115,7 @@ impl<'a> StringWrapper<'a> {
         Self { value }
     }
 
-    pub fn get(&self) -> &JString {
+    pub fn get(&self) -> &JString<'_> {
         &self.value
     }
 }
@@ -129,7 +129,7 @@ impl<'a> BinaryWrapper<'a> {
         Self { value }
     }
 
-    pub fn get(&self) -> &JObject {
+    pub fn get(&self) -> &JObject<'_> {
         &self.value
     }
 }

--- a/native/spark-expr/src/conversion_funcs/cast.rs
+++ b/native/spark-expr/src/conversion_funcs/cast.rs
@@ -679,7 +679,7 @@ macro_rules! cast_decimal_to_int16_down {
         let cast_array = $array
             .as_any()
             .downcast_ref::<Decimal128Array>()
-            .expect(concat!("Expected a Decimal128ArrayType"));
+            .expect("Expected a Decimal128ArrayType");
 
         let output_array = match $eval_mode {
             EvalMode::Ansi => cast_array
@@ -742,7 +742,7 @@ macro_rules! cast_decimal_to_int32_up {
         let cast_array = $array
             .as_any()
             .downcast_ref::<Decimal128Array>()
-            .expect(concat!("Expected a Decimal128ArrayType"));
+            .expect("Expected a Decimal128ArrayType");
 
         let output_array = match $eval_mode {
             EvalMode::Ansi => cast_array


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Rust 1.89 went to stable overnight and we have some new warnings and clippy failures.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Just warning and clippy cleanups.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests.
