### PR TITLE
feat: [iceberg] Support session token in Iceberg Native scan

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
@@ -426,6 +426,7 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
         // Global S3A configuration keys
         case "fs.s3a.access.key" => Some("s3.access-key-id" -> value)
         case "fs.s3a.secret.key" => Some("s3.secret-access-key" -> value)
+        case "fs.s3a.session.token" => Some("s3.session-token" -> value)
         case "fs.s3a.endpoint" => Some("s3.endpoint" -> value)
         case "fs.s3a.path.style.access" => Some("s3.path-style-access" -> value)
         case "fs.s3a.endpoint.region" => Some("s3.region" -> value)
@@ -440,6 +441,7 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
             property match {
               case "access.key" => Some(s"s3.bucket.$bucket.access-key-id" -> value)
               case "secret.key" => Some(s"s3.bucket.$bucket.secret-access-key" -> value)
+              case "session.token" => Some(s"s3.bucket.$bucket.session.token" -> value)
               case "endpoint" => Some(s"s3.bucket.$bucket.endpoint" -> value)
               case "path.style.access" => Some(s"s3.bucket.$bucket.path-style-access" -> value)
               case "endpoint.region" => Some(s"s3.bucket.$bucket.region" -> value)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

While using `S3AFileSystem` via Iceberg's `HadoopFileIO`, we sometimes need to pass temporary credentials to [Iceberg Rust](https://github.com/apache/iceberg-rust/blob/v0.7.0/crates/iceberg/src/io/storage_s3.rs#L40)

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Pass session-token at global and bucket level.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

I am able to read Iceberg tables by Iceberg native scan

```shell
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- CometHashAggregate
   +- CometExchange SinglePartition, ENSURE_REQUIREMENTS, CometNativeShuffle, [plan_id=62]
      +- CometHashAggregate
         +- CometHashAggregate
            +- CometExchange hashpartitioning(), ENSURE_REQUIREMENTS, CometNativeShuffle, [plan_id=59]
               +- CometHashAggregate
                  +- CometProject
                     +- CometIcebergNativeScan
```

and got some result back