### PR TITLE
fix: Fix `None.get` in `stringDecode` when `bin` child cannot be converted

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/strings.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/strings.scala
@@ -256,12 +256,13 @@ trait CommonStringExprs {
         // decode(col, 'utf-8') can be treated as a cast with "try" eval mode that puts nulls
         // for invalid strings.
         // Left child is the binary expression.
-        CometCast.castToProto(
-          expr,
-          None,
-          DataTypes.StringType,
-          exprToProtoInternal(bin, inputs, binding).get,
-          CometEvalMode.TRY)
+        val binExpr = exprToProtoInternal(bin, inputs, binding)
+        if (binExpr.isDefined) {
+          CometCast.castToProto(expr, None, DataTypes.StringType, binExpr.get, CometEvalMode.TRY)
+        } else {
+          withInfo(expr, bin)
+          None
+        }
       case _ =>
         withInfo(expr, "Comet only supports decoding with 'utf-8'.")
         None


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR fixes a potential `None.get` runtime crash in the `stringDecode` method by safely handling cases where the `bin` child expression is a Comet unsupported expression.

Steps to reproduce the bug
```scala
    sql("set spark.sql.optimizer.excludedRules=org.apache.spark.sql.catalyst.optimizer.ConstantFolding")
    sql("set spark.comet.explainFallback.enabled=true")
    sql("select decode(encode('abc', 'utf-8'), 'utf-8')").show
```

Error log before this PR

```
None.get
java.util.NoSuchElementException: None.get
	at scala.None$.get(Option.scala:529)
	at scala.None$.get(Option.scala:527)
	at org.apache.comet.serde.CommonStringExprs.stringDecode(strings.scala:263)
	at org.apache.comet.serde.CommonStringExprs.stringDecode$(strings.scala:247)
	at org.apache.comet.serde.QueryPlanSerde$.stringDecode(QueryPlanSerde.scala:63)
	at org.apache.comet.shims.CometExprShim.versionSpecificExprToProtoInternal(CometExprShim.scala:47)
	at org.apache.comet.shims.CometExprShim.versionSpecificExprToProtoInternal$(CometExprShim.scala:40)
	at org.apache.comet.serde.QueryPlanSerde$.versionSpecificExprToProtoInternal(QueryPlanSerde.scala:63)
	at org.apache.comet.serde.QueryPlanSerde$.exprToProtoInternal(QueryPlanSerde.scala:698)
	at org.apache.comet.shims.CometExprShim.versionSpecificExprToProtoInternal(CometExprShim.scala:63)
	at org.apache.comet.shims.CometExprShim.versionSpecificExprToProtoInternal$(CometExprShim.scala:40)
	at org.apache.comet.serde.QueryPlanSerde$.versionSpecificExprToProtoInternal(QueryPlanSerde.scala:63)
	at org.apache.comet.serde.QueryPlanSerde$.exprToProtoInternal(QueryPlanSerde.scala:698)
```


## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
