### PR TITLE
chore: Make CometColumnarToRowExec extends CometPlan

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometColumnarToRowExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometColumnarToRowExec.scala
@@ -53,6 +53,7 @@ import org.apache.comet.vector.CometPlainVector
  */
 case class CometColumnarToRowExec(child: SparkPlan)
     extends ColumnarToRowTransition
+    with CometPlan
     with CodegenSupport {
   // supportsColumnar requires to be only called on driver side, see also SPARK-37779.
   assert(Utils.isInRunningSparkTask || child.supportsColumnar)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

I still see the `CometColumnarToRow is not supported` fallback reason after #2450, which is not what I expected.

```
- DPP fallback *** FAILED *** (1 second, 561 milliseconds)
  "CometColumnarToRow is not supported" did not contain "Dynamic Partition Pruning is not supported" (CometExecSuite.scala:120)
```

## What changes are included in this PR?

Make CometColumnarToRowExec extends CometPlan

## How are these changes tested?

Test the abnormal case locally, before this:

```
"CometColumnarToRow is not supported" did not contain "Dynamic Partition Pruning is not supported"
ScalaTestFailureLocation: org.apache.comet.exec.CometExecSuite at (CometExecSuite.scala:120)
org.scalatest.exceptions.TestFailedException: "CometColumnarToRow is not supported" did not contain "Dynamic Partition Pruning is not supported"
	at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
```

after this:

```
"" did not contain "Dynamic Partition Pruning is not supported"
ScalaTestFailureLocation: org.apache.comet.exec.CometExecSuite at (CometExecSuite.scala:120)
org.scalatest.exceptions.TestFailedException: "" did not contain "Dynamic Partition Pruning is not supported"
	at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
```