### PR TITLE
chore: Split expression serde hash map into separate categories

### DIFF
--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -21,45 +21,37 @@
 
 The following Spark expressions are currently available. Any known compatibility issues are noted in the following tables.
 
-## Math Expressions
+## Literal Values
 
-| Expression     | SQL       | Notes                                                                                                                                                                                                                                              |
-| -------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Acos           | `acos`    |                                                                                                                                                                                                                                                    |
-| Add            | `+`       |
-| Asin           | `asin`    |                                                                                                                                                                                                                                                    |
-| Atan           | `atan`    |                                                                                                                                                                                                                                                    |
-| Atan2          | `atan2`   |                                                                                                                                                                                                                                                    |
-| BRound         | `bround`  |                                                                                                                                                                                                                                                    |
-| Ceil           | `ceil`    |                                                                                                                                                                                                                                                    |
-| Cos            | `cos`     |                                                                                                                                                                                                                                                    |
-| Divide         | `/`       |                                                                                                                                                                                                                                                    |
-| Exp            | `exp`     |                                                                                                                                                                                                                                                    |
-| Expm1          | `expm1`   |                                                                                                                                                                                                                                                    |
-| Floor          | `floor`   |                                                                                                                                                                                                                                                    |
-| Hex            | `hex`     |                                                                                                                                                                                                                                                    |
-| IntegralDivide | `div`     | All operands are cast to DecimalType (in case the input type is not already decima type) with precision 19 and scale 0. Please set `spark.comet.expression.allowIncompatible` to `true` to enable DataFusion’s cast operation for LongType inputs. |
-| IsNaN          | `isnan`   |                                                                                                                                                                                                                                                    |
-| Log            | `log`     |                                                                                                                                                                                                                                                    |
-| Log2           | `log2`    |                                                                                                                                                                                                                                                    |
-| Log10          | `log10`   |                                                                                                                                                                                                                                                    |
-| Multiply       | `*`       |                                                                                                                                                                                                                                                    |
-| Pow            | `power`   |                                                                                                                                                                                                                                                    |
-| Rand           | `rand`    |                                                                                                                                                                                                                                                    |
-| Randn          | `randn`   |                                                                                                                                                                                                                                                    |
-| Remainder      | `%`       |                                                                                                                                                                                                                                                    |
-| Round          | `round`   |                                                                                                                                                                                                                                                    |
-| Signum         | `signum`  |                                                                                                                                                                                                                                                    |
-| Sin            | `sin`     |                                                                                                                                                                                                                                                    |
-| Sqrt           | `sqrt`    |                                                                                                                                                                                                                                                    |
-| Subtract       | `-`       |                                                                                                                                                                                                                                                    |
-| Tan            | `tan`     |                                                                                                                                                                                                                                                    |
-| TryAdd         | `try_add` | Adds operands (IntegerTypes only) or returns NULL in case of overflow                                                                                                                                                                              |
-| TryDivide      | `try_div` | Subtracts operands (IntegerTypes only) or returns NULL in case of overflow                                                                                                                                                                         |
-| TryMultiply    | `try_mul` | Multiplies operands (IntegerTypes only) or returns NULL in case of overflow                                                                                                                                                                        |
-| TrySubtract    | `try_sub` | Subtracts operands (IntegerTypes only) or returns NULL in case of overflow                                                                                                                                                                         |
-| UnaryMinus     | `-`       |                                                                                                                                                                                                                                                    |
-| Unhex          | `unhex`   |                                                                                                                                                                                                                                                    |
+| Expression                             | Notes |
+| -------------------------------------- | ----- |
+| Literal values of supported data types |       |
+
+## Unary Arithmetic
+
+| Expression       | Notes |
+| ---------------- | ----- |
+| UnaryMinus (`-`) |       |
+
+## Binary Arithmetic
+
+| Expression             | Notes                                                                                                                                                                                                                                              |
+|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Add (`+`)              |                                                                                                                                                                                                                                                    |
+| Subtract (`-`)         |                                                                                                                                                                                                                                                    |
+| Multiply (`*`)         |                                                                                                                                                                                                                                                    |
+| Divide (`/`)           |                                                                                                                                                                                                                                                    |
+| IntegralDivide (`div`) | All operands are cast to DecimalType (in case the input type is not already decima type) with precision 19 and scale 0. Please set `spark.comet.expression.allowIncompatible` to `true` to enable DataFusion’s cast operation for LongType inputs. |
+| Remainder (`%`)        |                                                                                                                                                                                                                                                    |
+
+## Binary Try Arithmetic
+
+| Expression | Notes                                                                      |
+|------------|----------------------------------------------------------------------------|
+| `try_add`  | Adds operands (IntegerTypes only) or results NULL incase of overflow       |
+| `try_sub`  | Subtracts operands (IntegerTypes only) or results NULL incase of overflow  |
+| `try_mul`  | Multiplies operands (IntegerTypes only) or results NULL incase of overflow |
+| `try_div`  | Subtracts operands (IntegerTypes only) or results NULL incase of overflow  |
 
 ## Conditional Expressions
 
@@ -68,127 +60,143 @@ The following Spark expressions are currently available. Any known compatibility
 | CaseWhen   |       |
 | If         |       |
 
-## Predicate Expressions
+## Comparison
 
 | Expression                | Notes |
 | ------------------------- | ----- |
-| And                       |       |
 | EqualTo (`=`)             |       |
 | EqualNullSafe (`<=>`)     |       |
 | GreaterThan (`>`)         |       |
 | GreaterThanOrEqual (`>=`) |       |
 | LessThan (`<`)            |       |
 | LessThanOrEqual (`<=`)    |       |
-| In (`IN`)                 |       |
-| IsNotNull (`IS NOT NULL`) |       |
 | IsNull (`IS NULL`)        |       |
-| InSet                     |       |
-| Not                       |       |
-| Or                        |       |
-
-## Conversion Expressions
-
-| Expression | Notes                                                                           |
-| ---------- | ------------------------------------------------------------------------------- |
-| Cast       | See compatibility guide for list of supported cast expressions and known issues |
+| IsNotNull (`IS NOT NULL`) |       |
+| In (`IN`)                 |       |
 
 ## String Functions
 
-| Expression      | Notes                                                            |
-| --------------- | ---------------------------------------------------------------- |
-| Ascii           |                                                                  |
-| BitLength       |                                                                  |
-| Chr             |                                                                  |
-| ConcatWs        |                                                                  |
-| Contains        |                                                                  |
-| EndsWith        |                                                                  |
-| InitCap         |                                                                  |
-| Length          |                                                                  |
-| Like            |                                                                  |
-| Lower           |                                                                  |
-| OctetLength     |                                                                  |
-| Reverse         |                                                                  |
-| RLike           |                                                                  |
-| StartsWith      |                                                                  |
-| StringInstr     |                                                                  |
-| StringRepeat    | Negative argument for number of times to repeat causes exception |
-| StringReplace   |                                                                  |
-| StringRPad      |                                                                  |
-| StringSpace     |                                                                  |
-| StringTranslate |                                                                  |
-| StringTrim      |                                                                  |
-| StringTrimBoth  |                                                                  |
-| StringTrimLeft  |                                                                  |
-| StringTrimRight |                                                                  |
-| Substring       |                                                                  |
-| Upper           |                                                                  |
+| Expression      | Notes                                                                                                       |
+|-----------------| ----------------------------------------------------------------------------------------------------------- |
+| Ascii           |                                                                                                             |
+| BitLength       |                                                                                                             |
+| Chr             |                                                                                                             |
+| ConcatWs        |                                                                                                             |
+| Contains        |                                                                                                             |
+| EndsWith        |                                                                                                             |
+| InitCap         |                                                                                                             |
+| Instr           |                                                                                                             |
+| Length          |                                                                                                             |
+| Like            |                                                                                                             |
+| Lower           |                                                                                                             |
+| OctetLength     |                                                                                                             |
+| Repeat          | Negative argument for number of times to repeat causes exception                                            |
+| Replace         |                                                                                                             |
+| Reverse         |                                                                                                             |
+| StartsWith      |                                                                                                             |
+| StringRPad      |                                                                                                             |
+| StringSpace     |                                                                                                             |
+| StringTrim      |                                                                                                             |
+| StringTrimBoth  |                                                                                                             |
+| StringTrimLeft  |                                                                                                             |
+| StringTrimRight |                                                                                                             |
+| Substring       |                                                                                                             |
+| Translate       |                                                                                                             |
+| Upper           |                                                                                                             |
 
 ## Date/Time Functions
 
-| Expression     | Notes                                                                         |
-| -------------- | ----------------------------------------------------------------------------- |
-| DateAdd        |                                                                               |
-| DateSub        |                                                                               |
-| DatePart       | Only `year` is supported                                                      |
-| Extract        | Only `year` is supported                                                      |
-| FromUnixTime   | Does not support format, supports only -8334601211038 <= sec <= 8210266876799 |
-| Hour           |                                                                               |
-| Minute         |                                                                               |
-| Second         |                                                                               |
-| TruncDate      |                                                                               |
-| TruncTimestamp |                                                                               |
-| Year           |                                                                               |
+| Expression     | Notes                    |
+| -------------- | ------------------------ |
+| DatePart       | Only `year` is supported |
+| Extract        | Only `year` is supported |
+| Hour           |                          |
+| Minute         |                          |
+| Second         |                          |
+| TruncDate      |                          |
+| TruncTimestamp |                          |
+| Year           |                          |
+
+## Math Expressions
+
+| Expression | Notes                                                               |
+| ---------- | ------------------------------------------------------------------- |
+| Abs        |                                                                     |
+| Acos       |                                                                     |
+| Asin       |                                                                     |
+| Atan       |                                                                     |
+| Atan2      |                                                                     |
+| Ceil       |                                                                     |
+| Cos        |                                                                     |
+| Exp        |                                                                     |
+| Floor      |                                                                     |
+| IsNaN      |                                                                     |
+| Log        |                                                                     |
+| Log2       |                                                                     |
+| Log10      |                                                                     |
+| Pow        |                                                                     |
+| Round      |                                                                     |
+| Signum     |               |
+| Sin        |                                                                     |
+| Sqrt       |                                                                     |
+| Tan        |                                                                     |
 
 ## Hashing Functions
 
-| Expression  | Notes |
-| ----------- | ----- |
-| Md5         |       |
-| Murmur3Hash |       |
-| Sha2        |       |
-| XxHash64    |       |
+| Expression | Notes |
+| ---------- | ----- |
+| Md5        |       |
+| Hash       |       |
+| Sha2       |       |
+| XxHash64   |       |
+
+## Boolean Expressions
+
+| Expression | Notes |
+| ---------- | ----- |
+| And        |       |
+| Or         |       |
+| Not        |       |
 
 ## Bitwise Expressions
 
-| Expression        | Notes |
-| ----------------- | ----- |
-| BitwiseAnd (`&`)  |       |
-| BitwiseCount      |       |
-| BitwiseGet        |       |
-| BitwiseOr (`\|`)  |       |
-| BitwiseNot (`~`)  |       |
-| BitwiseXor (`^`)  |       |
-| ShiftLeft (`<<`)  |       |
-| ShiftRight (`>>`) |       |
+| Expression           | Notes |
+| -------------------- | ----- |
+| ShiftLeft (`<<`)     |       |
+| ShiftRight (`>>`)    |       |
+| BitAnd (`&`)         |       |
+| BitOr (`\|`)         |       |
+| BitXor (`^`)         |       |
+| BitwiseNot (`~`)     |       |
+| BoolAnd (`bool_and`) |       |
+| BoolOr (`bool_or`)   |       |
 
 ## Aggregate Expressions
 
-| Expression           | Notes |
-| -------------------- | ----- |
-| Average              |       |
-| BitAndAgg            |       |
-| BitOrAgg             |       |
-| BitXorAgg            |       |
-| BoolAnd (`bool_and`) |       |
-| BoolOr (`bool_or`)   |       |
-| Corr                 |       |
-| Count                |       |
-| CovPopulation        |       |
-| CovSample            |       |
-| First                |       |
-| Last                 |       |
-| Max                  |       |
-| Min                  |       |
-| StddevPop            |       |
-| StddevSamp           |       |
-| Sum                  |       |
-| VariancePop          |       |
-| VarianceSamp         |       |
+| Expression    | Notes |
+| ------------- | ----- |
+| Avg           |       |
+| BitAndAgg     |       |
+| BitOrAgg      |       |
+| BitXorAgg     |       |
+| Corr          |       |
+| Count         |       |
+| CovPopulation |       |
+| CovSample     |       |
+| First         |       |
+| Last          |       |
+| Max           |       |
+| Min           |       |
+| StddevPop     |       |
+| StddevSamp    |       |
+| Sum           |       |
+| VariancePop   |       |
+| VarianceSamp  |       |
 
-## Array Expressions
+## Arrays
 
 | Expression     | Notes                                                                                                                                                                                                        |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | ArrayAppend    | Experimental                                                                                                                                                                                                 |
 | ArrayCompact   | Experimental                                                                                                                                                                                                 |
 | ArrayContains  | Experimental                                                                                                                                                                                                 |
@@ -203,47 +211,35 @@ The following Spark expressions are currently available. Any known compatibility
 | ArrayRepeat    | Experimental                                                                                                                                                                                                 |
 | ArraysOverlap  | Experimental                                                                                                                                                                                                 |
 | ArrayUnion     | Experimental: behaves differently than spark. Datafusion sorts the input arrays before performing the union, while spark preserves the order of the first array and appends unique elements from the second. |
-| CreateArray    |                                                                                                                                                                                                              |
 | ElementAt      | Arrays only                                                                                                                                                                                                  |
-| Flatten        |                                                                                                                                                                                                              |
-| GetArrayItem   |                                                                                                                                                                                                              |
+| GetArrayItem   |
 
-## Map Expressions
+## Maps
 
-| Expression    | Notes |
-| ------------- | ----- |
-| GetMapValue   |       |
-| MapKeys       |       |
-| MapEntries    |       |
-| MapValues     |       |
-| MapFromArrays |       |
+| Expression          | Notes        |
+|---------------------|--------------|
+| MapLookupByKey ([]) |              |
+| MapKeys             |              |
+| MapValues           |              |     
+| MapEntries          |              |   
+| MapFromArrays       |              |
 
-## Struct Expressions
+## Structs
 
-| Expression           | Notes |
-| -------------------- | ----- |
-| CreateNamedStruct    |       |
-| GetArrayStructFields |       |
-| GetStructField       |       |
-| StructsToJson        |       |
+| Expression        | Notes        |
+|-------------------|--------------|
+| CreateNamedStruct |              |
+| GetStructField    |              |
+| StructsToJson     |              |
 
 ## Other
 
-| Expression                   | Notes                                  |
-| ---------------------------- | -------------------------------------- |
-| Alias                        |                                        |
-| AttributeRefernce            |                                        |
-| BloomFilterMightContain      |                                        |
-| Coalesce                     |                                        |
-| CheckOverflow                |                                        |
-| KnownFloatingPointNormalized |                                        |
-| Literal                      | Literal values of supported data types |
-| MakeDecimal                  |                                        |
-| MonotonicallyIncreasingID    |                                        |
-| NormalizeNaNAndZero          |                                        |
-| PromotePrecision             |                                        |
-| RegExpReplace                |                                        |
-| ScalarSubquery               |                                        |
-| SparkPartitionID             |                                        |
-| ToPrettyString               |                                        |
-| UnscaledValue                |                                        |
+| Expression              | Notes                                                                           |
+|-------------------------| ------------------------------------------------------------------------------- |
+| Cast                    | See compatibility guide for list of supported cast expressions and known issues |
+| BloomFilterMightContain |                                                                                 |
+| ScalarSubquery          |                                                                                 |
+| Coalesce                |                                                                                 |
+| NormalizeNaNAndZero     |                                                                                 |
+| ToPrettyString          |                                                                                 |
+| FromUnixTime            | Does not support format, supports only -8334601211038 <= sec <= 8210266876799   |


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Rather than have one large list of expressions in the code, this PR splits it up into multiple maps.

```scala
 private val exprSerdeMap: Map[Class[_ <: Expression], CometExpressionSerde[_]] =
    mathExpressions ++ hashExpressions ++ stringExpressions ++
      conditionalExpressions ++ mapExpressions ++ predicateExpressions ++
      structExpressions ++ bitwiseExpressions ++ miscExpressions ++ arrayExpressions ++
      temporalExpressions ++ conversionExpressions
```

This makes it much easier to compare code and documentation for each section:

<img width="1531" height="946" alt="math2" src="https://github.com/user-attachments/assets/7ebda6f9-ac63-4c4b-adeb-0ef916851a24" />


## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Split expression serde map into one map per category

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
