### PR TITLE
Add config to disable columnar shuffle for complex types

### DIFF
--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -376,6 +376,17 @@ object CometConf extends ShimCometConf {
       .intConf
       .createWithDefault(1)
 
+  val COMET_COLUMNAR_SHUFFLE_COMPLEX_TYPES_ENABLED: ConfigEntry[Boolean] =
+    conf("spark.comet.columnar.shuffle.complexTypes.enabled")
+      .category(CATEGORY_SHUFFLE)
+      .doc(
+        "Whether to enable Comet columnar shuffle for complex types (struct, array, map). " +
+          "When disabled (default), queries with complex types will fall back to Spark shuffle " +
+          "for better performance. Enable this only if you need columnar shuffle features for " +
+          "complex types and accept potential performance tradeoffs.")
+      .booleanConf
+      .createWithDefault(false)
+
   val COMET_COLUMNAR_SHUFFLE_ASYNC_ENABLED: ConfigEntry[Boolean] =
     conf("spark.comet.columnar.shuffle.async.enabled")
       .category(CATEGORY_SHUFFLE)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #2904

## Rationale for this change

Benchmarks show that Comet columnar shuffle with complex/nested types (struct, array, map) is significantly slower than Spark's default shuffle. This PR adds a configuration flag to disable columnar shuffle for complex types, falling back to Spark shuffle for better performance until the underlying performance issues can be addressed.
## What changes are included in this PR?

Add spark.comet.columnar.shuffle.complexTypes.enabled config (default: false)
When disabled, queries with complex types in the shuffle schema fall back to Spark shuffle
Update columnarShuffleSupported() to check this config for StructType, ArrayType, and MapTyp

## How are these changes tested?

Updated existing columnar shuffle tests for complex types to explicitly enable the new config
Added new test "Fallback to Spark for complex types when config is disabled (default)" that verifies struct, array, and map types fall back to Spark shuffle when the config is disabled
