### PR TITLE
chore: update actions/checkout from v4 to v6 in setup-iceberg and set…

### DIFF
--- a/.github/actions/setup-iceberg-builder/action.yaml
+++ b/.github/actions/setup-iceberg-builder/action.yaml
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps:
     - name: Clone Iceberg repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: apache/iceberg
         path: apache-iceberg

--- a/.github/actions/setup-iceberg-rust-builder/action.yaml
+++ b/.github/actions/setup-iceberg-rust-builder/action.yaml
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps:
     - name: Clone Iceberg repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: apache/iceberg
         path: apache-iceberg

--- a/.github/actions/setup-spark-builder/action.yaml
+++ b/.github/actions/setup-spark-builder/action.yaml
@@ -28,7 +28,7 @@ runs:
   using: "composite"
   steps:
     - name: Clone Spark repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: apache/spark
         path: apache-spark


### PR DESCRIPTION
…up-spark builders
There are 3 places where github actions/checkout is not updated from version 4 to version 6 

<img width="232" height="843" alt="image" src="https://github.com/user-attachments/assets/dd30948f-45b7-4caf-bd6c-4a69583cfc9b" />

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
