### PR TITLE
fix: Throws an exception when struct type has duplicate keys

### DIFF
--- a/common/src/main/scala/org/apache/spark/sql/comet/util/Utils.scala
+++ b/common/src/main/scala/org/apache/spark/sql/comet/util/Utils.scala
@@ -154,7 +154,13 @@ object Utils extends CometTypeShim {
           name,
           fieldType,
           Seq(toArrowField("element", elementType, containsNull, timeZoneId)).asJava)
-      case StructType(fields) =>
+      case st @ StructType(fields) =>
+        if (st.names.toSet.size != fields.length) {
+          throw new SparkException(
+            "Duplicated field names in Arrow Struct are not allowed," +
+              s" got ${st.names.mkString("[", ", ", "]")}.")
+        }
+
         val fieldType = new FieldType(nullable, ArrowType.Struct.INSTANCE, null)
         new Field(
           name,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2457.

## Rationale for this change

In the failed test case of https://github.com/apache/datafusion-comet/pull/2444, I found that the struct type with duplicate keys will be deduplicated when converted to arrowType, which causes RowToColumanr to lose some columns.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

This PR does not avoid the issue, but makes the error message more obvious. It was difficult to create a proper test case for this change until #2444 was merged.

Before this, the failing test case error in #2444 looked like:

```
[info] - Struct Star Expansion *** FAILED *** (2 seconds, 840 milliseconds)
[info]   org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 1230.0 failed 1 times, most recent failure: Lost task 0.0 in stage 1230.0 (TID 1549) (96a252fb2e73 executor driver): java.lang.IndexOutOfBoundsException: Index 2 out of bounds for length 2
[info] 	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
[info] 	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
[info] 	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:248)
[info] 	at java.base/java.util.Objects.checkIndex(Objects.java:374)
[info] 	at java.base/java.util.ArrayList.get(ArrayList.java:459)
[info] 	at org.apache.comet.vector.CometStructVector.getChild(CometStructVector.java:55)
[info] 	at org.apache.spark.sql.vectorized.ColumnarRow.getInt(ColumnarRow.java:113)
[info] 	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.apply(Unknown Source)
[info] 	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.apply(Unknown Source)
[info] 	at scala.collection.Iterator$$anon$10.next(Iterator.scala:461)
[info] 	at scala.collection.Iterator$$anon$11.next(Iterator.scala:496)
```

after this:

```
[info] - Struct Star Expansion *** FAILED *** (2 seconds, 882 milliseconds)
[info]   org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 1325.0 failed 1 times, most recent failure: Lost task 0.0 in stage 1325.0 (TID 1477) (6a0022271dbb executor driver): org.apache.spark.SparkException: Duplicated field names in Arrow Struct are not allowed, got [a, a, b, b].
[info] 	at org.apache.spark.sql.comet.util.Utils$.toArrowField(Utils.scala:161)
[info] 	at org.apache.spark.sql.comet.util.Utils$.$anonfun$toArrowSchema$1(Utils.scala:199)
[info] 	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:286)
[info] 	at scala.collection.Iterator.foreach(Iterator.scala:943)
[info] 	at scala.collection.Iterator.foreach$(Iterator.scala:943)
[info] 	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
[info] 	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
[info] 	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
```