### PR TITLE
chore: Improve plan comet transformation log

### DIFF
--- a/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.{Final, Partial}
 import org.apache.spark.sql.catalyst.optimizer.NormalizeNaNAndZero
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, RangePartitioning, RoundRobinPartitioning, SinglePartition}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.util.SparkStringUtils
+import org.apache.spark.sql.catalyst.util.sideBySide
 import org.apache.spark.sql.comet._
 import org.apache.spark.sql.comet.execution.shuffle.{CometColumnarShuffle, CometNativeShuffle, CometShuffleExchangeExec, CometShuffleManager}
 import org.apache.spark.sql.execution._
@@ -617,7 +617,7 @@ case class CometExecRule(session: SparkSession) extends Rule[SparkPlan] {
     if (showTransformations && !newPlan.fastEquals(plan)) {
       logInfo(s"""
            |=== Applying Rule $ruleName ===
-           |${SparkStringUtils.sideBySide(plan.treeString, newPlan.treeString).mkString("\n")}
+           |${sideBySide(plan.treeString, newPlan.treeString).mkString("\n")}
            |""".stripMargin)
     }
     newPlan

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -30,7 +30,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, GenericInternalRow, PlanExpression}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, GenericArrayData, MetadataColumnHelper, SparkStringUtils}
+import org.apache.spark.sql.catalyst.util.{sideBySide, ArrayBasedMapData, GenericArrayData, MetadataColumnHelper}
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns.getExistenceDefaultValues
 import org.apache.spark.sql.comet.{CometBatchScanExec, CometScanExec}
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
@@ -63,7 +63,7 @@ case class CometScanRule(session: SparkSession) extends Rule[SparkPlan] with Com
     if (showTransformations && !newPlan.fastEquals(plan)) {
       logInfo(s"""
            |=== Applying Rule $ruleName ===
-           |${SparkStringUtils.sideBySide(plan.treeString, newPlan.treeString).mkString("\n")}
+           |${sideBySide(plan.treeString, newPlan.treeString).mkString("\n")}
            |""".stripMargin)
     }
     newPlan

--- a/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
@@ -21,7 +21,7 @@ package org.apache.comet.rules
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.util.SparkStringUtils
+import org.apache.spark.sql.catalyst.util.sideBySide
 import org.apache.spark.sql.comet.{CometCollectLimitExec, CometColumnarToRowExec, CometPlan, CometSparkToColumnarExec}
 import org.apache.spark.sql.comet.execution.shuffle.{CometColumnarShuffle, CometShuffleExchangeExec}
 import org.apache.spark.sql.execution.{ColumnarToRowExec, RowToColumnarExec, SparkPlan}
@@ -60,7 +60,7 @@ case class EliminateRedundantTransitions(session: SparkSession) extends Rule[Spa
     if (showTransformations && !newPlan.fastEquals(plan)) {
       logInfo(s"""
            |=== Applying Rule $ruleName ===
-           |${SparkStringUtils.sideBySide(plan.treeString, newPlan.treeString).mkString("\n")}
+           |${sideBySide(plan.treeString, newPlan.treeString).mkString("\n")}
            |""".stripMargin)
     }
     newPlan


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Log plan transformations like in spark, refer to https://github.com/apache/spark/blob/3ac4a48fb8c5e0bdd9e7f0a4b98094531a7807f6/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala#L65-L72

## How are these changes tested?

Run `CometExpressionSuite.test length function` test locally.

after this:

```
25/10/13 20:18:18.923 ScalaTest-run-running-CometExpressionSuite INFO CometScanRule: 
=== Applying Rule org.apache.comet.rules.CometScanRule ===
 DeserializeToObject createexternalrow(staticinvoke(class java.lang.Integer, ObjectType(class java.lang.Integer), valueOf, length(c1)#16, true, false, true), staticinvoke(class java.lang.Integer, ObjectType(class java.lang.Integer), valueOf, x#15, true, false, true), StructField(length(c1),IntegerType,true), StructField(x,IntegerType,true)), obj#21: org.apache.spark.sql.Row   DeserializeToObject createexternalrow(staticinvoke(class java.lang.Integer, ObjectType(class java.lang.Integer), valueOf, length(c1)#16, true, false, true), staticinvoke(class java.lang.Integer, ObjectType(class java.lang.Integer), valueOf, x#15, true, false, true), StructField(length(c1),IntegerType,true), StructField(x,IntegerType,true)), obj#21: org.apache.spark.sql.Row
 +- Project [length(c1)#16, x#15]                                                                                                                                                                                                                                                                                                                                                          +- Project [length(c1)#16, x#15]
    +- Sort [c1#4 ASC NULLS FIRST], true, 0                                                                                                                                                                                                                                                                                                                                                   +- Sort [c1#4 ASC NULLS FIRST], true, 0
!      +- Exchange rangepartitioning(c1#4 ASC NULLS FIRST, 10), ENSURE_REQUIREMENTS, [plan_id=149]                                                                                                                                                                                                                                                                                               +- Exchange rangepartitioning(c1#4 ASC NULLS FIRST, 10), ENSURE_REQUIREMENTS, [plan_id=156]
          +- Project [length(c1#4) AS length(c1)#16, length(c2#5) AS x#15, c1#4]                                                                                                                                                                                                                                                                                                                    +- Project [length(c1#4) AS length(c1)#16, length(c2#5) AS x#15, c1#4]
!            +- FileScan parquet spark_catalog.default.t1[c1#4,c2#5] Batched: true, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex(1 paths)[file:/Users/wforget/work/git/datafusion-comet/spark-warehouse/t1], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<c1:string,c2:binary>                                                                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.t1[c1#4,c2#5] Batched: true, DataFilters: [], Format: CometParquet, Location: InMemoryFileIndex(1 paths)[file:/Users/wforget/work/git/datafusion-comet/spark-warehouse/t1], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<c1:string,c2:binary>

25/10/13 20:18:18.925 ScalaTest-run-running-CometExpressionSuite INFO CometExecRule: 
=== Applying Rule org.apache.comet.rules.CometExecRule ===
 DeserializeToObject createexternalrow(staticinvoke(class java.lang.Integer, ObjectType(class java.lang.Integer), valueOf, length(c1)#16, true, false, true), staticinvoke(class java.lang.Integer, ObjectType(class java.lang.Integer), valueOf, x#15, true, false, true), StructField(length(c1),IntegerType,true), StructField(x,IntegerType,true)), obj#21: org.apache.spark.sql.Row   DeserializeToObject createexternalrow(staticinvoke(class java.lang.Integer, ObjectType(class java.lang.Integer), valueOf, length(c1)#16, true, false, true), staticinvoke(class java.lang.Integer, ObjectType(class java.lang.Integer), valueOf, x#15, true, false, true), StructField(length(c1),IntegerType,true), StructField(x,IntegerType,true)), obj#21: org.apache.spark.sql.Row
!+- Project [length(c1)#16, x#15]                                                                                                                                                                                                                                                                                                                                                          +- CometProject [length(c1)#16, x#15], [length(c1)#16, x#15]
!   +- Sort [c1#4 ASC NULLS FIRST], true, 0                                                                                                                                                                                                                                                                                                                                                   +- CometSort [length(c1)#16, x#15, c1#4], [c1#4 ASC NULLS FIRST]
!      +- Exchange rangepartitioning(c1#4 ASC NULLS FIRST, 10), ENSURE_REQUIREMENTS, [plan_id=156]                                                                                                                                                                                                                                                                                               +- CometColumnarExchange rangepartitioning(c1#4 ASC NULLS FIRST, 10), ENSURE_REQUIREMENTS, CometColumnarShuffle, [plan_id=173]
          +- Project [length(c1#4) AS length(c1)#16, length(c2#5) AS x#15, c1#4]                                                                                                                                                                                                                                                                                                                    +- Project [length(c1#4) AS length(c1)#16, length(c2#5) AS x#15, c1#4]
             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.t1[c1#4,c2#5] Batched: true, DataFilters: [], Format: CometParquet, Location: InMemoryFileIndex(1 paths)[file:/Users/wforget/work/git/datafusion-comet/spark-warehouse/t1], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<c1:string,c2:binary>                                                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.t1[c1#4,c2#5] Batched: true, DataFilters: [], Format: CometParquet, Location: InMemoryFileIndex(1 paths)[file:/Users/wforget/work/git/datafusion-comet/spark-warehouse/t1], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<c1:string,c2:binary>

25/10/13 20:18:18.928 ScalaTest-run-running-CometExpressionSuite INFO EliminateRedundantTransitions: 
=== Applying Rule org.apache.comet.rules.EliminateRedundantTransitions ===
!CometColumnarExchange rangepartitioning(c1#4 ASC NULLS FIRST, 10), ENSURE_REQUIREMENTS, CometColumnarShuffle, [plan_id=193]                                                                                                                                                                                                                CometColumnarExchange rangepartitioning(c1#4 ASC NULLS FIRST, 10), ENSURE_REQUIREMENTS, CometColumnarShuffle, [plan_id=198]
!+- RowToColumnar                                                                                                                                                                                                                                                                                                                           +- Project [length(c1#4) AS length(c1)#16, length(c2#5) AS x#15, c1#4]
!   +- Project [length(c1#4) AS length(c1)#16, length(c2#5) AS x#15, c1#4]                                                                                                                                                                                                                                                                     +- CometColumnarToRow
!      +- ColumnarToRow                                                                                                                                                                                                                                                                                                                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.t1[c1#4,c2#5] Batched: true, DataFilters: [], Format: CometParquet, Location: InMemoryFileIndex(1 paths)[file:/Users/wforget/work/git/datafusion-comet/spark-warehouse/t1], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<c1:string,c2:binary>
!         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.t1[c1#4,c2#5] Batched: true, DataFilters: [], Format: CometParquet, Location: InMemoryFileIndex(1 paths)[file:/Users/wforget/work/git/datafusion-comet/spark-warehouse/t1], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<c1:string,c2:binary>   

```