### PR TITLE
feat: support_ansi-mode_aggregated_benchmarking

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometAggregateBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometAggregateBenchmark.scala
@@ -19,8 +19,11 @@
 
 package org.apache.spark.sql.benchmark
 
+import scala.util.Try
+
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.DecimalType
 
 import org.apache.comet.CometConf
@@ -52,7 +55,8 @@ object CometAggregateBenchmark extends CometBenchmarkBase {
     BenchAggregateFunction("MIN"),
     BenchAggregateFunction("MAX"),
     BenchAggregateFunction("COUNT"),
-    BenchAggregateFunction("COUNT", distinct = true))
+    BenchAggregateFunction("COUNT", distinct = true),
+    BenchAggregateFunction("AVG"))
 
   def aggFunctionSQL(aggregateFunction: BenchAggregateFunction, input: String): String = {
     s"${aggregateFunction.name}(${if (aggregateFunction.distinct) s"DISTINCT $input" else input})"
@@ -61,11 +65,12 @@ object CometAggregateBenchmark extends CometBenchmarkBase {
   def singleGroupAndAggregate(
       values: Int,
       groupingKeyCardinality: Int,
-      aggregateFunction: BenchAggregateFunction): Unit = {
+      aggregateFunction: BenchAggregateFunction,
+      isAnsiMode: Boolean): Unit = {
     val benchmark =
       new Benchmark(
         s"Grouped HashAgg Exec: single group key (cardinality $groupingKeyCardinality), " +
-          s"single aggregate ${aggregateFunction.toString}",
+          s"single aggregate ${aggregateFunction.toString}, ansi mode enabled : ${isAnsiMode}",
         values,
         output = output)
 
@@ -78,16 +83,23 @@ object CometAggregateBenchmark extends CometBenchmarkBase {
         val functionSQL = aggFunctionSQL(aggregateFunction, "value")
         val query = s"SELECT key, $functionSQL FROM parquetV1Table GROUP BY key"
 
-        benchmark.addCase(s"SQL Parquet - Spark (${aggregateFunction.toString})") { _ =>
-          spark.sql(query).noop()
+        benchmark.addCase(
+          s"SQL Parquet - Spark (${aggregateFunction.toString}) ansi mode enabled : ${isAnsiMode}") {
+          _ =>
+            withSQLConf(SQLConf.ANSI_ENABLED.key -> isAnsiMode.toString) {
+              Try { spark.sql(query).noop() }
+            }
         }
 
-        benchmark.addCase(s"SQL Parquet - Comet (${aggregateFunction.toString})") { _ =>
-          withSQLConf(
-            CometConf.COMET_ENABLED.key -> "true",
-            CometConf.COMET_EXEC_ENABLED.key -> "true") {
-            spark.sql(query).noop()
-          }
+        benchmark.addCase(
+          s"SQL Parquet - Comet (${aggregateFunction.toString}) ansi mode enabled : ${isAnsiMode}") {
+          _ =>
+            withSQLConf(
+              CometConf.COMET_ENABLED.key -> "true",
+              CometConf.COMET_EXEC_ENABLED.key -> "true",
+              SQLConf.ANSI_ENABLED.key -> isAnsiMode.toString) {
+              Try { spark.sql(query).noop() }
+            }
         }
 
         benchmark.run()
@@ -99,7 +111,8 @@ object CometAggregateBenchmark extends CometBenchmarkBase {
       values: Int,
       dataType: DecimalType,
       groupingKeyCardinality: Int,
-      aggregateFunction: BenchAggregateFunction): Unit = {
+      aggregateFunction: BenchAggregateFunction,
+      isAnsiMode: Boolean): Unit = {
     val benchmark =
       new Benchmark(
         s"Grouped HashAgg Exec: single group key (cardinality $groupingKeyCardinality), " +
@@ -120,16 +133,23 @@ object CometAggregateBenchmark extends CometBenchmarkBase {
         val functionSQL = aggFunctionSQL(aggregateFunction, "value")
         val query = s"SELECT key, $functionSQL FROM parquetV1Table GROUP BY key"
 
-        benchmark.addCase(s"SQL Parquet - Spark (${aggregateFunction.toString})") { _ =>
-          spark.sql(query).noop()
+        withSQLConf(SQLConf.ANSI_ENABLED.key -> isAnsiMode.toString) {
+          benchmark.addCase(
+            s"SQL Parquet - Spark (${aggregateFunction.toString}) ansi mode enabled : ${isAnsiMode}") {
+            _ =>
+              Try { spark.sql(query).noop() }
+          }
         }
 
-        benchmark.addCase(s"SQL Parquet - Comet (${aggregateFunction.toString})") { _ =>
-          withSQLConf(
-            CometConf.COMET_ENABLED.key -> "true",
-            CometConf.COMET_EXEC_ENABLED.key -> "true") {
-            spark.sql(query).noop()
-          }
+        benchmark.addCase(
+          s"SQL Parquet - Comet (${aggregateFunction.toString}) ansi mode enabled : ${isAnsiMode}") {
+          _ =>
+            withSQLConf(
+              CometConf.COMET_ENABLED.key -> "true",
+              CometConf.COMET_EXEC_ENABLED.key -> "true",
+              SQLConf.ANSI_ENABLED.key -> isAnsiMode.toString) {
+              Try { spark.sql(query).noop() }
+            }
         }
 
         benchmark.run()
@@ -140,7 +160,8 @@ object CometAggregateBenchmark extends CometBenchmarkBase {
   def multiGroupKeys(
       values: Int,
       groupingKeyCard: Int,
-      aggregateFunction: BenchAggregateFunction): Unit = {
+      aggregateFunction: BenchAggregateFunction,
+      isAnsiMode: Boolean): Unit = {
     val benchmark =
       new Benchmark(
         s"Grouped HashAgg Exec: multiple group keys (cardinality $groupingKeyCard), " +
@@ -160,17 +181,24 @@ object CometAggregateBenchmark extends CometBenchmarkBase {
         val query =
           s"SELECT key1, key2, $functionSQL FROM parquetV1Table GROUP BY key1, key2"
 
-        benchmark.addCase(s"SQL Parquet - Spark (${aggregateFunction.toString})") { _ =>
-          spark.sql(query).noop()
+        benchmark.addCase(
+          s"SQL Parquet - Spark (${aggregateFunction.toString}) isANSIMode: ${isAnsiMode.toString}") {
+          _ =>
+            withSQLConf(SQLConf.ANSI_ENABLED.key -> isAnsiMode.toString) {
+              Try { spark.sql(query).noop() }
+            }
         }
 
-        benchmark.addCase(s"SQL Parquet - Comet (${aggregateFunction.toString})") { _ =>
-          withSQLConf(
-            CometConf.COMET_ENABLED.key -> "true",
-            CometConf.COMET_EXEC_ENABLED.key -> "true",
-            CometConf.COMET_ONHEAP_MEMORY_OVERHEAD.key -> "1G") {
-            spark.sql(query).noop()
-          }
+        benchmark.addCase(
+          s"SQL Parquet - Comet (${aggregateFunction.toString}) isANSIMode: ${isAnsiMode.toString}") {
+          _ =>
+            withSQLConf(
+              CometConf.COMET_ENABLED.key -> "true",
+              CometConf.COMET_EXEC_ENABLED.key -> "true",
+              CometConf.COMET_ONHEAP_MEMORY_OVERHEAD.key -> "1G",
+              SQLConf.ANSI_ENABLED.key -> isAnsiMode.toString) {
+              Try { spark.sql(query).noop() }
+            }
         }
 
         benchmark.run()
@@ -181,11 +209,12 @@ object CometAggregateBenchmark extends CometBenchmarkBase {
   def multiAggregates(
       values: Int,
       groupingKeyCard: Int,
-      aggregateFunction: BenchAggregateFunction): Unit = {
+      aggregateFunction: BenchAggregateFunction,
+      isAnsiMode: Boolean): Unit = {
     val benchmark =
       new Benchmark(
         s"Grouped HashAgg Exec: single group key (cardinality $groupingKeyCard), " +
-          s"multiple aggregates ${aggregateFunction.toString}",
+          s"multiple aggregates ${aggregateFunction.toString} isANSIMode: ${isAnsiMode.toString}",
         values,
         output = output)
 
@@ -203,16 +232,23 @@ object CometAggregateBenchmark extends CometBenchmarkBase {
         val query = s"SELECT key, $functionSQL1, $functionSQL2 " +
           "FROM parquetV1Table GROUP BY key"
 
-        benchmark.addCase(s"SQL Parquet - Spark (${aggregateFunction.toString})") { _ =>
-          spark.sql(query).noop()
+        benchmark.addCase(
+          s"SQL Parquet - Spark (${aggregateFunction.toString}) isANSIMode: ${isAnsiMode.toString}") {
+          _ =>
+            withSQLConf(SQLConf.ANSI_ENABLED.key -> isAnsiMode.toString) {
+              Try { spark.sql(query).noop() }
+            }
         }
 
-        benchmark.addCase(s"SQL Parquet - Comet (${aggregateFunction.toString})") { _ =>
-          withSQLConf(
-            CometConf.COMET_ENABLED.key -> "true",
-            CometConf.COMET_EXEC_ENABLED.key -> "true") {
-            spark.sql(query).noop()
-          }
+        benchmark.addCase(
+          s"SQL Parquet - Comet (${aggregateFunction.toString}) isANSIMode: ${isAnsiMode.toString}") {
+          _ =>
+            withSQLConf(
+              CometConf.COMET_ENABLED.key -> "true",
+              CometConf.COMET_EXEC_ENABLED.key -> "true",
+              SQLConf.ANSI_ENABLED.key -> isAnsiMode.toString) {
+              Try { spark.sql(query).noop() }
+            }
         }
 
         benchmark.run()
@@ -223,39 +259,40 @@ object CometAggregateBenchmark extends CometBenchmarkBase {
   override def runCometBenchmark(mainArgs: Array[String]): Unit = {
     val total = 1024 * 1024 * 10
     val combinations = List(100, 1024, 1024 * 1024) // number of distinct groups
-
     benchmarkAggFuncs.foreach { aggFunc =>
-      runBenchmarkWithTable(
-        s"Grouped Aggregate (single group key + single aggregate $aggFunc)",
-        total) { v =>
-        for (card <- combinations) {
-          singleGroupAndAggregate(v, card, aggFunc)
+      Seq(true, false).foreach(k => {
+        runBenchmarkWithTable(
+          s"Grouped Aggregate (single group key + single aggregate $aggFunc)",
+          total) { v =>
+          for (card <- combinations) {
+            singleGroupAndAggregate(v, card, aggFunc, k)
+          }
         }
-      }
 
-      runBenchmarkWithTable(
-        s"Grouped Aggregate (multiple group keys + single aggregate $aggFunc)",
-        total) { v =>
-        for (card <- combinations) {
-          multiGroupKeys(v, card, aggFunc)
+        runBenchmarkWithTable(
+          s"Grouped Aggregate (multiple group keys + single aggregate $aggFunc)",
+          total) { v =>
+          for (card <- combinations) {
+            multiGroupKeys(v, card, aggFunc, k)
+          }
         }
-      }
 
-      runBenchmarkWithTable(
-        s"Grouped Aggregate (single group key + multiple aggregates $aggFunc)",
-        total) { v =>
-        for (card <- combinations) {
-          multiAggregates(v, card, aggFunc)
+        runBenchmarkWithTable(
+          s"Grouped Aggregate (single group key + multiple aggregates $aggFunc)",
+          total) { v =>
+          for (card <- combinations) {
+            multiAggregates(v, card, aggFunc, k)
+          }
         }
-      }
 
-      runBenchmarkWithTable(
-        s"Grouped Aggregate (single group key + single aggregate $aggFunc on decimal)",
-        total) { v =>
-        for (card <- combinations) {
-          singleGroupAndAggregateDecimal(v, DecimalType(18, 10), card, aggFunc)
+        runBenchmarkWithTable(
+          s"Grouped Aggregate (single group key + single aggregate $aggFunc on decimal)",
+          total) { v =>
+          for (card <- combinations) {
+            singleGroupAndAggregateDecimal(v, DecimalType(18, 10), card, aggFunc, k)
+          }
         }
-      }
+      })
     }
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2883  .

## Rationale for this change

Current comet aggregated benchmarking tests do not support ANSI Mode (throws an exception) . These changes essentially allow us to test all aggregated comet expressions (with ANSI mode enabled) so as to derive benchmarks 

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
