### PR TITLE
chore: Refactor string benchmarks (~10x reduction in LOC)

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometStringExpressionBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometStringExpressionBenchmark.scala
@@ -53,8 +53,8 @@ object CometStringExpressionBenchmark extends CometBenchmarkBase {
     val benchmark = new Benchmark(config.name, values, output = output)
 
     withTempPath { dir =>
-      withTempTable("tbl") {
-        prepareTable(dir, spark.sql(s"SELECT REPEAT(CAST(value AS STRING), 100) AS c1 FROM tbl"))
+      withTempTable("parquetV1Table") {
+        prepareTable(dir, spark.sql(s"SELECT REPEAT(CAST(value AS STRING), 100) AS c1 FROM $tbl"))
 
         benchmark.addCase("SQL Parquet - Spark") { _ =>
           spark.sql(config.query).noop()
@@ -87,23 +87,23 @@ object CometStringExpressionBenchmark extends CometBenchmarkBase {
 
   // Configuration for all string expression benchmarks
   private val stringExpressions = List(
-    StringExprConfig("Substring", "select substring(c1, 1, 100) from tbl"),
-    StringExprConfig("ascii", "select ascii(c1) from tbl"),
-    StringExprConfig("bitLength", "select bit_length(c1) from tbl"),
-    StringExprConfig("octet_length", "select octet_length(c1) from tbl"),
-    StringExprConfig("upper", "select upper(c1) from tbl"),
-    StringExprConfig("lower", "select lower(c1) from tbl"),
-    StringExprConfig("chr", "select chr(c1) from tbl"),
-    StringExprConfig("initCap", "select initCap(c1) from tbl"),
-    StringExprConfig("trim", "select trim(c1) from tbl"),
-    StringExprConfig("concatws", "select concat_ws(' ', c1, c1) from tbl"),
-    StringExprConfig("length", "select length(c1) from tbl"),
-    StringExprConfig("repeat", "select repeat(c1, 3) from tbl"),
-    StringExprConfig("reverse", "select reverse(c1) from tbl"),
-    StringExprConfig("instr", "select instr(c1, '123') from tbl"),
-    StringExprConfig("replace", "select replace(c1, '123', 'ab') from tbl"),
-    StringExprConfig("space", "select space(2) from tbl"),
-    StringExprConfig("translate", "select translate(c1, '123456', 'aBcDeF') from tbl"))
+    StringExprConfig("Substring", "select substring(c1, 1, 100) from parquetV1Table"),
+    StringExprConfig("ascii", "select ascii(c1) from parquetV1Table"),
+    StringExprConfig("bitLength", "select bit_length(c1) from parquetV1Table"),
+    StringExprConfig("octet_length", "select octet_length(c1) from parquetV1Table"),
+    StringExprConfig("upper", "select upper(c1) from parquetV1Table"),
+    StringExprConfig("lower", "select lower(c1) from parquetV1Table"),
+    StringExprConfig("chr", "select chr(c1) from parquetV1Table"),
+    StringExprConfig("initCap", "select initCap(c1) from parquetV1Table"),
+    StringExprConfig("trim", "select trim(c1) from parquetV1Table"),
+    StringExprConfig("concatws", "select concat_ws(' ', c1, c1) from parquetV1Table"),
+    StringExprConfig("length", "select length(c1) from parquetV1Table"),
+    StringExprConfig("repeat", "select repeat(c1, 3) from parquetV1Table"),
+    StringExprConfig("reverse", "select reverse(c1) from parquetV1Table"),
+    StringExprConfig("instr", "select instr(c1, '123') from parquetV1Table"),
+    StringExprConfig("replace", "select replace(c1, '123', 'ab') from parquetV1Table"),
+    StringExprConfig("space", "select space(2) from parquetV1Table"),
+    StringExprConfig("translate", "select translate(c1, '123456', 'aBcDeF') from parquetV1Table"))
 
   override def runCometBenchmark(mainArgs: Array[String]): Unit = {
     val values = 1024 * 1024;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

I want to improve these benchmarks but I needed to refactor first to remove all the copy and paste boilerplate.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Refactor
- The only functional change was to change the `space` benchmak since it was using an input contain integers instead of strings (unlike the other benchmarks), so I changed it to `space(2)` and disabled constant folding

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

```
Running benchmark: Substring
  Running case: SQL Parquet - Spark
  Stopped after 2 iterations, 13722 ms
  Running case: SQL Parquet - Comet (Scan)
  Stopped after 2 iterations, 13799 ms
  Running case: SQL Parquet - Comet (Scan, Exec)
  Stopped after 2 iterations, 2240 ms

OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Mac OS X 14.6.1
Apple M3 Max
Substring:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
SQL Parquet - Spark                                6861           6861           0          0.2        6543.4       1.0X
SQL Parquet - Comet (Scan)                         6896           6900           5          0.2        6576.6       1.0X
SQL Parquet - Comet (Scan, Exec)                   1092           1120          39          1.0        1041.9       6.3X

Running benchmark: ascii
  Running case: SQL Parquet - Spark
  Stopped after 5 iterations, 2304 ms
  Running case: SQL Parquet - Comet (Scan)
  Stopped after 5 iterations, 2393 ms
  Running case: SQL Parquet - Comet (Scan, Exec)
  Stopped after 3 iterations, 2305 ms

OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Mac OS X 14.6.1
Apple M3 Max
ascii:                                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
SQL Parquet - Spark                                 421            461          39          2.5         401.5       1.0X
SQL Parquet - Comet (Scan)                          463            479          26          2.3         441.2       0.9X
SQL Parquet - Comet (Scan, Exec)                    697            769          62          1.5         665.2       0.6X

Running benchmark: bitLength
  Running case: SQL Parquet - Spark
  Stopped after 5 iterations, 2056 ms
  Running case: SQL Parquet - Comet (Scan)
  Stopped after 4 iterations, 2004 ms
  Running case: SQL Parquet - Comet (Scan, Exec)
  Stopped after 3 iterations, 2278 ms

OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Mac OS X 14.6.1
Apple M3 Max
bitLength:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
SQL Parquet - Spark                                 388            411          40          2.7         369.9       1.0X
SQL Parquet - Comet (Scan)                          432            501          48          2.4         411.7       0.9X
SQL Parquet - Comet (Scan, Exec)                    683            760          66          1.5         651.5       0.6X

Running benchmark: octet_length
  Running case: SQL Parquet - Spark
  Stopped after 6 iterations, 2371 ms
  Running case: SQL Parquet - Comet (Scan)
  Stopped after 4 iterations, 2076 ms
  Running case: SQL Parquet - Comet (Scan, Exec)
  Stopped after 3 iterations, 2059 ms

OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Mac OS X 14.6.1
Apple M3 Max
octet_length:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
SQL Parquet - Spark                                 379            395          25          2.8         361.3       1.0X
SQL Parquet - Comet (Scan)                          516            519           6          2.0         491.7       0.7X
SQL Parquet - Comet (Scan, Exec)                    679            687           8          1.5         647.4       0.6X

Running benchmark: upper
  Running case: SQL Parquet - Spark
  Stopped after 2 iterations, 5979 ms
  Running case: SQL Parquet - Comet (Scan)
  Stopped after 2 iterations, 6167 ms
  Running case: SQL Parquet - Comet (Scan, Exec)
  Stopped after 3 iterations, 2979 ms

OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Mac OS X 14.6.1
Apple M3 Max
upper:                                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
SQL Parquet - Spark                                2988           2990           3          0.4        2849.3       1.0X
SQL Parquet - Comet (Scan)                         3051           3084          45          0.3        2910.1       1.0X
SQL Parquet - Comet (Scan, Exec)                    991            993           4          1.1         944.6       3.0X

Running benchmark: lower
  Running case: SQL Parquet - Spark
  Stopped after 2 iterations, 6255 ms
  Running case: SQL Parquet - Comet (Scan)
  Stopped after 2 iterations, 6216 ms
  Running case: SQL Parquet - Comet (Scan, Exec)
  Stopped after 2 iterations, 2069 ms

OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Mac OS X 14.6.1
Apple M3 Max
lower:                                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
SQL Parquet - Spark                                3125           3128           3          0.3        2980.6       1.0X
SQL Parquet - Comet (Scan)                         3078           3108          42          0.3        2935.7       1.0X
SQL Parquet - Comet (Scan, Exec)                   1030           1035           6          1.0         982.7       3.0X

Running benchmark: chr
  Running case: SQL Parquet - Spark
  Stopped after 4 iterations, 2047 ms
  Running case: SQL Parquet - Comet (Scan)
  Stopped after 4 iterations, 2071 ms
  Running case: SQL Parquet - Comet (Scan, Exec)
  Stopped after 3 iterations, 2502 ms

OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Mac OS X 14.6.1
Apple M3 Max
chr:                                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
SQL Parquet - Spark                                 497            512          12          2.1         473.5       1.0X
SQL Parquet - Comet (Scan)                          449            518          47          2.3         427.8       1.1X
SQL Parquet - Comet (Scan, Exec)                    830            834           5          1.3         791.2       0.6X

Running benchmark: initCap
  Running case: SQL Parquet - Spark
  Stopped after 2 iterations, 9003 ms
  Running case: SQL Parquet - Comet (Scan)
  Stopped after 2 iterations, 9180 ms
  Running case: SQL Parquet - Comet (Scan, Exec)
  Stopped after 2 iterations, 10578 ms

OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Mac OS X 14.6.1
Apple M3 Max
initCap:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
SQL Parquet - Spark                                4496           4502           9          0.2        4287.2       1.0X
SQL Parquet - Comet (Scan)                         4537           4590          76          0.2        4326.6       1.0X
SQL Parquet - Comet (Scan, Exec)                   5279           5289          14          0.2        5034.9       0.9X

Running benchmark: trim
  Running case: SQL Parquet - Spark
  Stopped after 5 iterations, 2265 ms
  Running case: SQL Parquet - Comet (Scan)
  Stopped after 4 iterations, 2107 ms
  Running case: SQL Parquet - Comet (Scan, Exec)
  Stopped after 2 iterations, 2128 ms

OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Mac OS X 14.6.1
Apple M3 Max
trim:                                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
SQL Parquet - Spark                                 428            453          42          2.5         408.0       1.0X
SQL Parquet - Comet (Scan)                          482            527          36          2.2         459.7       0.9X
SQL Parquet - Comet (Scan, Exec)                   1062           1064           4          1.0        1012.7       0.4X

Running benchmark: concatws
  Running case: SQL Parquet - Spark
  Stopped after 4 iterations, 2643 ms
  Running case: SQL Parquet - Comet (Scan)
  Stopped after 3 iterations, 2121 ms
  Running case: SQL Parquet - Comet (Scan, Exec)
  Stopped after 2 iterations, 2554 ms

OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Mac OS X 14.6.1
Apple M3 Max
concatws:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
SQL Parquet - Spark                                 629            661          22          1.7         600.1       1.0X
SQL Parquet - Comet (Scan)                          649            707          51          1.6         618.5       1.0X
SQL Parquet - Comet (Scan, Exec)                   1268           1277          13          0.8        1209.2       0.5X

Running benchmark: length
  Running case: SQL Parquet - Spark
  Stopped after 2 iterations, 14653 ms
  Running case: SQL Parquet - Comet (Scan)
  Stopped after 2 iterations, 13070 ms
  Running case: SQL Parquet - Comet (Scan, Exec)
  Stopped after 3 iterations, 2446 ms

OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Mac OS X 14.6.1
Apple M3 Max
length:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
SQL Parquet - Spark                                7325           7327           2          0.1        6985.9       1.0X
SQL Parquet - Comet (Scan)                         6526           6535          13          0.2        6223.9       1.1X
SQL Parquet - Comet (Scan, Exec)                    804            815          10          1.3         766.7       9.1X

Running benchmark: repeat
  Running case: SQL Parquet - Spark
  Stopped after 3 iterations, 2207 ms
  Running case: SQL Parquet - Comet (Scan)
  Stopped after 3 iterations, 2373 ms
  Running case: SQL Parquet - Comet (Scan, Exec)
  Stopped after 2 iterations, 3262 ms

OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Mac OS X 14.6.1
Apple M3 Max
repeat:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
SQL Parquet - Spark                                 717            736          22          1.5         683.5       1.0X
SQL Parquet - Comet (Scan)                          771            791          34          1.4         735.4       0.9X
SQL Parquet - Comet (Scan, Exec)                   1626           1631           8          0.6        1550.7       0.4X

Running benchmark: reverse
  Running case: SQL Parquet - Spark
  Stopped after 2 iterations, 16550 ms
  Running case: SQL Parquet - Comet (Scan)
  Stopped after 2 iterations, 15554 ms
  Running case: SQL Parquet - Comet (Scan, Exec)
  Stopped after 2 iterations, 2406 ms

OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Mac OS X 14.6.1
Apple M3 Max
reverse:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
SQL Parquet - Spark                                8239           8275          51          0.1        7857.5       1.0X
SQL Parquet - Comet (Scan)                         7768           7777          13          0.1        7408.5       1.1X
SQL Parquet - Comet (Scan, Exec)                   1186           1203          24          0.9        1131.3       6.9X

Running benchmark: instr
  Running case: SQL Parquet - Spark
  Stopped after 2 iterations, 7534 ms
  Running case: SQL Parquet - Comet (Scan)
  Stopped after 2 iterations, 12540 ms
  Running case: SQL Parquet - Comet (Scan, Exec)
  Stopped after 2 iterations, 13470 ms

OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Mac OS X 14.6.1
Apple M3 Max
instr:                                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
SQL Parquet - Spark                                3757           3767          15          0.3        3582.8       1.0X
SQL Parquet - Comet (Scan)                         6244           6270          37          0.2        5954.8       0.6X
SQL Parquet - Comet (Scan, Exec)                   6725           6735          15          0.2        6413.1       0.6X

Running benchmark: replace
  Running case: SQL Parquet - Spark
  Stopped after 2 iterations, 5026 ms
  Running case: SQL Parquet - Comet (Scan)
  Stopped after 2 iterations, 5113 ms
  Running case: SQL Parquet - Comet (Scan, Exec)
  Stopped after 2 iterations, 4036 ms

OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Mac OS X 14.6.1
Apple M3 Max
replace:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
SQL Parquet - Spark                                2504           2513          13          0.4        2388.4       1.0X
SQL Parquet - Comet (Scan)                         2555           2557           3          0.4        2436.7       1.0X
SQL Parquet - Comet (Scan, Exec)                   1990           2018          40          0.5        1897.6       1.3X

Running benchmark: space
  Running case: SQL Parquet - Spark
  Stopped after 45 iterations, 2015 ms
  Running case: SQL Parquet - Comet (Scan)
  Stopped after 43 iterations, 2129 ms
  Running case: SQL Parquet - Comet (Scan, Exec)
  Stopped after 41 iterations, 2026 ms

OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Mac OS X 14.6.1
Apple M3 Max
space:                                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
SQL Parquet - Spark                                  24             45          32         43.5          23.0       1.0X
SQL Parquet - Comet (Scan)                           24             50          27         43.4          23.0       1.0X
SQL Parquet - Comet (Scan, Exec)                     29             49          34         36.5          27.4       0.8X

Running benchmark: translate
  Running case: SQL Parquet - Spark
  Stopped after 2 iterations, 58794 ms
  Running case: SQL Parquet - Comet (Scan)
  Stopped after 2 iterations, 58909 ms
  Running case: SQL Parquet - Comet (Scan, Exec)
  Stopped after 2 iterations, 71357 ms

OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Mac OS X 14.6.1
Apple M3 Max
translate:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
SQL Parquet - Spark                               29380          29397          24          0.0       28019.1       1.0X
SQL Parquet - Comet (Scan)                        29428          29455          38          0.0       28064.4       1.0X
SQL Parquet - Comet (Scan, Exec)                  35628          35679          71          0.0       33977.8       0.8X
```
