### PR TITLE
fix: Capture unexpected output when retrieving JVM 17 args in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 .PHONY: all core jvm test clean release-linux release bench
 
 define spark_jvm_17_extra_args
-$(shell ./mvnw help:evaluate -Dexpression=extraJavaTestArgs | grep -v '\[')
+$(shell ./mvnw help:evaluate -q -DforceStdout -Dexpression=extraJavaTestArgs)
 endef
 
 # Build optional Comet native features (like hdfs e.g)


### PR DESCRIPTION
# Which issue does this PR close?
No open issue.

# Rationale for this change
When running ./mvnw for the first time, executing make benchmark-xxxx may fail because the Java 17 arguments include unwanted “Downloading” messages. This change ensures the arguments are retrieved correctly.

# What changes are included in this PR?
Use ./mvnw parameters to fetch the Java 17 arguments cleanly.

# How are these changes tested?
Manual testing.