### PR TITLE
fix: modify CometNativeScan to generate the file partitions without instantiating RDD

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometNativeScan.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometNativeScan.scala
@@ -142,10 +142,12 @@ object CometNativeScan extends CometOperatorSerde[CometScanExec] with Logging {
         nativeScanBuilder.addAllDefaultValuesIndexes(indexes.toIterable.asJava)
       }
 
+      var firstPartition: Option[PartitionedFile] = None
       val filePartitions = scan.getFilePartitions()
-      val firstPartition = filePartitions.flatMap(p => p.files).headOption
-
       filePartitions.foreach { partition =>
+        if (firstPartition.isEmpty) {
+          firstPartition = partition.files.headOption
+        }
         partition2Proto(partition, nativeScanBuilder, scan.relation.partitionSchema)
       }
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
@@ -294,9 +294,10 @@ case class CometScanExec(
   }
 
   /**
-   * Get the file partitions for this scan without instantiating readers or RDD.
+   * Get the file partitions for this scan without instantiating readers or RDD. This is useful
+   * for native scans that only need partition metadata.
    */
-  def getFilePartitions: Seq[FilePartition] = {
+  def getFilePartitions(): Seq[FilePartition] = {
     val filePartitions = if (bucketedScan) {
       createFilePartitionsForBucketedScan(
         relation.bucketSpec.get,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Partially address #2878.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

native_datafusion calls `inputRDD` to get the file lists for each partition, but this is wasteful because it actually instantiates readers that it never uses:

https://github.com/apache/datafusion-comet/blob/7282d575a326f85a42921d012974706a9d9b7ae2/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala#L205

There's a TODO to fix this:

https://github.com/apache/datafusion-comet/blob/7282d575a326f85a42921d012974706a9d9b7ae2/spark/src/main/scala/org/apache/comet/serde/operator/CometNativeScan.scala#L146

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

CometScanExec.scala:
- Added `getFilePartitions()`
- Added `createFilePartitionsForBucketedScan()`
- Added `createFilePartitionsForNonBucketedScan()`
- Refactored `createBucketedReadRDD()` and `createReadRDD()`

CometNativeScan.scala:
- Replaced inputRDD pattern matching with `scan.getFilePartitions()`

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests.