### PR TITLE
test: reorder fake hdfs to see what breaks

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -117,8 +117,8 @@ jobs:
               org.apache.comet.exec.DisableAQECometAsyncShuffleSuite
           - name: "parquet"
             value: |
-              org.apache.comet.parquet.ParquetReadFromFakeHadoopFsSuite
               org.apache.comet.parquet.ParquetReadV1Suite
+              org.apache.comet.parquet.ParquetReadFromFakeHadoopFsSuite
               org.apache.comet.parquet.ParquetReadV2Suite
               org.apache.spark.sql.comet.ParquetDatetimeRebaseV1Suite
               org.apache.spark.sql.comet.ParquetDatetimeRebaseV2Suite


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

looking at the fake Hadoop FileSystem it looks like it modifying global property `useDeprecatedFileStatus` in `RawLocalFileSystem` by calling `useStatIfAvailable`

Moving it to the first will make sure that other tests are not affected by it.
moving it to the end will hide problems and can easily lead to errors

## What changes are included in this PR?

Moved `org.apache.comet.parquet.ParquetReadFromFakeHadoopFsSuite` to be at the start

## How are these changes tested?

CI