### PR TITLE
perf: Use await instead of block_on in native shuffle writer

### DIFF
--- a/native/core/src/execution/shuffle/shuffle_writer.rs
+++ b/native/core/src/execution/shuffle/shuffle_writer.rs
@@ -44,7 +44,6 @@ use datafusion::{
     },
 };
 use datafusion_comet_spark_expr::hash_funcs::murmur3::create_murmur3_hashes;
-use futures::executor::block_on;
 use futures::{StreamExt, TryFutureExt, TryStreamExt};
 use itertools::Itertools;
 use std::borrow::Borrow;
@@ -254,11 +253,11 @@ async fn external_shuffle(
         };
 
         while let Some(batch) = input.next().await {
-            // Block on the repartitioner to insert the batch and shuffle the rows
+            // Await the repartitioner to insert the batch and shuffle the rows
             // into the corresponding partition buffer.
             // Otherwise, pull the next batch from the input stream might overwrite the
             // current batch in the repartitioner.
-            block_on(repartitioner.insert_batch(batch?))?;
+            repartitioner.insert_batch(batch?).await?;
         }
 
         repartitioner.shuffle_write()?;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A.

## Rationale for this change

The shuffle writer was calling `futures::executor::block_on()` from within an async function running on Tokio's runtime. This blocks the Tokio worker thread and prevents other tasks from running.

### Specific Problems

1. **Blocks worker threads**: Uses `thread::park()` to block the current Tokio worker thread, preventing Tokio from scheduling other tasks on it
2. **Bypasses Tokio runtime**: Uses its own polling infrastructure instead of Tokio's scheduler
3. **Hot path performance issue**: Runs for every batch during shuffle operations

### Sources

I am not a Tokio optimization expert, so I'll defer to some sources I read and maybe others can tell me if I've misunderstood:

From [Rust Async Book](https://rust-lang.github.io/async-book/01_getting_started/04_async_await_primer.html):

> "calling a blocking function in a synchronous method would block the whole thread, [while] blocked Futures will yield control of the thread, allowing other Futures to run."

> "The `.await` operator doesn't block the current thread, but instead asynchronously waits for the future to complete, allowing other tasks to run if the future is currently unable to make progress."

From [futures-rs source code](https://github.com/rust-lang/futures-rs/blob/master/futures-executor/src/local_pool.rs), `block_on` internally uses `thread::park()` to block the current thread when waiting for the future to complete.

From [Tokio documentation](https://docs.rs/tokio/latest/tokio/task/fn.block_in_place.html):

> "issuing a blocking call or performing a lot of compute in a future without yielding is problematic, as it may prevent the executor from driving other tasks forward."

## What changes are included in this PR?
- Replaced `block_on(repartitioner.insert_batch(batch?))?` with `repartitioner.insert_batch(batch?).await?`

This maintains the same sequential behavior (waiting for each batch to complete before getting the next one) but does so cooperatively without blocking the thread.

## How are these changes tested?

Existing tests. I'll try to run a benchmark too.