### PR TITLE
fix: enable cast tests for Spark 4.0

### DIFF
--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -33,7 +33,6 @@ import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{ArrayType, BooleanType, ByteType, DataType, DataTypes, DecimalType, IntegerType, LongType, ShortType, StringType, StructField, StructType}
 
-import org.apache.comet.CometSparkSessionExtensions.isSpark40Plus
 import org.apache.comet.expressions.{CometCast, CometEvalMode}
 import org.apache.comet.rules.CometScanTypeChecker
 import org.apache.comet.serde.Compatible
@@ -575,8 +574,6 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   // CAST from StringType
 
   test("cast StringType to BooleanType") {
-    // TODO fix for Spark 4.0.0
-    assume(!isSpark40Plus)
     val testValues =
       (Seq("TRUE", "True", "true", "FALSE", "False", "false", "1", "0", "", null) ++
         gen.generateStrings(dataSize, "truefalseTRUEFALSEyesno10" + whitespaceChars, 8)).toDF("a")
@@ -617,8 +614,6 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   )
 
   test("cast StringType to ByteType") {
-    // TODO fix for Spark 4.0.0
-    assume(!isSpark40Plus)
     // test with hand-picked values
     castTest(castStringToIntegralInputs.toDF("a"), DataTypes.ByteType)
     // fuzz test
@@ -626,8 +621,6 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("cast StringType to ShortType") {
-    // TODO fix for Spark 4.0.0
-    assume(!isSpark40Plus)
     // test with hand-picked values
     castTest(castStringToIntegralInputs.toDF("a"), DataTypes.ShortType)
     // fuzz test
@@ -635,8 +628,6 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("cast StringType to IntegerType") {
-    // TODO fix for Spark 4.0.0
-    assume(!isSpark40Plus)
     // test with hand-picked values
     castTest(castStringToIntegralInputs.toDF("a"), DataTypes.IntegerType)
     // fuzz test
@@ -644,8 +635,6 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("cast StringType to LongType") {
-    // TODO fix for Spark 4.0.0
-    assume(!isSpark40Plus)
     // test with hand-picked values
     castTest(castStringToIntegralInputs.toDF("a"), DataTypes.LongType)
     // fuzz test
@@ -707,8 +696,6 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("cast StringType to DateType") {
-    // TODO fix for Spark 4.0.0
-    assume(!isSpark40Plus)
     val validDates = Seq(
       "262142-01-01",
       "262142-01-01 ",
@@ -1295,10 +1282,21 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
               } else {
                 if (CometSparkSessionExtensions.isSpark40Plus) {
                   // for Spark 4 we expect to sparkException carries the message
-                  assert(
-                    sparkException.getMessage
-                      .replace(".WITH_SUGGESTION] ", "]")
-                      .startsWith(cometMessage))
+                  assert(sparkMessage.contains("SQLSTATE"))
+                  if (sparkMessage.startsWith("[NUMERIC_VALUE_OUT_OF_RANGE.WITH_SUGGESTION]")) {
+                    assert(
+                      sparkMessage.replace(".WITH_SUGGESTION] ", "]").startsWith(cometMessage))
+                  } else if (cometMessage.startsWith("[CAST_INVALID_INPUT]") || cometMessage
+                      .startsWith("[CAST_OVERFLOW]")) {
+                    assert(
+                      sparkMessage.startsWith(
+                        cometMessage
+                          .replace(
+                            "If necessary set \"spark.sql.ansi.enabled\" to \"false\" to bypass this error.",
+                            "")))
+                  } else {
+                    assert(sparkMessage.startsWith(cometMessage))
+                  }
                 } else {
                   // for Spark 3.4 we expect to reproduce the error message exactly
                   assert(cometMessage == sparkMessage)
@@ -1325,5 +1323,4 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     df.write.mode(SaveMode.Overwrite).parquet(filename)
     spark.read.parquet(filename)
   }
-
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2885.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
Some cast tests are skipped for Spark 4.0 due to exception message mismatch after https://github.com/apache/spark/pull/48054.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Drop `If necessary set \"spark.sql.ansi.enabled\" to \"false\" to bypass this error.` from comet exception message like https://github.com/apache/spark/pull/48054, and enable tests skipped for Spark 4.0.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
