### PR TITLE
fix: [iceberg] Close reader instance in ReadConf

### DIFF
--- a/dev/diffs/iceberg/1.8.1.diff
+++ b/dev/diffs/iceberg/1.8.1.diff
@@ -17,7 +17,7 @@ index 7327b38905d..7967109f039 100644
        exclude group: 'org.apache.avro', module: 'avro'
        // already shaded by Parquet
 diff --git a/gradle/libs.versions.toml b/gradle/libs.versions.toml
-index 04ffa8f4edc..cc0099ccc93 100644
+index 04ffa8f4edc..a909cd552c1 100644
 --- a/gradle/libs.versions.toml
 +++ b/gradle/libs.versions.toml
 @@ -34,6 +34,7 @@ azuresdk-bom = "1.2.31"
@@ -300,10 +300,10 @@ index 00000000000..ddf6c7de5ae
 +}
 diff --git a/parquet/src/main/java/org/apache/iceberg/parquet/CometVectorizedParquetReader.java b/parquet/src/main/java/org/apache/iceberg/parquet/CometVectorizedParquetReader.java
 new file mode 100644
-index 00000000000..88b195b76a2
+index 00000000000..a3cba401827
 --- /dev/null
 +++ b/parquet/src/main/java/org/apache/iceberg/parquet/CometVectorizedParquetReader.java
-@@ -0,0 +1,255 @@
+@@ -0,0 +1,260 @@
 +/*
 + * Licensed to the Apache Software Foundation (ASF) under one
 + * or more contributor license agreements.  See the NOTICE file
@@ -446,6 +446,7 @@ index 00000000000..88b195b76a2
 +    private long valuesRead = 0;
 +    private T last = null;
 +    private final FileReader cometReader;
++    private ReadConf conf;
 +
 +    FileIterator(
 +        ReadConf conf,
@@ -470,6 +471,7 @@ index 00000000000..88b195b76a2
 +              length,
 +              fileEncryptionKey,
 +              fileAADPrefix);
++      this.conf = conf;
 +    }
 +
 +    private FileReader newCometReader(
@@ -556,6 +558,9 @@ index 00000000000..88b195b76a2
 +    public void close() throws IOException {
 +      model.close();
 +      cometReader.close();
++      if (conf != null && conf.reader() != null) {
++        conf.reader().close();
++      }
 +    }
 +  }
 +}

--- a/dev/diffs/iceberg/1.9.1.diff
+++ b/dev/diffs/iceberg/1.9.1.diff
@@ -291,10 +291,10 @@ index 00000000000..ddf6c7de5ae
 +}
 diff --git a/parquet/src/main/java/org/apache/iceberg/parquet/CometVectorizedParquetReader.java b/parquet/src/main/java/org/apache/iceberg/parquet/CometVectorizedParquetReader.java
 new file mode 100644
-index 00000000000..88b195b76a2
+index 00000000000..a3cba401827
 --- /dev/null
 +++ b/parquet/src/main/java/org/apache/iceberg/parquet/CometVectorizedParquetReader.java
-@@ -0,0 +1,255 @@
+@@ -0,0 +1,260 @@
 +/*
 + * Licensed to the Apache Software Foundation (ASF) under one
 + * or more contributor license agreements.  See the NOTICE file
@@ -437,6 +437,7 @@ index 00000000000..88b195b76a2
 +    private long valuesRead = 0;
 +    private T last = null;
 +    private final FileReader cometReader;
++    private ReadConf conf;
 +
 +    FileIterator(
 +        ReadConf conf,
@@ -461,6 +462,7 @@ index 00000000000..88b195b76a2
 +              length,
 +              fileEncryptionKey,
 +              fileAADPrefix);
++      this.conf = conf;
 +    }
 +
 +    private FileReader newCometReader(
@@ -547,6 +549,9 @@ index 00000000000..88b195b76a2
 +    public void close() throws IOException {
 +      model.close();
 +      cometReader.close();
++      if (conf != null && conf.reader() != null) {
++        conf.reader().close();
++      }
 +    }
 +  }
 +}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #. N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

 - When we tested Comet `0.10.0` on production Iceberg workload, we found that there are connection leaks and led to job failures.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

 - Close the `ParquetFileReader` instance in the `ReadConf` used by `CometVectorizedParquetReader` in Iceberg 1.8.1 and 1.9.1 diffs.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

 - After the fix, our Spark jobs completed w/o issues.