### PR TITLE
Allow Spark partial / Comet final for compatible aggregates

### DIFF
--- a/dev/diffs/3.4.3.diff
+++ b/dev/diffs/3.4.3.diff
@@ -1,5 +1,5 @@
 diff --git a/pom.xml b/pom.xml
-index d3544881af1..377683b10c5 100644
+index d354488..377683b 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -148,6 +148,8 @@
@@ -38,7 +38,7 @@ index d3544881af1..377683b10c5 100644
    </dependencyManagement>
  
 diff --git a/sql/core/pom.xml b/sql/core/pom.xml
-index b386d135da1..46449e3f3f1 100644
+index b386d13..46449e3 100644
 --- a/sql/core/pom.xml
 +++ b/sql/core/pom.xml
 @@ -77,6 +77,10 @@
@@ -53,7 +53,7 @@ index b386d135da1..46449e3f3f1 100644
      <!--
        This spark-tags test-dep is needed even though it isn't used in this module, otherwise testing-cmds that exclude
 diff --git a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
-index c595b50950b..3abb6cb9441 100644
+index c595b50..3abb6cb 100644
 --- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
 +++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
 @@ -102,7 +102,7 @@ class SparkSession private(
@@ -114,7 +114,7 @@ index c595b50950b..3abb6cb9441 100644
 +  }
  }
 diff --git a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala
-index db587dd9868..aac7295a53d 100644
+index db587dd..aac7295 100644
 --- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala
 +++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala
 @@ -18,6 +18,7 @@
@@ -134,7 +134,7 @@ index db587dd9868..aac7295a53d 100644
      }
      new SparkPlanInfo(
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/explain-aqe.sql b/sql/core/src/test/resources/sql-tests/inputs/explain-aqe.sql
-index 7aef901da4f..f3d6e18926d 100644
+index 7aef901..f3d6e18 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/explain-aqe.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/explain-aqe.sql
 @@ -2,3 +2,4 @@
@@ -143,7 +143,7 @@ index 7aef901da4f..f3d6e18926d 100644
  --SET spark.sql.maxMetadataStringLength = 500
 +--SET spark.comet.enabled = false
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/explain-cbo.sql b/sql/core/src/test/resources/sql-tests/inputs/explain-cbo.sql
-index eeb2180f7a5..afd1b5ec289 100644
+index eeb2180..afd1b5e 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/explain-cbo.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/explain-cbo.sql
 @@ -1,5 +1,6 @@
@@ -154,7 +154,7 @@ index eeb2180f7a5..afd1b5ec289 100644
  CREATE TABLE explain_temp1(a INT, b INT) USING PARQUET;
  CREATE TABLE explain_temp2(c INT, d INT) USING PARQUET;
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/explain.sql b/sql/core/src/test/resources/sql-tests/inputs/explain.sql
-index 698ca009b4f..57d774a3617 100644
+index 698ca00..57d774a 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/explain.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/explain.sql
 @@ -1,6 +1,7 @@
@@ -166,7 +166,7 @@ index 698ca009b4f..57d774a3617 100644
  -- Test tables
  CREATE table  explain_temp1 (key int, val int) USING PARQUET;
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/aggregates_part1.sql b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/aggregates_part1.sql
-index 1152d77da0c..f77493f690b 100644
+index 1152d77..f77493f 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/aggregates_part1.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/aggregates_part1.sql
 @@ -7,6 +7,9 @@
@@ -180,7 +180,7 @@ index 1152d77da0c..f77493f690b 100644
  -- Test aggregate operator with codegen on and off.
  --CONFIG_DIM1 spark.sql.codegen.wholeStage=true
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/aggregates_part3.sql b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/aggregates_part3.sql
-index 41fd4de2a09..44cd244d3b0 100644
+index 41fd4de..44cd244 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/aggregates_part3.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/aggregates_part3.sql
 @@ -5,6 +5,9 @@
@@ -194,7 +194,7 @@ index 41fd4de2a09..44cd244d3b0 100644
  --CONFIG_DIM1 spark.sql.codegen.wholeStage=true
  --CONFIG_DIM1 spark.sql.codegen.wholeStage=false,spark.sql.codegen.factoryMode=CODEGEN_ONLY
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/int4.sql b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/int4.sql
-index 3a409eea348..38fed024c98 100644
+index 3a409ee..38fed02 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/int4.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/int4.sql
 @@ -69,6 +69,8 @@ SELECT '' AS one, i.* FROM INT4_TBL i WHERE (i.f1 % smallint('2')) = smallint('1
@@ -207,7 +207,7 @@ index 3a409eea348..38fed024c98 100644
  SELECT '' AS five, i.f1, i.f1 * smallint('2') AS x FROM INT4_TBL i;
  
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/int8.sql b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/int8.sql
-index fac23b4a26f..2b73732c33f 100644
+index fac23b4..2b73732 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/int8.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/int8.sql
 @@ -1,6 +1,10 @@
@@ -222,7 +222,7 @@ index fac23b4a26f..2b73732c33f 100644
  -- INT8
  -- Test int8 64-bit integers.
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/select_having.sql b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/select_having.sql
-index 0efe0877e9b..423d3b3d76d 100644
+index 0efe087..423d3b3 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/select_having.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/select_having.sql
 @@ -1,6 +1,10 @@
@@ -237,7 +237,7 @@ index 0efe0877e9b..423d3b3d76d 100644
  -- SELECT_HAVING
  -- https://github.com/postgres/postgres/blob/REL_12_BETA2/src/test/regress/sql/select_having.sql
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
-index cf40e944c09..bdd5be4f462 100644
+index cf40e94..bdd5be4 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
 @@ -38,7 +38,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeConstants
@@ -260,7 +260,7 @@ index cf40e944c09..bdd5be4f462 100644
  
    test("A cached table preserves the partitioning and ordering of its cached SparkPlan") {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
-index 1cc09c3d7fc..f031fa45c33 100644
+index 1cc09c3..f031fa4 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
 @@ -27,7 +27,7 @@ import org.apache.spark.SparkException
@@ -282,7 +282,7 @@ index 1cc09c3d7fc..f031fa45c33 100644
        assert(exchangePlans.length == 1)
      }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
-index 56e9520fdab..917932336df 100644
+index 56e9520..9179323 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
 @@ -435,7 +435,9 @@ class DataFrameJoinSuite extends QueryTest
@@ -297,7 +297,7 @@ index 56e9520fdab..917932336df 100644
            spark.range(100).write.saveAsTable(s"$dbName.$table2Name")
  
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
-index a9f69ab28a1..760ea0e9565 100644
+index a9f69ab..760ea0e 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
 @@ -39,11 +39,12 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, Attri
@@ -357,7 +357,7 @@ index a9f69ab28a1..760ea0e9565 100644
      assert(exchanges.size == 2)
    }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
-index 433b4741979..07148eee480 100644
+index 433b474..07148ee 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
 @@ -23,8 +23,9 @@ import org.apache.spark.TestUtils.{assertNotSpilled, assertSpilled}
@@ -395,7 +395,7 @@ index 433b4741979..07148eee480 100644
            }
          case _ => false
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
-index daef11ae4d6..9f3cc9181f2 100644
+index daef11a..9f3cc91 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
 @@ -39,7 +39,7 @@ import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftSemi}
@@ -417,7 +417,7 @@ index daef11ae4d6..9f3cc9181f2 100644
      assert(exchanges.size == 2)
    }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
-index f33432ddb6f..7d758d2481f 100644
+index f33432d..7d758d2 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
 @@ -22,6 +22,7 @@ import org.scalatest.GivenWhenThen
@@ -498,7 +498,7 @@ index f33432ddb6f..7d758d2481f 100644
              }
            assert(scanOption.isDefined)
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
-index a6b295578d6..91acca4306f 100644
+index a6b2955..91acca4 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
 @@ -463,7 +463,8 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
@@ -659,7 +659,7 @@ index 00000000000..5691536c114
 +  }
 +}
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
-index fda442eeef0..1b69e4f280e 100644
+index fda442e..1b69e4f 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
 @@ -468,7 +468,8 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
@@ -683,7 +683,7 @@ index fda442eeef0..1b69e4f280e 100644
        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "2000") {
        assertRewroteWithBloomFilter("select * from bf5part join bf2 on " +
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/JoinHintSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/JoinHintSuite.scala
-index 1792b4c32eb..1616e6f39bd 100644
+index 1792b4c..1616e6f 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/JoinHintSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinHintSuite.scala
 @@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide
@@ -711,7 +711,7 @@ index 1792b4c32eb..1616e6f39bd 100644
      assert(shuffleMergeJoins.size == 1)
    }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
-index 7f062bfb899..0ed85486e80 100644
+index 7f062bf..0ed8548 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
 @@ -30,7 +30,8 @@ import org.apache.spark.sql.catalyst.TableIdentifier
@@ -930,7 +930,7 @@ index 7f062bfb899..0ed85486e80 100644
      withSQLConf(
        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "1") {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
-index b5b34922694..a72403780c4 100644
+index b5b3492..a724037 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
 @@ -69,7 +69,7 @@ import org.apache.spark.tags.ExtendedSQLTest
@@ -943,7 +943,7 @@ index b5b34922694..a72403780c4 100644
    protected val baseResourcePath = {
      // use the same way as `SQLQueryTestSuite` to get the resource path
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
-index 525d97e4998..843f0472c23 100644
+index 525d97e..843f047 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
 @@ -1508,7 +1508,8 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
@@ -999,7 +999,7 @@ index 525d97e4998..843f0472c23 100644
        SQLConf.ANSI_ENABLED.key -> "true") {
        withTable("t") {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
-index 48ad10992c5..51d1ee65422 100644
+index 48ad109..51d1ee6 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
 @@ -221,6 +221,8 @@ class SparkSessionExtensionSuite extends SparkFunSuite with SQLHelper {
@@ -1030,7 +1030,7 @@ index 48ad10992c5..51d1ee65422 100644
          extensions.injectColumnar(session =>
            MyColumnarRule(PreRuleReplaceAddWithBrokenVersion(), MyPostRule())) }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
-index 18123a4d6ec..0fe185baa33 100644
+index 18123a4..0fe185b 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
 @@ -17,6 +17,8 @@
@@ -1097,7 +1097,7 @@ index 18123a4d6ec..0fe185baa33 100644
  
    test("non-matching optional group") {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
-index 75eabcb96f2..7c0bbd71551 100644
+index 75eabcb..7c0bbd7 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
 @@ -21,10 +21,11 @@ import scala.collection.mutable.ArrayBuffer
@@ -1136,7 +1136,7 @@ index 75eabcb96f2..7c0bbd71551 100644
        assert(exchanges.size === 1)
      }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
-index 02990a7a40d..bddf5e1ccc2 100644
+index 02990a7..bddf5e1 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
 @@ -24,6 +24,7 @@ import test.org.apache.spark.sql.connector._
@@ -1199,7 +1199,7 @@ index 02990a7a40d..bddf5e1ccc2 100644
                }
              }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/connector/FileDataSourceV2FallBackSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/connector/FileDataSourceV2FallBackSuite.scala
-index cfc8b2cc845..c4be7eb3731 100644
+index cfc8b2c..c4be7eb 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/connector/FileDataSourceV2FallBackSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/FileDataSourceV2FallBackSuite.scala
 @@ -21,6 +21,7 @@ import scala.collection.mutable.ArrayBuffer
@@ -1224,7 +1224,7 @@ index cfc8b2cc845..c4be7eb3731 100644
          } finally {
            spark.listenerManager.unregister(listener)
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
-index cf76f6ca32c..f454128af06 100644
+index cf76f6c..f454128 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
 @@ -22,6 +22,7 @@ import org.apache.spark.sql.{DataFrame, Row}
@@ -1262,7 +1262,7 @@ index cf76f6ca32c..f454128af06 100644
    }
  
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
-index c0ec8a58bd5..4e8bc6ed3c5 100644
+index c0ec8a5..4e8bc6e 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
 @@ -27,7 +27,7 @@ import org.apache.hadoop.fs.permission.FsPermission
@@ -1285,7 +1285,7 @@ index c0ec8a58bd5..4e8bc6ed3c5 100644
      // Fail to read ancient datetime values.
      withSQLConf(SQLConf.PARQUET_REBASE_MODE_IN_READ.key -> EXCEPTION.toString) {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala
-index 418ca3430bb..eb8267192f8 100644
+index 418ca34..eb82671 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala
 @@ -23,7 +23,7 @@ import scala.util.Random
@@ -1307,7 +1307,7 @@ index 418ca3430bb..eb8267192f8 100644
        withTempPath { path =>
          val dir = path.getCanonicalPath
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/LogicalPlanTagInSparkPlanSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/LogicalPlanTagInSparkPlanSuite.scala
-index 743ec41dbe7..9f30d6c8e04 100644
+index 743ec41..9f30d6c 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/LogicalPlanTagInSparkPlanSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/LogicalPlanTagInSparkPlanSuite.scala
 @@ -53,6 +53,10 @@ class LogicalPlanTagInSparkPlanSuite extends TPCDSQuerySuite with DisableAdaptiv
@@ -1322,7 +1322,7 @@ index 743ec41dbe7..9f30d6c8e04 100644
      case _ => false
    }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
-index 4b3d3a4b805..56e1e0e6f16 100644
+index 4b3d3a4..56e1e0e 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
 @@ -18,7 +18,7 @@
@@ -1346,7 +1346,7 @@ index 4b3d3a4b805..56e1e0e6f16 100644
  
    setupTestData()
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantProjectsSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantProjectsSuite.scala
-index 9e9d717db3b..ec73082f458 100644
+index 9e9d717..ec73082 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantProjectsSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantProjectsSuite.scala
 @@ -17,7 +17,10 @@
@@ -1419,7 +1419,7 @@ index 9e9d717db3b..ec73082f458 100644
  
        // Check the original plan's output and the new plan's output are the same.
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantSortsSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantSortsSuite.scala
-index 30ce940b032..0d3f6c6c934 100644
+index 30ce940..0d3f6c6 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantSortsSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantSortsSuite.scala
 @@ -19,6 +19,7 @@ package org.apache.spark.sql.execution
@@ -1440,7 +1440,7 @@ index 30ce940b032..0d3f6c6c934 100644
  
    private def checkSorts(query: String, enabledCount: Int, disabledCount: Int): Unit = {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/ReplaceHashWithSortAggSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/ReplaceHashWithSortAggSuite.scala
-index 47679ed7865..9ffbaecb98e 100644
+index 47679ed..9ffbaec 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ReplaceHashWithSortAggSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ReplaceHashWithSortAggSuite.scala
 @@ -18,6 +18,7 @@
@@ -1461,7 +1461,7 @@ index 47679ed7865..9ffbaecb98e 100644
      assert(collectWithSubqueries(plan) { case s: SortAggregateExec => s }.length == sortAggCount)
    }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
-index eec396b2e39..bf3f1c769d6 100644
+index eec396b..bf3f1c7 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
 @@ -18,7 +18,7 @@
@@ -1483,7 +1483,7 @@ index eec396b2e39..bf3f1c769d6 100644
      nums.createOrReplaceTempView("nums")
  
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
-index b14f4a405f6..90bed10eca9 100644
+index b14f4a4..90bed10 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
 @@ -23,6 +23,7 @@ import org.apache.spark.sql.QueryTest
@@ -1508,7 +1508,7 @@ index b14f4a405f6..90bed10eca9 100644
            spark.range(1).foreach { _ =>
              columnarToRowExec.canonicalized
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
-index ac710c32296..2854b433dd3 100644
+index ac710c3..2854b43 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
 @@ -17,7 +17,7 @@
@@ -1530,7 +1530,7 @@ index ac710c32296..2854b433dd3 100644
  
    import testImplicits._
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
-index 593bd7bb4ba..32af28b0238 100644
+index 593bd7b..84bd740 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
 @@ -26,9 +26,11 @@ import org.scalatest.time.SpanSugar._
@@ -1538,7 +1538,7 @@ index 593bd7bb4ba..32af28b0238 100644
  import org.apache.spark.SparkException
  import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListenerJobStart}
 -import org.apache.spark.sql.{Dataset, QueryTest, Row, SparkSession, Strategy}
-+import org.apache.spark.sql.{Dataset, IgnoreComet, QueryTest, Row, SparkSession, Strategy}
++import org.apache.spark.sql.{Dataset, IgnoreComet, IgnoreCometNativeDataFusion, QueryTest, Row, SparkSession, Strategy}
  import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
  import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan}
 +import org.apache.spark.sql.comet._
@@ -1798,7 +1798,37 @@ index 593bd7bb4ba..32af28b0238 100644
      withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
        val (_, adaptivePlan) = runAdaptiveAndVerifyResult(
          "SELECT key FROM testData GROUP BY key")
-@@ -1599,7 +1628,7 @@ class AdaptiveQueryExecSuite
+@@ -1525,7 +1554,8 @@ class AdaptiveQueryExecSuite
+     }
+   }
+ 
+-  test("SPARK-35585: Support propagate empty relation through project/filter") {
++  test("SPARK-35585: Support propagate empty relation through project/filter",
++    IgnoreCometNativeDataFusion("CometHashAggregate prevents AQE empty relation propagation")) {
+     withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+       val (plan1, adaptivePlan1) = runAdaptiveAndVerifyResult(
+@@ -1541,7 +1571,8 @@ class AdaptiveQueryExecSuite
+     }
+   }
+ 
+-  test("SPARK-35442: Support propagate empty relation through aggregate") {
++  test("SPARK-35442: Support propagate empty relation through aggregate",
++    IgnoreCometNativeDataFusion("CometHashAggregate prevents AQE empty relation propagation")) {
+     withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
+       val (plan1, adaptivePlan1) = runAdaptiveAndVerifyResult(
+         "SELECT key, count(*) FROM testData WHERE value = 'no_match' GROUP BY key")
+@@ -1560,7 +1591,8 @@ class AdaptiveQueryExecSuite
+     }
+   }
+ 
+-  test("SPARK-35442: Support propagate empty relation through union") {
++  test("SPARK-35442: Support propagate empty relation through union",
++    IgnoreCometNativeDataFusion("CometHashAggregate prevents AQE empty relation propagation")) {
+     def checkNumUnion(plan: SparkPlan, numUnion: Int): Unit = {
+       assert(
+         collect(plan) {
+@@ -1599,7 +1631,7 @@ class AdaptiveQueryExecSuite
          val (_, adaptivePlan) = runAdaptiveAndVerifyResult(
            "SELECT id FROM v1 GROUP BY id DISTRIBUTE BY id")
          assert(collect(adaptivePlan) {
@@ -1807,7 +1837,7 @@ index 593bd7bb4ba..32af28b0238 100644
          }.length == 1)
        }
      }
-@@ -1679,7 +1708,8 @@ class AdaptiveQueryExecSuite
+@@ -1679,7 +1711,8 @@ class AdaptiveQueryExecSuite
      }
    }
  
@@ -1817,7 +1847,7 @@ index 593bd7bb4ba..32af28b0238 100644
      def hasRepartitionShuffle(plan: SparkPlan): Boolean = {
        find(plan) {
          case s: ShuffleExchangeLike =>
-@@ -1864,6 +1894,9 @@ class AdaptiveQueryExecSuite
+@@ -1864,6 +1897,9 @@ class AdaptiveQueryExecSuite
      def checkNoCoalescePartitions(ds: Dataset[Row], origin: ShuffleOrigin): Unit = {
        assert(collect(ds.queryExecution.executedPlan) {
          case s: ShuffleExchangeExec if s.shuffleOrigin == origin && s.numPartitions == 2 => s
@@ -1827,7 +1857,7 @@ index 593bd7bb4ba..32af28b0238 100644
        }.size == 1)
        ds.collect()
        val plan = ds.queryExecution.executedPlan
-@@ -1872,6 +1905,9 @@ class AdaptiveQueryExecSuite
+@@ -1872,6 +1908,9 @@ class AdaptiveQueryExecSuite
        }.isEmpty)
        assert(collect(plan) {
          case s: ShuffleExchangeExec if s.shuffleOrigin == origin && s.numPartitions == 2 => s
@@ -1837,7 +1867,17 @@ index 593bd7bb4ba..32af28b0238 100644
        }.size == 1)
        checkAnswer(ds, testData)
      }
-@@ -2028,7 +2064,8 @@ class AdaptiveQueryExecSuite
+@@ -1892,7 +1931,8 @@ class AdaptiveQueryExecSuite
+     }
+   }
+ 
+-  test("SPARK-34980: Support coalesce partition through union") {
++  test("SPARK-34980: Support coalesce partition through union",
++    IgnoreCometNativeDataFusion("CometHashAggregate prevents AQE partition coalescing")) {
+     def checkResultPartition(
+         df: Dataset[Row],
+         numUnion: Int,
+@@ -2028,7 +2068,8 @@ class AdaptiveQueryExecSuite
      }
    }
  
@@ -1847,7 +1887,7 @@ index 593bd7bb4ba..32af28b0238 100644
      withTempView("t1", "t2") {
        def checkJoinStrategy(shouldShuffleHashJoin: Boolean): Unit = {
          Seq("100", "100000").foreach { size =>
-@@ -2114,7 +2151,8 @@ class AdaptiveQueryExecSuite
+@@ -2114,7 +2155,8 @@ class AdaptiveQueryExecSuite
      }
    }
  
@@ -1857,7 +1897,7 @@ index 593bd7bb4ba..32af28b0238 100644
      withTempView("v") {
        withSQLConf(
          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
-@@ -2213,7 +2251,7 @@ class AdaptiveQueryExecSuite
+@@ -2213,7 +2255,7 @@ class AdaptiveQueryExecSuite
                runAdaptiveAndVerifyResult(s"SELECT $repartition key1 FROM skewData1 " +
                  s"JOIN skewData2 ON key1 = key2 GROUP BY key1")
              val shuffles1 = collect(adaptive1) {
@@ -1866,7 +1906,7 @@ index 593bd7bb4ba..32af28b0238 100644
              }
              assert(shuffles1.size == 3)
              // shuffles1.head is the top-level shuffle under the Aggregate operator
-@@ -2226,7 +2264,7 @@ class AdaptiveQueryExecSuite
+@@ -2226,7 +2268,7 @@ class AdaptiveQueryExecSuite
                runAdaptiveAndVerifyResult(s"SELECT $repartition key1 FROM skewData1 " +
                  s"JOIN skewData2 ON key1 = key2")
              val shuffles2 = collect(adaptive2) {
@@ -1875,7 +1915,7 @@ index 593bd7bb4ba..32af28b0238 100644
              }
              if (hasRequiredDistribution) {
                assert(shuffles2.size == 3)
-@@ -2260,7 +2298,8 @@ class AdaptiveQueryExecSuite
+@@ -2260,7 +2302,8 @@ class AdaptiveQueryExecSuite
      }
    }
  
@@ -1885,7 +1925,7 @@ index 593bd7bb4ba..32af28b0238 100644
      CostEvaluator.instantiate(
        classOf[SimpleShuffleSortCostEvaluator].getCanonicalName, spark.sparkContext.getConf)
      intercept[IllegalArgumentException] {
-@@ -2404,6 +2443,7 @@ class AdaptiveQueryExecSuite
+@@ -2404,6 +2447,7 @@ class AdaptiveQueryExecSuite
            val (_, adaptive) = runAdaptiveAndVerifyResult(query)
            assert(adaptive.collect {
              case sort: SortExec => sort
@@ -1893,7 +1933,7 @@ index 593bd7bb4ba..32af28b0238 100644
            }.size == 1)
            val read = collect(adaptive) {
              case read: AQEShuffleReadExec => read
-@@ -2421,7 +2461,8 @@ class AdaptiveQueryExecSuite
+@@ -2421,7 +2465,8 @@ class AdaptiveQueryExecSuite
      }
    }
  
@@ -1903,7 +1943,7 @@ index 593bd7bb4ba..32af28b0238 100644
      withTempView("v") {
        withSQLConf(
          SQLConf.ADAPTIVE_OPTIMIZE_SKEWS_IN_REBALANCE_PARTITIONS_ENABLED.key -> "true",
-@@ -2533,7 +2574,7 @@ class AdaptiveQueryExecSuite
+@@ -2533,7 +2578,7 @@ class AdaptiveQueryExecSuite
            runAdaptiveAndVerifyResult("SELECT key1 FROM skewData1 JOIN skewData2 ON key1 = key2 " +
              "JOIN skewData3 ON value2 = value3")
          val shuffles1 = collect(adaptive1) {
@@ -1912,7 +1952,7 @@ index 593bd7bb4ba..32af28b0238 100644
          }
          assert(shuffles1.size == 4)
          val smj1 = findTopLevelSortMergeJoin(adaptive1)
-@@ -2544,7 +2585,7 @@ class AdaptiveQueryExecSuite
+@@ -2544,7 +2589,7 @@ class AdaptiveQueryExecSuite
            runAdaptiveAndVerifyResult("SELECT key1 FROM skewData1 JOIN skewData2 ON key1 = key2 " +
              "JOIN skewData3 ON value1 = value3")
          val shuffles2 = collect(adaptive2) {
@@ -1922,7 +1962,7 @@ index 593bd7bb4ba..32af28b0238 100644
          assert(shuffles2.size == 4)
          val smj2 = findTopLevelSortMergeJoin(adaptive2)
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
-index bd9c79e5b96..2ada8c28842 100644
+index bd9c79e..2ada8c2 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
 @@ -27,6 +27,7 @@ import org.apache.spark.sql.catalyst.SchemaPruningTest
@@ -1943,7 +1983,7 @@ index bd9c79e5b96..2ada8c28842 100644
      assert(fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
        s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
-index ce43edb79c1..8436cb727c6 100644
+index ce43edb..8436cb7 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
 @@ -17,9 +17,10 @@
@@ -1985,7 +2025,7 @@ index ce43edb79c1..8436cb727c6 100644
        withTable("t") {
          sql(
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
-index 1d2e467c94c..3ea82cd1a3f 100644
+index 1d2e467..3ea82cd 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
 @@ -28,7 +28,7 @@ import org.apache.hadoop.fs.{FileStatus, FileSystem, GlobFilter, Path}
@@ -2009,7 +2049,7 @@ index 1d2e467c94c..3ea82cd1a3f 100644
  
    private var testDir: String = _
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala
-index 07e2849ce6f..3e73645b638 100644
+index 07e2849..3e73645 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala
 @@ -28,7 +28,7 @@ import org.apache.parquet.hadoop.ParquetOutputFormat
@@ -2184,7 +2224,7 @@ index 104b4e416cd..b8af360fa14 100644
          case _ =>
            throw new AnalysisException("Can not match ParquetTable in the query.")
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
-index 8670d95c65e..c7ba51f770f 100644
+index 8670d95..c7ba51f 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
 @@ -41,6 +41,7 @@ import org.apache.parquet.schema.{MessageType, MessageTypeParser}
@@ -2226,7 +2266,7 @@ index 8670d95c65e..c7ba51f770f 100644
        checkAnswer(
          // "fruit" column in this file is encoded using DELTA_LENGTH_BYTE_ARRAY.
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
-index 29cb224c878..ee5a87fa200 100644
+index 29cb224..ee5a87f 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
 @@ -27,6 +27,7 @@ import org.apache.parquet.hadoop.ParquetOutputFormat
@@ -2307,7 +2347,7 @@ index 29cb224c878..ee5a87fa200 100644
      }
    }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRebaseDatetimeSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRebaseDatetimeSuite.scala
-index 240bb4e6dcb..8287ffa03ca 100644
+index 240bb4e..8287ffa 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRebaseDatetimeSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRebaseDatetimeSuite.scala
 @@ -21,7 +21,7 @@ import java.nio.file.{Files, Paths, StandardCopyOption}
@@ -2332,7 +2372,7 @@ index 240bb4e6dcb..8287ffa03ca 100644
  
    import testImplicits._
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
-index 351c6d698fc..583d9225cca 100644
+index 351c6d6..583d922 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
 @@ -20,12 +20,14 @@ import java.io.File
@@ -2382,7 +2422,7 @@ index 351c6d698fc..583d9225cca 100644
          withTempPath{ path =>
            val df = spark.range(0, 10, 1, 1).toDF("id")
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruningSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruningSuite.scala
-index 5c0b7def039..151184bc98c 100644
+index 5c0b7de..151184b 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruningSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruningSuite.scala
 @@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.datasources.parquet
@@ -2402,7 +2442,7 @@ index 5c0b7def039..151184bc98c 100644
      assert(fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
        s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
-index bf5c51b89bb..4e2f0bdb389 100644
+index bf5c51b..4e2f0bd 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
 @@ -27,6 +27,7 @@ import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
@@ -2444,7 +2484,7 @@ index bf5c51b89bb..4e2f0bdb389 100644
  
      withTempPath { dir =>
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
-index 3a0bd35cb70..b28f06a757f 100644
+index 3a0bd35..b28f06a 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
 @@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.debug
@@ -2466,7 +2506,7 @@ index 3a0bd35cb70..b28f06a757f 100644
        val workDirPath = workDir.getAbsolutePath
        val input = spark.range(5).toDF("id")
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
-index 26e61c6b58d..cb09d7e116a 100644
+index 26e61c6..cb09d7e 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
 @@ -45,8 +45,10 @@ import org.apache.spark.sql.util.QueryExecutionListener
@@ -2492,7 +2532,7 @@ index 26e61c6b58d..cb09d7e116a 100644
        spark.range(10).selectExpr("id", "id % 3 as p")
          .write.partitionBy("p").saveAsTable("testDataForScan")
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
-index 0ab8691801d..b18a5bea944 100644
+index 0ab8691..b18a5be 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
 @@ -18,6 +18,7 @@
@@ -2550,7 +2590,7 @@ index 0ab8691801d..b18a5bea944 100644
            assert(scanNodes.length == 1)
            // $"a" is not null and $"a" > 1
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
-index d083cac48ff..3c11bcde807 100644
+index d083cac..3c11bcd 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
 @@ -37,8 +37,10 @@ import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryException,
@@ -2566,7 +2606,7 @@ index d083cac48ff..3c11bcde807 100644
    import testImplicits._
  
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
-index 266bb343526..f8ad838e2b2 100644
+index 266bb34..f8ad838 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
 @@ -19,15 +19,18 @@ package org.apache.spark.sql.sources
@@ -2765,7 +2805,7 @@ index 266bb343526..f8ad838e2b2 100644
              assert(scans.isEmpty)
            }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
-index b5f6d2f9f68..277784a92af 100644
+index b5f6d2f..277784a 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
 @@ -20,7 +20,7 @@ package org.apache.spark.sql.sources
@@ -2790,7 +2830,7 @@ index b5f6d2f9f68..277784a92af 100644
  
    protected override lazy val sql = spark.sql _
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala
-index 1f55742cd67..f20129d9dd8 100644
+index 1f55742..f20129d 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala
 @@ -20,6 +20,7 @@ package org.apache.spark.sql.sources
@@ -2815,7 +2855,7 @@ index 1f55742cd67..f20129d9dd8 100644
      }
  
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
-index 75f440caefc..36b1146bc3a 100644
+index 75f440c..36b1146 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
 @@ -34,6 +34,7 @@ import org.apache.spark.paths.SparkPath
@@ -2836,7 +2876,7 @@ index 75f440caefc..36b1146bc3a 100644
          fail(s"No FileScan in query\n${df.queryExecution}")
        }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsWithStateSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsWithStateSuite.scala
-index 6aa7d0945c7..ad26ad833e2 100644
+index 6aa7d09..ad26ad8 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsWithStateSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsWithStateSuite.scala
 @@ -46,6 +46,7 @@ case class RunningCount(count: Long)
@@ -2848,7 +2888,7 @@ index 6aa7d0945c7..ad26ad833e2 100644
  class FlatMapGroupsWithStateSuite extends StateStoreMetricsTest {
  
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
-index ef5b8a769fe..84fe1bfabc9 100644
+index ef5b8a7..84fe1bf 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
 @@ -37,6 +37,7 @@ import org.apache.spark.sql._
@@ -2884,7 +2924,7 @@ index ef5b8a769fe..84fe1bfabc9 100644
        }
      }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationDistributionSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationDistributionSuite.scala
-index b4c4ec7acbf..20579284856 100644
+index b4c4ec7..2057928 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationDistributionSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationDistributionSuite.scala
 @@ -23,6 +23,7 @@ import org.apache.commons.io.FileUtils
@@ -2912,7 +2952,7 @@ index b4c4ec7acbf..20579284856 100644
  
          val aggregateExecsWithoutPartialAgg = allAggregateExecs.filter {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
-index 4d92e270539..33f1c2eb75e 100644
+index 4d92e27..33f1c2e 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
 @@ -31,7 +31,7 @@ import org.apache.spark.scheduler.ExecutorCacheTaskLocation
@@ -2962,7 +3002,7 @@ index 4d92e270539..33f1c2eb75e 100644
    }
  
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
-index abe606ad9c1..2d930b64cca 100644
+index abe606a..2d930b6 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
 @@ -22,7 +22,7 @@ import java.util
@@ -2985,7 +3025,7 @@ index abe606ad9c1..2d930b64cca 100644
      val tblTargetName = "tbl_target"
      val tblSourceQualified = s"default.$tblSourceName"
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
-index dd55fcfe42c..99bc018008a 100644
+index dd55fcf..99bc018 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
 @@ -27,6 +27,7 @@ import scala.concurrent.duration._
@@ -3079,7 +3119,7 @@ index dd55fcfe42c..99bc018008a 100644
  
      spark.internalCreateDataFrame(withoutFilters.execute(), schema)
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala b/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
-index ed2e309fa07..a5ea58146ad 100644
+index ed2e309..a5ea581 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
 @@ -74,6 +74,31 @@ trait SharedSparkSessionBase
@@ -3115,7 +3155,7 @@ index ed2e309fa07..a5ea58146ad 100644
        StaticSQLConf.WAREHOUSE_PATH,
        conf.get(StaticSQLConf.WAREHOUSE_PATH) + "/" + getClass.getCanonicalName)
 diff --git a/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceWithActualMetricsSuite.scala b/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceWithActualMetricsSuite.scala
-index 1510e8957f9..7618419d8ff 100644
+index 1510e89..7618419 100644
 --- a/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceWithActualMetricsSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceWithActualMetricsSuite.scala
 @@ -43,7 +43,7 @@ class SqlResourceWithActualMetricsSuite
@@ -3128,7 +3168,7 @@ index 1510e8957f9..7618419d8ff 100644
    implicit val formats = new DefaultFormats {
      override def dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
 diff --git a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
-index 52abd248f3a..7a199931a08 100644
+index 52abd24..7a19993 100644
 --- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
 +++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
 @@ -19,6 +19,7 @@ package org.apache.spark.sql.hive
@@ -3150,7 +3190,7 @@ index 52abd248f3a..7a199931a08 100644
          case d: DynamicPruningExpression => d.child
        }
 diff --git a/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionedTablePerfStatsSuite.scala b/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionedTablePerfStatsSuite.scala
-index de3b1ffccf0..2a76d127093 100644
+index de3b1ff..2a76d12 100644
 --- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionedTablePerfStatsSuite.scala
 +++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionedTablePerfStatsSuite.scala
 @@ -23,14 +23,15 @@ import java.util.concurrent.{Executors, TimeUnit}
@@ -3172,7 +3212,7 @@ index de3b1ffccf0..2a76d127093 100644
    override def beforeEach(): Unit = {
      super.beforeEach()
 diff --git a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
-index a902cb3a69e..800a3acbe99 100644
+index a902cb3..800a3ac 100644
 --- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
 +++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
 @@ -24,6 +24,7 @@ import java.sql.{Date, Timestamp}
@@ -3200,7 +3240,7 @@ index a902cb3a69e..800a3acbe99 100644
  
    test("SPARK-4963 DataFrame sample on mutable row return wrong result") {
 diff --git a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
-index 07361cfdce9..97dab2a3506 100644
+index 07361cf..97dab2a 100644
 --- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
 +++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
 @@ -55,25 +55,54 @@ object TestHive

--- a/dev/diffs/3.4.3.diff
+++ b/dev/diffs/3.4.3.diff
@@ -501,6 +501,16 @@ diff --git a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala b/s
 index a6b2955..91acca4 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+@@ -267,7 +267,8 @@ trait ExplainSuiteHelper extends QueryTest with SharedSparkSession {
+     }
+   }
+ 
+-  test("SPARK-33853: explain codegen - check presence of subquery") {
++  test("SPARK-33853: explain codegen - check presence of subquery",
++      IgnoreComet("Comet replaces WholeStageCodegen subtrees with native operators")) {
+     withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true") {
+       withTempView("df") {
+         val df1 = spark.range(1, 100)
 @@ -463,7 +463,8 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
      }
    }
@@ -2483,6 +2493,28 @@ index bf5c51b..4e2f0bd 100644
      import testImplicits._
  
      withTempPath { dir =>
+diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+index placeholder..placeholder 100644
+--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
++++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+@@ -38,6 +38,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
+ import org.apache.spark.sql.catalyst.InternalRow
+ import org.apache.spark.sql.catalyst.expressions.Attribute
+ import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
++import org.apache.spark.sql.IgnoreComet
+ import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
+ import org.apache.spark.sql.catalyst.util.quietly
+ import org.apache.spark.sql.connector.{CSVDataWriter, CSVDataWriterFactory, RangeInputPartition, SimpleScanBuilder, SimpleWritableDataSource, TestLocalScanTable}
+@@ -701,7 +702,8 @@ abstract class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTest
+     assert(statusStore.execution(2) === None)
+   }
+ 
+-  test("SPARK-29894 test Codegen Stage Id in SparkPlanInfo",
++  test("SPARK-29894 test Codegen Stage Id in SparkPlanInfo",
++    IgnoreComet("Comet replaces WholeStageCodegen with native operators"),
+     DisableAdaptiveExecution("WSCG rule is applied later in AQE")) {
+     // with AQE on, the WholeStageCodegen rule is applied when running QueryStageExec.
+     val df = createTestDataFrame.select(count("*"))
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
 index 3a0bd35..b28f06a 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
@@ -2495,7 +2527,27 @@ index 3a0bd35..b28f06a 100644
  import org.apache.spark.sql.catalyst.InternalRow
  import org.apache.spark.sql.catalyst.expressions.Attribute
  import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
-@@ -124,7 +125,8 @@ class DebuggingSuite extends DebuggingSuiteBase with DisableAdaptiveExecutionSui
+@@ -46,7 +47,8 @@ abstract class DebuggingSuiteBase extends SharedSparkSession {
+     testData.as[TestData].debug()
+   }
+ 
+-  test("debugCodegen") {
++  test("debugCodegen",
++      IgnoreComet("Comet replaces WholeStageCodegen subtrees with native operators")) {
+     val df = spark.range(10).groupBy(col("id") * 2).count()
+     df.collect()
+     val res = codegenString(df.queryExecution.executedPlan)
+@@ -53,7 +55,8 @@ abstract class DebuggingSuiteBase extends SharedSparkSession {
+     assert(res.contains("Object[]"))
+   }
+ 
+-  test("debugCodegenStringSeq") {
++  test("debugCodegenStringSeq",
++      IgnoreComet("Comet replaces WholeStageCodegen subtrees with native operators")) {
+     val df = spark.range(10).groupBy(col("id") * 2).count()
+     df.collect()
+     val res = codegenStringSeq(df.queryExecution.executedPlan)
+@@ -124,7 +129,8 @@ class DebuggingSuite extends DebuggingSuiteBase with DisableAdaptiveExecutionSui
           | id LongType: {}""".stripMargin))
    }
  

--- a/dev/diffs/3.5.8.diff
+++ b/dev/diffs/3.5.8.diff
@@ -1466,7 +1466,7 @@ index 2f8e401e743..a4f94417dcc 100644
  import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListenerJobStart}
  import org.apache.spark.shuffle.sort.SortShuffleManager
 -import org.apache.spark.sql.{Dataset, QueryTest, Row, SparkSession, Strategy}
-+import org.apache.spark.sql.{Dataset, IgnoreComet, QueryTest, Row, SparkSession, Strategy}
++import org.apache.spark.sql.{Dataset, IgnoreComet, IgnoreCometNativeDataFusion, QueryTest, Row, SparkSession, Strategy}
  import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
  import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan}
 +import org.apache.spark.sql.comet._
@@ -1885,6 +1885,46 @@ index 2f8e401e743..a4f94417dcc 100644
        plan.inputPlan.output.zip(plan.finalPhysicalPlan.output).foreach { case (o1, o2) =>
          assert(o1.semanticEquals(o2), "Different output column order after AQE optimization")
        }
+@@ -1551,7 +1553,8 @@ class AdaptiveQueryExecSuite
+     }
+   }
+ 
+-  test("SPARK-35585: Support propagate empty relation through project/filter") {
++  test("SPARK-35585: Support propagate empty relation through project/filter",
++    IgnoreCometNativeDataFusion("CometHashAggregate prevents AQE empty relation propagation")) {
+     withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+       val (plan1, adaptivePlan1) = runAdaptiveAndVerifyResult(
+@@ -1567,7 +1570,8 @@ class AdaptiveQueryExecSuite
+     }
+   }
+ 
+-  test("SPARK-35442: Support propagate empty relation through aggregate") {
++  test("SPARK-35442: Support propagate empty relation through aggregate",
++    IgnoreCometNativeDataFusion("CometHashAggregate prevents AQE empty relation propagation")) {
+     withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
+       val (plan1, adaptivePlan1) = runAdaptiveAndVerifyResult(
+         "SELECT key, count(*) FROM testData WHERE value = 'no_match' GROUP BY key")
+@@ -1586,7 +1590,8 @@ class AdaptiveQueryExecSuite
+     }
+   }
+ 
+-  test("SPARK-35442: Support propagate empty relation through union") {
++  test("SPARK-35442: Support propagate empty relation through union",
++    IgnoreCometNativeDataFusion("CometHashAggregate prevents AQE empty relation propagation")) {
+     def checkNumUnion(plan: SparkPlan, numUnion: Int): Unit = {
+       assert(
+         collect(plan) {
+@@ -1918,7 +1923,8 @@ class AdaptiveQueryExecSuite
+     }
+   }
+ 
+-  test("SPARK-34980: Support coalesce partition through union") {
++  test("SPARK-34980: Support coalesce partition through union",
++    IgnoreCometNativeDataFusion("CometHashAggregate prevents AQE partition coalescing")) {
+     def checkResultPartition(
+         df: Dataset[Row],
+         numUnion: Int,
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
 index fd52d038ca6..154c800be67 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala

--- a/dev/diffs/3.5.8.diff
+++ b/dev/diffs/3.5.8.diff
@@ -472,7 +472,17 @@ diff --git a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala b/s
 index a206e97c353..fea1149b67d 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
-@@ -467,7 +467,8 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
+@@ -267,7 +267,8 @@ trait ExplainSuiteHelper extends QueryTest with SharedSparkSession {
+     }
+   }
+ 
+-  test("SPARK-33853: explain codegen - check presence of subquery") {
++  test("SPARK-33853: explain codegen - check presence of subquery",
++      IgnoreComet("Comet replaces WholeStageCodegen subtrees with native operators")) {
+     withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true") {
+       withTempView("df") {
+         val df1 = spark.range(1, 100)
+@@ -467,7 +468,8 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
      }
    }
  
@@ -2411,6 +2421,28 @@ index 3f47c5e506f..f1ce3194279 100644
      import testImplicits._
  
      withTempPath { dir =>
+diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+index placeholder..placeholder 100644
+--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
++++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+@@ -38,6 +38,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
+ import org.apache.spark.sql.catalyst.InternalRow
+ import org.apache.spark.sql.catalyst.expressions.Attribute
+ import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
++import org.apache.spark.sql.IgnoreComet
+ import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
+ import org.apache.spark.sql.catalyst.util.quietly
+ import org.apache.spark.sql.connector.{CSVDataWriter, CSVDataWriterFactory, RangeInputPartition, SimpleScanBuilder, SimpleWritableDataSource, TestLocalScanTable}
+@@ -701,7 +702,8 @@ abstract class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTest
+     assert(statusStore.execution(2) === None)
+   }
+ 
+-  test("SPARK-29894 test Codegen Stage Id in SparkPlanInfo",
++  test("SPARK-29894 test Codegen Stage Id in SparkPlanInfo",
++    IgnoreComet("Comet replaces WholeStageCodegen with native operators"),
+     DisableAdaptiveExecution("WSCG rule is applied later in AQE")) {
+     // with AQE on, the WholeStageCodegen rule is applied when running QueryStageExec.
+     val df = createTestDataFrame.select(count("*"))
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
 index b8f3ea3c6f3..bbd44221288 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
@@ -2423,7 +2455,27 @@ index b8f3ea3c6f3..bbd44221288 100644
  import org.apache.spark.sql.catalyst.InternalRow
  import org.apache.spark.sql.catalyst.expressions.Attribute
  import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
-@@ -125,7 +126,8 @@ class DebuggingSuite extends DebuggingSuiteBase with DisableAdaptiveExecutionSui
+@@ -46,7 +47,8 @@ abstract class DebuggingSuiteBase extends SharedSparkSession {
+     testData.as[TestData].debug()
+   }
+ 
+-  test("debugCodegen") {
++  test("debugCodegen",
++      IgnoreComet("Comet replaces WholeStageCodegen subtrees with native operators")) {
+     val df = spark.range(10).groupBy(col("id") * 2).count()
+     df.collect()
+     val res = codegenString(df.queryExecution.executedPlan)
+@@ -53,7 +55,8 @@ abstract class DebuggingSuiteBase extends SharedSparkSession {
+     assert(res.contains("Object[]"))
+   }
+ 
+-  test("debugCodegenStringSeq") {
++  test("debugCodegenStringSeq",
++      IgnoreComet("Comet replaces WholeStageCodegen subtrees with native operators")) {
+     val df = spark.range(10).groupBy(col("id") * 2).count()
+     df.collect()
+     val res = codegenStringSeq(df.queryExecution.executedPlan)
+@@ -125,7 +130,8 @@ class DebuggingSuite extends DebuggingSuiteBase with DisableAdaptiveExecutionSui
           | id LongType: {}""".stripMargin))
    }
  

--- a/dev/diffs/4.0.1.diff
+++ b/dev/diffs/4.0.1.diff
@@ -245,6 +245,20 @@ index aa3d02dc..c4f878d9 100644
  -- Test cases with unicode_rtrim.
  WITH t(c1) AS (SELECT replace(listagg(DISTINCT col1 COLLATE unicode_rtrim) COLLATE utf8_binary, ' ', '') FROM (VALUES ('xbc  '), ('xbc '), ('a'), ('xbc'))) SELECT len(c1), regexp_count(c1, 'a'), regexp_count(c1, 'xbc') FROM t;
  WITH t(c1) AS (SELECT listagg(col1) WITHIN GROUP (ORDER BY col1 COLLATE unicode_rtrim) FROM (VALUES ('abc '), ('abc\n'), ('abc'), ('x'))) SELECT replace(replace(c1, ' ', ''), '\n', '$') FROM t;
+diff --git a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/aggregates_part3.sql b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/aggregates_part3.sql
+index placeholder..placeholder 100644
+--- a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/aggregates_part3.sql
++++ b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/aggregates_part3.sql
+@@ -5,6 +5,9 @@
+ -- AGGREGATES [Part 3]
+ -- https://github.com/postgres/postgres/blob/REL_12_BETA2/src/test/regress/sql/aggregates.sql#L352-L605
+ 
++-- Disable Comet exec due to floating point precision difference
++--SET spark.comet.exec.enabled = false
++
+ -- Test aggregate operator with codegen on and off.
+ --CONFIG_DIM1 spark.sql.codegen.wholeStage=true
+ --CONFIG_DIM1 spark.sql.codegen.wholeStage=false,spark.sql.codegen.factoryMode=CODEGEN_ONLY
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/int4.sql b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/int4.sql
 index 3a409eea..26e9aaf2 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/int4.sql
@@ -288,6 +302,18 @@ index 0efe0877..f9df0400 100644
  -- load test data
  CREATE TABLE test_having (a int, b int, c string, d string) USING parquet;
  INSERT INTO test_having VALUES (0, 1, 'XXXX', 'A');
+diff --git a/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-count-bug.sql b/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-count-bug.sql
+index placeholder..placeholder 100644
+--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-count-bug.sql
++++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-count-bug.sql
+@@ -1,4 +1,7 @@
+ --ONLY_IF spark
++-- Disable Comet exec due to incorrect results with correlated IN subquery
++-- combined with OR and count(*) (count-bug decorrelation)
++--SET spark.comet.exec.enabled = false
+ create temporary view t1(c1, c2) as values (0, 1), (1, 2);
+ create temporary view t2(c1, c2) as values (0, 2), (0, 3);
+ create temporary view t3(c1, c2) as values (0, 3), (1, 4), (2, 5);
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-limit.sql b/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-limit.sql
 index 7c816d8a..b1551a2b 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-limit.sql

--- a/dev/diffs/4.0.1.diff
+++ b/dev/diffs/4.0.1.diff
@@ -686,6 +686,16 @@ diff --git a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala b/s
 index 9c90e010..fadf2f0f 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+@@ -267,7 +267,8 @@ trait ExplainSuiteHelper extends QueryTest with SharedSparkSession {
+     }
+   }
+ 
+-  test("SPARK-33853: explain codegen - check presence of subquery") {
++  test("SPARK-33853: explain codegen - check presence of subquery",
++      IgnoreComet("Comet replaces WholeStageCodegen subtrees with native operators")) {
+     withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true") {
+       withTempView("df") {
+         val df1 = spark.range(1, 100)
 @@ -470,7 +470,8 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
      }
    }
@@ -3358,6 +3368,29 @@ index 458b5dfc..d209f3c8 100644
  
    private def testWithTempDir(name: String)(block: File => Unit): Unit = test(name) {
      withTempDir { dir =>
+diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+index placeholder..placeholder 100644
+--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
++++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+@@ -38,6 +38,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
+ import org.apache.spark.sql.catalyst.InternalRow
+ import org.apache.spark.sql.catalyst.expressions.Attribute
+ import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
++import org.apache.spark.sql.IgnoreComet
+ import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
+ import org.apache.spark.sql.catalyst.util.quietly
+ import org.apache.spark.sql.connector.{CSVDataWriter, CSVDataWriterFactory, RangeInputPartition, SimpleScanBuilder, SimpleWritableDataSource, TestLocalScanTable}
+@@ -701,7 +702,8 @@ abstract class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTest
+     assert(statusStore.execution(2) === None)
+   }
+ 
+-  test("SPARK-29894 test Codegen Stage Id in SparkPlanInfo",
++  test("SPARK-29894 test Codegen Stage Id in SparkPlanInfo",
++    IgnoreComet("Comet replaces WholeStageCodegen with native operators"),
+     DisableAdaptiveExecution("WSCG rule is applied later in AQE")) {
+     // with AQE on, the WholeStageCodegen rule is applied when running QueryStageExec.
+     val df = createTestDataFrame.select(count("*"))
+
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
 index b8f3ea3c..bbd44221 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
@@ -3370,7 +3403,31 @@ index b8f3ea3c..bbd44221 100644
  import org.apache.spark.sql.catalyst.InternalRow
  import org.apache.spark.sql.catalyst.expressions.Attribute
  import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
-@@ -125,7 +126,8 @@ class DebuggingSuite extends DebuggingSuiteBase with DisableAdaptiveExecutionSui
+@@ -25,6 +26,38 @@ import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
+ import org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation
+ import org.apache.spark.sql.test.SharedSparkSession
+ 
++@@ -46,7 +47,8 @@ abstract class DebuggingSuiteBase extends SharedSparkSession {
++     testData.as[TestData].debug()
++   }
++ 
++-  test("debugCodegen") {
+++  test("debugCodegen",
+++      IgnoreComet("Comet replaces WholeStageCodegen subtrees with native operators")) {
++     val df = spark.range(10).groupBy(col("id") * 2).count()
++     df.collect()
++     val res = codegenString(df.queryExecution.executedPlan)
++@@ -53,7 +55,8 @@ abstract class DebuggingSuiteBase extends SharedSparkSession {
++     assert(res.contains("Object[]"))
++   }
++ 
++-  test("debugCodegenStringSeq") {
+++  test("debugCodegenStringSeq",
+++      IgnoreComet("Comet replaces WholeStageCodegen subtrees with native operators")) {
++     val df = spark.range(10).groupBy(col("id") * 2).count()
++     df.collect()
++     val res = codegenStringSeq(df.queryExecution.executedPlan)
+ @@ -125,7 +130,8 @@ class DebuggingSuite extends DebuggingSuiteBase with DisableAdaptiveExecutionSui
           | id LongType: {}""".stripMargin))
    }
  

--- a/dev/diffs/4.0.1.diff
+++ b/dev/diffs/4.0.1.diff
@@ -1,5 +1,5 @@
 diff --git a/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala b/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
-index 6c51bd4ff2e..e72ec1d26e2 100644
+index 6c51bd4f..e72ec1d2 100644
 --- a/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
 +++ b/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
 @@ -231,6 +231,11 @@ class FallbackStorageSuite extends SparkFunSuite with LocalSparkContext {
@@ -39,7 +39,7 @@ index 6c51bd4ff2e..e72ec1d26e2 100644
        withSpark(sc) { sc =>
          TestUtils.waitUntilExecutorsUp(sc, 2, 60000)
 diff --git a/pom.xml b/pom.xml
-index 22922143fc3..97332f7e6ac 100644
+index 22922143..97332f7e 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -148,6 +148,8 @@
@@ -78,7 +78,7 @@ index 22922143fc3..97332f7e6ac 100644
        <dependency>
          <groupId>org.apache.datasketches</groupId>
 diff --git a/sql/core/pom.xml b/sql/core/pom.xml
-index dcf6223a98b..0458a5bb640 100644
+index dcf6223a..0458a5bb 100644
 --- a/sql/core/pom.xml
 +++ b/sql/core/pom.xml
 @@ -90,6 +90,10 @@
@@ -93,7 +93,7 @@ index dcf6223a98b..0458a5bb640 100644
      <!--
        This spark-tags test-dep is needed even though it isn't used in this module, otherwise testing-cmds that exclude
 diff --git a/sql/core/src/main/scala/org/apache/spark/sql/classic/SparkSession.scala b/sql/core/src/main/scala/org/apache/spark/sql/classic/SparkSession.scala
-index 0015d7ff99e..dcbf0325904 100644
+index 0015d7ff..dcbf0325 100644
 --- a/sql/core/src/main/scala/org/apache/spark/sql/classic/SparkSession.scala
 +++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/SparkSession.scala
 @@ -1042,6 +1042,23 @@ object SparkSession extends SparkSessionCompanion with Logging {
@@ -131,7 +131,7 @@ index 0015d7ff99e..dcbf0325904 100644
          val extensionConfClass = Utils.classForName(extensionConfClassName)
          val extensionConf = extensionConfClass.getConstructor().newInstance()
 diff --git a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala
-index 4410fe50912..43bcce2a038 100644
+index 4410fe50..43bcce2a 100644
 --- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala
 +++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala
 @@ -19,6 +19,7 @@ package org.apache.spark.sql.execution
@@ -151,7 +151,7 @@ index 4410fe50912..43bcce2a038 100644
      }
      val childrenInfo = children.flatMap {
 diff --git a/sql/core/src/test/resources/sql-tests/analyzer-results/listagg-collations.sql.out b/sql/core/src/test/resources/sql-tests/analyzer-results/listagg-collations.sql.out
-index 7aca17dcb25..8afeb3b4a2f 100644
+index 7aca17dc..8afeb3b4 100644
 --- a/sql/core/src/test/resources/sql-tests/analyzer-results/listagg-collations.sql.out
 +++ b/sql/core/src/test/resources/sql-tests/analyzer-results/listagg-collations.sql.out
 @@ -64,15 +64,6 @@ WithCTE
@@ -171,7 +171,7 @@ index 7aca17dcb25..8afeb3b4a2f 100644
  WITH t(c1) AS (SELECT replace(listagg(DISTINCT col1 COLLATE unicode_rtrim) COLLATE utf8_binary, ' ', '') FROM (VALUES ('xbc  '), ('xbc '), ('a'), ('xbc'))) SELECT len(c1), regexp_count(c1, 'a'), regexp_count(c1, 'xbc') FROM t
  -- !query analysis
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/collations.sql b/sql/core/src/test/resources/sql-tests/inputs/collations.sql
-index 17815ed5dde..baad440b1ce 100644
+index 17815ed5..baad440b 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/collations.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/collations.sql
 @@ -1,3 +1,6 @@
@@ -182,7 +182,7 @@ index 17815ed5dde..baad440b1ce 100644
  
  -- Create a test table with data
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/decimalArithmeticOperations.sql b/sql/core/src/test/resources/sql-tests/inputs/decimalArithmeticOperations.sql
-index 13bbd9d81b7..541cdfb1e04 100644
+index 13bbd9d8..541cdfb1 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/decimalArithmeticOperations.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/decimalArithmeticOperations.sql
 @@ -15,6 +15,12 @@
@@ -199,7 +199,7 @@ index 13bbd9d81b7..541cdfb1e04 100644
  
  -- division, remainder and pmod by 0 return NULL
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/explain-aqe.sql b/sql/core/src/test/resources/sql-tests/inputs/explain-aqe.sql
-index 7aef901da4f..f3d6e18926d 100644
+index 7aef901d..f3d6e189 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/explain-aqe.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/explain-aqe.sql
 @@ -2,3 +2,4 @@
@@ -208,7 +208,7 @@ index 7aef901da4f..f3d6e18926d 100644
  --SET spark.sql.maxMetadataStringLength = 500
 +--SET spark.comet.enabled = false
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/explain-cbo.sql b/sql/core/src/test/resources/sql-tests/inputs/explain-cbo.sql
-index eeb2180f7a5..afd1b5ec289 100644
+index eeb2180f..afd1b5ec 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/explain-cbo.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/explain-cbo.sql
 @@ -1,5 +1,6 @@
@@ -219,7 +219,7 @@ index eeb2180f7a5..afd1b5ec289 100644
  CREATE TABLE explain_temp1(a INT, b INT) USING PARQUET;
  CREATE TABLE explain_temp2(c INT, d INT) USING PARQUET;
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/explain.sql b/sql/core/src/test/resources/sql-tests/inputs/explain.sql
-index 698ca009b4f..57d774a3617 100644
+index 698ca009..57d774a3 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/explain.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/explain.sql
 @@ -1,6 +1,7 @@
@@ -231,7 +231,7 @@ index 698ca009b4f..57d774a3617 100644
  -- Test tables
  CREATE table  explain_temp1 (key int, val int) USING PARQUET;
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/listagg-collations.sql b/sql/core/src/test/resources/sql-tests/inputs/listagg-collations.sql
-index aa3d02dc2fb..c4f878d9908 100644
+index aa3d02dc..c4f878d9 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/listagg-collations.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/listagg-collations.sql
 @@ -5,7 +5,9 @@ WITH t(c1) AS (SELECT listagg(col1) WITHIN GROUP (ORDER BY col1) FROM (VALUES ('
@@ -245,23 +245,8 @@ index aa3d02dc2fb..c4f878d9908 100644
  -- Test cases with unicode_rtrim.
  WITH t(c1) AS (SELECT replace(listagg(DISTINCT col1 COLLATE unicode_rtrim) COLLATE utf8_binary, ' ', '') FROM (VALUES ('xbc  '), ('xbc '), ('a'), ('xbc'))) SELECT len(c1), regexp_count(c1, 'a'), regexp_count(c1, 'xbc') FROM t;
  WITH t(c1) AS (SELECT listagg(col1) WITHIN GROUP (ORDER BY col1 COLLATE unicode_rtrim) FROM (VALUES ('abc '), ('abc\n'), ('abc'), ('x'))) SELECT replace(replace(c1, ' ', ''), '\n', '$') FROM t;
-diff --git a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/aggregates_part3.sql b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/aggregates_part3.sql
-index 0000000..0000000 100644
---- a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/aggregates_part3.sql
-+++ b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/aggregates_part3.sql
-@@ -6,6 +6,10 @@
- -- https://github.com/postgres/postgres/blob/REL_12_BETA2/src/test/regress/sql/aggregates.sql#L352-L605
-
- -- Test aggregate operator with codegen on and off.
-+
-+-- Floating-point precision difference between DataFusion and JVM for FILTER aggregates
-+--SET spark.comet.enabled = false
-+
- --CONFIG_DIM1 spark.sql.codegen.wholeStage=true
- --CONFIG_DIM1 spark.sql.codegen.wholeStage=false,spark.sql.codegen.factoryMode=CODEGEN_ONLY
- --CONFIG_DIM1 spark.sql.codegen.wholeStage=false,spark.sql.codegen.factoryMode=NO_CODEGEN
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/int4.sql b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/int4.sql
-index 3a409eea348..26e9aaf215c 100644
+index 3a409eea..26e9aaf2 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/int4.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/int4.sql
 @@ -6,6 +6,9 @@
@@ -275,7 +260,7 @@ index 3a409eea348..26e9aaf215c 100644
  
  -- [SPARK-28023] Trim the string when cast string type to other types
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/int8.sql b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/int8.sql
-index fac23b4a26f..98b12ae5ccc 100644
+index fac23b4a..98b12ae5 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/int8.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/int8.sql
 @@ -6,6 +6,10 @@
@@ -290,7 +275,7 @@ index fac23b4a26f..98b12ae5ccc 100644
  
  -- PostgreSQL implicitly casts string literals to data with integral types, but
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/select_having.sql b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/select_having.sql
-index 0efe0877e9b..f9df0400c99 100644
+index 0efe0877..f9df0400 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/select_having.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/select_having.sql
 @@ -6,6 +6,9 @@
@@ -304,7 +289,7 @@ index 0efe0877e9b..f9df0400c99 100644
  CREATE TABLE test_having (a int, b int, c string, d string) USING parquet;
  INSERT INTO test_having VALUES (0, 1, 'XXXX', 'A');
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-limit.sql b/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-limit.sql
-index 7c816d8a416..b1551a2b296 100644
+index 7c816d8a..b1551a2b 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-limit.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-limit.sql
 @@ -1,6 +1,23 @@
@@ -340,7 +325,7 @@ index 7c816d8a416..b1551a2b296 100644
  -- LIMIT on both parent and subquery sides
  SELECT *
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/view-schema-binding-config.sql b/sql/core/src/test/resources/sql-tests/inputs/view-schema-binding-config.sql
-index e803254ea64..74db78aee38 100644
+index e803254e..74db78ae 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/view-schema-binding-config.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/view-schema-binding-config.sql
 @@ -1,6 +1,9 @@
@@ -354,7 +339,7 @@ index e803254ea64..74db78aee38 100644
  SET spark.sql.legacy.viewSchemaBindingMode;
  
 diff --git a/sql/core/src/test/resources/sql-tests/inputs/view-schema-compensation.sql b/sql/core/src/test/resources/sql-tests/inputs/view-schema-compensation.sql
-index 21a3ce1e122..f4762ab98f0 100644
+index 21a3ce1e..f4762ab9 100644
 --- a/sql/core/src/test/resources/sql-tests/inputs/view-schema-compensation.sql
 +++ b/sql/core/src/test/resources/sql-tests/inputs/view-schema-compensation.sql
 @@ -1,5 +1,9 @@
@@ -368,7 +353,7 @@ index 21a3ce1e122..f4762ab98f0 100644
  
  -- In COMPENSATION views get invalidated if the type can't cast
 diff --git a/sql/core/src/test/resources/sql-tests/results/listagg-collations.sql.out b/sql/core/src/test/resources/sql-tests/results/listagg-collations.sql.out
-index 1f8c5822e7d..b7de4e28813 100644
+index 1f8c5822..b7de4e28 100644
 --- a/sql/core/src/test/resources/sql-tests/results/listagg-collations.sql.out
 +++ b/sql/core/src/test/resources/sql-tests/results/listagg-collations.sql.out
 @@ -40,14 +40,6 @@ struct<len(c1):int,regexp_count(c1, a):int,regexp_count(c1, b):int>
@@ -387,7 +372,7 @@ index 1f8c5822e7d..b7de4e28813 100644
  WITH t(c1) AS (SELECT replace(listagg(DISTINCT col1 COLLATE unicode_rtrim) COLLATE utf8_binary, ' ', '') FROM (VALUES ('xbc  '), ('xbc '), ('a'), ('xbc'))) SELECT len(c1), regexp_count(c1, 'a'), regexp_count(c1, 'xbc') FROM t
  -- !query schema
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
-index 0f42502f1d9..e9ff802141f 100644
+index 0f42502f..e9ff8021 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
 @@ -39,7 +39,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeConstants
@@ -432,7 +417,7 @@ index 0f42502f1d9..e9ff802141f 100644
  
        withTempView("t0", "t1", "t2") {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
-index 9db406ff12f..245e4caa319 100644
+index 9db406ff..245e4caa 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
 @@ -30,7 +30,7 @@ import org.apache.spark.sql.errors.DataTypeErrors.toSQLId
@@ -454,7 +439,7 @@ index 9db406ff12f..245e4caa319 100644
        assert(exchangePlans.length == 1)
      }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
-index ed182322aec..1ae6afa686a 100644
+index ed182322..1ae6afa6 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
 @@ -435,7 +435,9 @@ class DataFrameJoinSuite extends QueryTest
@@ -469,7 +454,7 @@ index ed182322aec..1ae6afa686a 100644
            spark.range(100).write.saveAsTable(s"$dbName.$table2Name")
  
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
-index 5b88eeefeca..d4f07bc182a 100644
+index 5b88eeef..d4f07bc1 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
 @@ -36,11 +36,12 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference,
@@ -529,7 +514,7 @@ index 5b88eeefeca..d4f07bc182a 100644
      assert(exchanges.size == 2)
    }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
-index 01e72daead4..0a8d1e8b9b9 100644
+index 01e72dae..0a8d1e8b 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
 @@ -24,8 +24,9 @@ import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression
@@ -567,7 +552,7 @@ index 01e72daead4..0a8d1e8b9b9 100644
            }
          case _ => false
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
-index 81713c777bc..b5f92ed9742 100644
+index 81713c77..b5f92ed9 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
 @@ -46,7 +46,7 @@ import org.apache.spark.sql.catalyst.trees.DataFrameQueryContext
@@ -589,7 +574,7 @@ index 81713c777bc..b5f92ed9742 100644
      assert(exchanges.size == 2)
    }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
-index 2c24cc7d570..12096ea361e 100644
+index 2c24cc7d..12096ea3 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
 @@ -22,6 +22,7 @@ import org.scalatest.GivenWhenThen
@@ -698,7 +683,7 @@ index 2c24cc7d570..12096ea361e 100644
              }
            assert(scanOption.isDefined)
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
-index 9c90e0105a4..fadf2f0f698 100644
+index 9c90e010..fadf2f0f 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
 @@ -470,7 +470,8 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
@@ -886,7 +871,7 @@ index 00000000000..5691536c114
 +  }
 +}
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
-index 7d7185ae6c1..442a5bddeb8 100644
+index 7d7185ae..442a5bdd 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
 @@ -442,7 +442,8 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
@@ -910,7 +895,7 @@ index 7d7185ae6c1..442a5bddeb8 100644
        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "2000") {
        assertRewroteWithBloomFilter("select * from bf5part join bf2 on " +
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/JoinHintSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/JoinHintSuite.scala
-index 53e47f428c3..a55d8f0c161 100644
+index 53e47f42..a55d8f0c 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/JoinHintSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinHintSuite.scala
 @@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide
@@ -938,7 +923,7 @@ index 53e47f428c3..a55d8f0c161 100644
      assert(shuffleMergeJoins.size == 1)
    }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
-index aaac0ebc9aa..fbef0774d46 100644
+index aaac0ebc..fbef0774 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
 @@ -29,7 +29,8 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
@@ -1180,7 +1165,7 @@ index aaac0ebc9aa..fbef0774d46 100644
      withSQLConf(
        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "1") {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
-index ad424b3a7cc..4ece0117a34 100644
+index ad424b3a..4ece0117 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
 @@ -69,7 +69,7 @@ import org.apache.spark.tags.ExtendedSQLTest
@@ -1193,7 +1178,7 @@ index ad424b3a7cc..4ece0117a34 100644
    protected val baseResourcePath = {
      // use the same way as `SQLQueryTestSuite` to get the resource path
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
-index f294ff81021..8a3b818ee94 100644
+index f294ff81..8a3b818e 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
 @@ -1524,7 +1524,8 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
@@ -1249,8 +1234,19 @@ index f294ff81021..8a3b818ee94 100644
      withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
        SQLConf.ANSI_ENABLED.key -> "true") {
        withTable("t") {
+diff --git a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
++++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+@@ -165,5 +165,6 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession with SQLHelper
+   /** List of test cases to ignore, in lower cases. */
+   protected def ignoreList: Set[String] = Set(
+-    "ignored.sql" // Do NOT remove this one. It is here to test the ignore functionality.
++    "ignored.sql", // Do NOT remove this one. It is here to test the ignore functionality.
++    "charvarchar.sql" // INDETERMINATE_COLLATION error with Comet enabled
+   ) ++ otherIgnoreList
+   /** List of test cases that require TPCDS table schemas to be loaded. */
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
-index c1c041509c3..7d463e4b85e 100644
+index c1c04150..7d463e4b 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
 @@ -235,6 +235,8 @@ class SparkSessionExtensionSuite extends SparkFunSuite with SQLHelper with Adapt
@@ -1281,7 +1277,7 @@ index c1c041509c3..7d463e4b85e 100644
          extensions.injectColumnar(session =>
            MyColumnarRule(PreRuleReplaceAddWithBrokenVersion(), MyPostRule())) }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionJobTaggingAndCancellationSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionJobTaggingAndCancellationSuite.scala
-index 5ba69c8f9d9..ac1256afe88 100644
+index 5ba69c8f..ac1256af 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionJobTaggingAndCancellationSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionJobTaggingAndCancellationSuite.scala
 @@ -82,6 +82,10 @@ class SparkSessionJobTaggingAndCancellationSuite
@@ -1296,7 +1292,7 @@ index 5ba69c8f9d9..ac1256afe88 100644
      val session = classic.SparkSession.builder().sparkContext(sc).getOrCreate()
      import session.implicits._
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
-index 0df7f806272..92390bd819f 100644
+index 0df7f806..92390bd8 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
 @@ -17,6 +17,8 @@
@@ -1363,7 +1359,7 @@ index 0df7f806272..92390bd819f 100644
  
    test("non-matching optional group") {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
-index 2e33f6505ab..d0f84e8c44d 100644
+index 2e33f650..d0f84e8c 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
 @@ -23,12 +23,14 @@ import org.apache.spark.SparkRuntimeException
@@ -1456,7 +1452,7 @@ index 2e33f6505ab..d0f84e8c44d 100644
  
      withTable("t1", "t2") {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/VariantShreddingSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/VariantShreddingSuite.scala
-index fee375db10a..8c2c24e2c5f 100644
+index fee375db..8c2c24e2 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/VariantShreddingSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/VariantShreddingSuite.scala
 @@ -33,7 +33,9 @@ import org.apache.spark.sql.types._
@@ -1471,7 +1467,7 @@ index fee375db10a..8c2c24e2c5f 100644
      val v = VariantBuilder.parseJson(s, false)
      new VariantVal(v.getValue, v.getMetadata)
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
-index 11e9547dfc5..637411056ae 100644
+index 11e9547d..63741105 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
 @@ -24,6 +24,7 @@ import org.apache.spark.sql.{AnalysisException, Row}
@@ -1530,7 +1526,7 @@ index 11e9547dfc5..637411056ae 100644
              }
            }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
-index 3eeed2e4175..9f21d547c1c 100644
+index 3eeed2e4..9f21d547 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
 @@ -26,6 +26,7 @@ import test.org.apache.spark.sql.connector._
@@ -1593,7 +1589,7 @@ index 3eeed2e4175..9f21d547c1c 100644
                }
              }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/connector/FileDataSourceV2FallBackSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/connector/FileDataSourceV2FallBackSuite.scala
-index 2a0ab21ddb0..6030e7c2b9b 100644
+index 2a0ab21d..6030e7c2 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/connector/FileDataSourceV2FallBackSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/FileDataSourceV2FallBackSuite.scala
 @@ -21,6 +21,7 @@ import scala.collection.mutable.ArrayBuffer
@@ -1618,7 +1614,7 @@ index 2a0ab21ddb0..6030e7c2b9b 100644
          } finally {
            spark.listenerManager.unregister(listener)
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
-index c73e8e16fbb..399f1442ad5 100644
+index c73e8e16..399f1442 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
 @@ -24,6 +24,8 @@ import org.apache.spark.sql.{DataFrame, Row}
@@ -1665,7 +1661,7 @@ index c73e8e16fbb..399f1442ad5 100644
    }
  
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
-index f62e092138a..c0404bfe85e 100644
+index f62e0921..c0404bfe 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
 @@ -21,7 +21,7 @@ package org.apache.spark.sql.connector
@@ -1688,7 +1684,7 @@ index f62e092138a..c0404bfe85e 100644
  
    before {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
-index 04d33ecd3d5..450df347297 100644
+index 04d33ecd..450df347 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
 @@ -31,7 +31,7 @@ import org.mockito.Mockito.{mock, spy, when}
@@ -1711,7 +1707,7 @@ index 04d33ecd3d5..450df347297 100644
      // Fail to read ancient datetime values.
      withSQLConf(SQLConf.PARQUET_REBASE_MODE_IN_READ.key -> EXCEPTION.toString) {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala
-index 418ca3430bb..eb8267192f8 100644
+index 418ca343..eb826719 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala
 @@ -23,7 +23,7 @@ import scala.util.Random
@@ -1733,7 +1729,7 @@ index 418ca3430bb..eb8267192f8 100644
        withTempPath { path =>
          val dir = path.getCanonicalPath
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/InsertSortForLimitAndOffsetSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/InsertSortForLimitAndOffsetSuite.scala
-index d1b11a74cf3..75e4600863a 100644
+index d1b11a74..75e46008 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/InsertSortForLimitAndOffsetSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/InsertSortForLimitAndOffsetSuite.scala
 @@ -19,6 +19,7 @@ package org.apache.spark.sql.execution
@@ -1774,7 +1770,7 @@ index d1b11a74cf3..75e4600863a 100644
      }.isDefined
    }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/LogicalPlanTagInSparkPlanSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/LogicalPlanTagInSparkPlanSuite.scala
-index 743ec41dbe7..9f30d6c8e04 100644
+index 743ec41d..9f30d6c8 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/LogicalPlanTagInSparkPlanSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/LogicalPlanTagInSparkPlanSuite.scala
 @@ -53,6 +53,10 @@ class LogicalPlanTagInSparkPlanSuite extends TPCDSQuerySuite with DisableAdaptiv
@@ -1789,7 +1785,7 @@ index 743ec41dbe7..9f30d6c8e04 100644
      case _ => false
    }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
-index 1400ee25f43..5b016c3f9c5 100644
+index 1400ee25..5b016c3f 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
 @@ -19,7 +19,7 @@ package org.apache.spark.sql.execution
@@ -1813,7 +1809,7 @@ index 1400ee25f43..5b016c3f9c5 100644
  
    setupTestData()
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
-index 47d5ff67b84..8dc8f65d4b1 100644
+index 47d5ff67..8dc8f65d 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
 @@ -20,7 +20,7 @@ import scala.collection.mutable
@@ -1835,7 +1831,7 @@ index 47d5ff67b84..8dc8f65d4b1 100644
      withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantProjectsSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantProjectsSuite.scala
-index b5bac8079c4..9420dbdb936 100644
+index b5bac807..9420dbdb 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantProjectsSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantProjectsSuite.scala
 @@ -17,7 +17,10 @@
@@ -1909,7 +1905,7 @@ index b5bac8079c4..9420dbdb936 100644
  
        // Check the original plan's output and the new plan's output are the same.
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantSortsSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantSortsSuite.scala
-index 005e764cc30..92ec088efab 100644
+index 005e764c..92ec088e 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantSortsSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantSortsSuite.scala
 @@ -19,6 +19,7 @@ package org.apache.spark.sql.execution
@@ -1930,7 +1926,7 @@ index 005e764cc30..92ec088efab 100644
  
    private def checkSorts(query: String, enabledCount: Int, disabledCount: Int): Unit = {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/ReplaceHashWithSortAggSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/ReplaceHashWithSortAggSuite.scala
-index 47679ed7865..9ffbaecb98e 100644
+index 47679ed7..9ffbaecb 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ReplaceHashWithSortAggSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ReplaceHashWithSortAggSuite.scala
 @@ -18,6 +18,7 @@
@@ -1951,7 +1947,7 @@ index 47679ed7865..9ffbaecb98e 100644
      assert(collectWithSubqueries(plan) { case s: SortAggregateExec => s }.length == sortAggCount)
    }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
-index 77a988f340e..1acc534064e 100644
+index 77a988f3..1acc5340 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
 @@ -1061,7 +1061,8 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
@@ -1965,7 +1961,7 @@ index 77a988f340e..1acc534064e 100644
        Seq(2, 3, 1).toDF("c1").write.format("parquet").saveAsTable("t")
        withView("v1") {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
-index aed11badb71..1a365b5aacf 100644
+index aed11bad..1a365b5a 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
 @@ -23,6 +23,7 @@ import org.apache.spark.sql.QueryTest
@@ -1990,7 +1986,7 @@ index aed11badb71..1a365b5aacf 100644
            spark.range(1).foreach { _ =>
              columnarToRowExec.canonicalized
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
-index a3cfdc5a240..3793b6191bf 100644
+index a3cfdc5a..3793b619 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
 @@ -19,9 +19,10 @@ package org.apache.spark.sql.execution
@@ -2234,7 +2230,7 @@ index a3cfdc5a240..3793b6191bf 100644
        })
        checkAnswer(distinctWithId, Seq(Row(1, 0), Row(1, 0)))
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
-index 272be70f9fe..06957694002 100644
+index 272be70f..cdbf1623 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
 @@ -28,12 +28,14 @@ import org.apache.spark.SparkException
@@ -2242,7 +2238,7 @@ index 272be70f9fe..06957694002 100644
  import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListenerJobStart}
  import org.apache.spark.shuffle.sort.SortShuffleManager
 -import org.apache.spark.sql.{DataFrame, Dataset, QueryTest, Row, SparkSession}
-+import org.apache.spark.sql.{DataFrame, Dataset, IgnoreComet, QueryTest, Row, SparkSession}
++import org.apache.spark.sql.{DataFrame, Dataset, IgnoreComet, IgnoreCometNativeDataFusion, QueryTest, Row, SparkSession}
  import org.apache.spark.sql.catalyst.InternalRow
  import org.apache.spark.sql.catalyst.expressions.Attribute
  import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
@@ -2505,7 +2501,37 @@ index 272be70f9fe..06957694002 100644
      withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
        val (_, adaptivePlan) = runAdaptiveAndVerifyResult(
          "SELECT key FROM testData GROUP BY key")
-@@ -1721,7 +1750,7 @@ class AdaptiveQueryExecSuite
+@@ -1647,7 +1676,8 @@ class AdaptiveQueryExecSuite
+     }
+   }
+ 
+-  test("SPARK-35585: Support propagate empty relation through project/filter") {
++  test("SPARK-35585: Support propagate empty relation through project/filter",
++    IgnoreCometNativeDataFusion("CometHashAggregate prevents AQE empty relation propagation")) {
+     withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+       val (plan1, adaptivePlan1) = runAdaptiveAndVerifyResult(
+@@ -1663,7 +1693,8 @@ class AdaptiveQueryExecSuite
+     }
+   }
+ 
+-  test("SPARK-35442: Support propagate empty relation through aggregate") {
++  test("SPARK-35442: Support propagate empty relation through aggregate",
++    IgnoreCometNativeDataFusion("CometHashAggregate prevents AQE empty relation propagation")) {
+     withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
+       val (plan1, adaptivePlan1) = runAdaptiveAndVerifyResult(
+         "SELECT key, count(*) FROM testData WHERE value = 'no_match' GROUP BY key")
+@@ -1682,7 +1713,8 @@ class AdaptiveQueryExecSuite
+     }
+   }
+ 
+-  test("SPARK-35442: Support propagate empty relation through union") {
++  test("SPARK-35442: Support propagate empty relation through union",
++    IgnoreCometNativeDataFusion("CometHashAggregate prevents AQE empty relation propagation")) {
+     def checkNumUnion(plan: SparkPlan, numUnion: Int): Unit = {
+       assert(
+         collect(plan) {
+@@ -1721,7 +1753,7 @@ class AdaptiveQueryExecSuite
          val (_, adaptivePlan) = runAdaptiveAndVerifyResult(
            "SELECT id FROM v1 GROUP BY id DISTRIBUTE BY id")
          assert(collect(adaptivePlan) {
@@ -2514,7 +2540,7 @@ index 272be70f9fe..06957694002 100644
          }.length == 1)
        }
      }
-@@ -1801,7 +1830,8 @@ class AdaptiveQueryExecSuite
+@@ -1801,7 +1833,8 @@ class AdaptiveQueryExecSuite
      }
    }
  
@@ -2524,7 +2550,7 @@ index 272be70f9fe..06957694002 100644
      def hasRepartitionShuffle(plan: SparkPlan): Boolean = {
        find(plan) {
          case s: ShuffleExchangeLike =>
-@@ -1986,6 +2016,9 @@ class AdaptiveQueryExecSuite
+@@ -1986,6 +2019,9 @@ class AdaptiveQueryExecSuite
      def checkNoCoalescePartitions(ds: Dataset[Row], origin: ShuffleOrigin): Unit = {
        assert(collect(ds.queryExecution.executedPlan) {
          case s: ShuffleExchangeExec if s.shuffleOrigin == origin && s.numPartitions == 2 => s
@@ -2534,7 +2560,7 @@ index 272be70f9fe..06957694002 100644
        }.size == 1)
        ds.collect()
        val plan = ds.queryExecution.executedPlan
-@@ -1994,6 +2027,9 @@ class AdaptiveQueryExecSuite
+@@ -1994,6 +2030,9 @@ class AdaptiveQueryExecSuite
        }.isEmpty)
        assert(collect(plan) {
          case s: ShuffleExchangeExec if s.shuffleOrigin == origin && s.numPartitions == 2 => s
@@ -2544,7 +2570,17 @@ index 272be70f9fe..06957694002 100644
        }.size == 1)
        checkAnswer(ds, testData)
      }
-@@ -2150,7 +2186,8 @@ class AdaptiveQueryExecSuite
+@@ -2014,7 +2053,8 @@ class AdaptiveQueryExecSuite
+     }
+   }
+ 
+-  test("SPARK-34980: Support coalesce partition through union") {
++  test("SPARK-34980: Support coalesce partition through union",
++    IgnoreCometNativeDataFusion("CometHashAggregate prevents AQE partition coalescing")) {
+     def checkResultPartition(
+         df: Dataset[Row],
+         numUnion: Int,
+@@ -2150,7 +2190,8 @@ class AdaptiveQueryExecSuite
      }
    }
  
@@ -2554,7 +2590,7 @@ index 272be70f9fe..06957694002 100644
      withTempView("t1", "t2") {
        def checkJoinStrategy(shouldShuffleHashJoin: Boolean): Unit = {
          Seq("100", "100000").foreach { size =>
-@@ -2236,7 +2273,8 @@ class AdaptiveQueryExecSuite
+@@ -2236,7 +2277,8 @@ class AdaptiveQueryExecSuite
      }
    }
  
@@ -2564,7 +2600,7 @@ index 272be70f9fe..06957694002 100644
      withTempView("v") {
        withSQLConf(
          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
-@@ -2335,7 +2373,7 @@ class AdaptiveQueryExecSuite
+@@ -2335,7 +2377,7 @@ class AdaptiveQueryExecSuite
                runAdaptiveAndVerifyResult(s"SELECT $repartition key1 FROM skewData1 " +
                  s"JOIN skewData2 ON key1 = key2 GROUP BY key1")
              val shuffles1 = collect(adaptive1) {
@@ -2573,7 +2609,7 @@ index 272be70f9fe..06957694002 100644
              }
              assert(shuffles1.size == 3)
              // shuffles1.head is the top-level shuffle under the Aggregate operator
-@@ -2348,7 +2386,7 @@ class AdaptiveQueryExecSuite
+@@ -2348,7 +2390,7 @@ class AdaptiveQueryExecSuite
                runAdaptiveAndVerifyResult(s"SELECT $repartition key1 FROM skewData1 " +
                  s"JOIN skewData2 ON key1 = key2")
              val shuffles2 = collect(adaptive2) {
@@ -2582,7 +2618,7 @@ index 272be70f9fe..06957694002 100644
              }
              if (hasRequiredDistribution) {
                assert(shuffles2.size == 3)
-@@ -2382,7 +2420,8 @@ class AdaptiveQueryExecSuite
+@@ -2382,7 +2424,8 @@ class AdaptiveQueryExecSuite
      }
    }
  
@@ -2592,7 +2628,7 @@ index 272be70f9fe..06957694002 100644
      CostEvaluator.instantiate(
        classOf[SimpleShuffleSortCostEvaluator].getCanonicalName, spark.sparkContext.getConf)
      intercept[IllegalArgumentException] {
-@@ -2513,7 +2552,8 @@ class AdaptiveQueryExecSuite
+@@ -2513,7 +2556,8 @@ class AdaptiveQueryExecSuite
    }
  
    test("SPARK-48037: Fix SortShuffleWriter lacks shuffle write related metrics " +
@@ -2602,7 +2638,7 @@ index 272be70f9fe..06957694002 100644
      withTable("t3") {
        withSQLConf(
          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
-@@ -2548,6 +2588,7 @@ class AdaptiveQueryExecSuite
+@@ -2548,6 +2592,7 @@ class AdaptiveQueryExecSuite
            val (_, adaptive) = runAdaptiveAndVerifyResult(query)
            assert(adaptive.collect {
              case sort: SortExec => sort
@@ -2610,7 +2646,7 @@ index 272be70f9fe..06957694002 100644
            }.size == 1)
            val read = collect(adaptive) {
              case read: AQEShuffleReadExec => read
-@@ -2565,7 +2606,8 @@ class AdaptiveQueryExecSuite
+@@ -2565,7 +2610,8 @@ class AdaptiveQueryExecSuite
      }
    }
  
@@ -2620,7 +2656,7 @@ index 272be70f9fe..06957694002 100644
      withTempView("v") {
        withSQLConf(
          SQLConf.ADAPTIVE_OPTIMIZE_SKEWS_IN_REBALANCE_PARTITIONS_ENABLED.key -> "true",
-@@ -2677,7 +2719,7 @@ class AdaptiveQueryExecSuite
+@@ -2677,7 +2723,7 @@ class AdaptiveQueryExecSuite
            runAdaptiveAndVerifyResult("SELECT key1 FROM skewData1 JOIN skewData2 ON key1 = key2 " +
              "JOIN skewData3 ON value2 = value3")
          val shuffles1 = collect(adaptive1) {
@@ -2629,7 +2665,7 @@ index 272be70f9fe..06957694002 100644
          }
          assert(shuffles1.size == 4)
          val smj1 = findTopLevelSortMergeJoin(adaptive1)
-@@ -2688,7 +2730,7 @@ class AdaptiveQueryExecSuite
+@@ -2688,7 +2734,7 @@ class AdaptiveQueryExecSuite
            runAdaptiveAndVerifyResult("SELECT key1 FROM skewData1 JOIN skewData2 ON key1 = key2 " +
              "JOIN skewData3 ON value1 = value3")
          val shuffles2 = collect(adaptive2) {
@@ -2638,7 +2674,7 @@ index 272be70f9fe..06957694002 100644
          }
          assert(shuffles2.size == 4)
          val smj2 = findTopLevelSortMergeJoin(adaptive2)
-@@ -2946,6 +2988,7 @@ class AdaptiveQueryExecSuite
+@@ -2946,6 +2992,7 @@ class AdaptiveQueryExecSuite
          }.size == (if (firstAccess) 1 else 0))
          assert(collect(initialExecutedPlan) {
            case s: SortExec => s
@@ -2646,7 +2682,7 @@ index 272be70f9fe..06957694002 100644
          }.size == (if (firstAccess) 2 else 0))
          assert(collect(initialExecutedPlan) {
            case i: InMemoryTableScanLike => i
-@@ -2958,6 +3001,7 @@ class AdaptiveQueryExecSuite
+@@ -2958,6 +3005,7 @@ class AdaptiveQueryExecSuite
          }.isEmpty)
          assert(collect(finalExecutedPlan) {
            case s: SortExec => s
@@ -2655,7 +2691,7 @@ index 272be70f9fe..06957694002 100644
          assert(collect(initialExecutedPlan) {
            case i: InMemoryTableScanLike => i
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
-index 0a0b23d1e60..dcc9c141315 100644
+index 0a0b23d1..dcc9c141 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
 @@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.expressions.Concat
@@ -2676,7 +2712,7 @@ index 0a0b23d1e60..dcc9c141315 100644
      assert(fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
        s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
-index 80d771428d9..9327dca6c21 100644
+index 80d77142..9327dca6 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
 @@ -17,9 +17,10 @@
@@ -2718,7 +2754,7 @@ index 80d771428d9..9327dca6c21 100644
        withTable("t") {
          sql(
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
-index 62f2f2cb10a..feef4bb2928 100644
+index 62f2f2cb..feef4bb2 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
 @@ -28,7 +28,7 @@ import org.apache.hadoop.fs.{FileStatus, FileSystem, GlobFilter, Path}
@@ -2742,7 +2778,7 @@ index 62f2f2cb10a..feef4bb2928 100644
  
    private var testDir: String = _
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala
-index cd6f41b4ef4..4b6a17344bc 100644
+index cd6f41b4..4b6a1734 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala
 @@ -28,7 +28,7 @@ import org.apache.parquet.hadoop.ParquetOutputFormat
@@ -2918,7 +2954,7 @@ index 6080a5e8e4b..ea058d57b4b 100644
          case _ => assert(false, "Can not match ParquetTable in the query.")
        }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
-index 4474ec1fd42..05fa0257c82 100644
+index 4474ec1f..05fa0257 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
 @@ -39,6 +39,7 @@ import org.apache.parquet.schema.{MessageType, MessageTypeParser}
@@ -2950,7 +2986,7 @@ index 4474ec1fd42..05fa0257c82 100644
        checkAnswer(
          // "fruit" column in this file is encoded using DELTA_LENGTH_BYTE_ARRAY.
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
-index bba71f1c48d..0b52574e0f3 100644
+index bba71f1c..0b52574e 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
 @@ -27,6 +27,7 @@ import org.apache.parquet.hadoop.ParquetOutputFormat
@@ -3035,7 +3071,7 @@ index bba71f1c48d..0b52574e0f3 100644
        Seq(0).toDF("a").write.parquet(path.toString)
        withAllParquetReaders {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRebaseDatetimeSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRebaseDatetimeSuite.scala
-index 30503af0fab..1491f4bc2d5 100644
+index 30503af0..1491f4bc 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRebaseDatetimeSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRebaseDatetimeSuite.scala
 @@ -21,7 +21,7 @@ import java.nio.file.{Files, Paths, StandardCopyOption}
@@ -3060,7 +3096,7 @@ index 30503af0fab..1491f4bc2d5 100644
  
    import testImplicits._
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
-index 08fd8a9ecb5..24baf360234 100644
+index 08fd8a9e..24baf360 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
 @@ -20,6 +20,7 @@ import java.io.File
@@ -3134,7 +3170,7 @@ index 08fd8a9ecb5..24baf360234 100644
          withTempPath{ path =>
            val df = spark.range(0, 10, 1, 1).toDF("id")
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruningSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruningSuite.scala
-index 5c0b7def039..151184bc98c 100644
+index 5c0b7def..151184bc 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruningSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaPruningSuite.scala
 @@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.datasources.parquet
@@ -3154,7 +3190,7 @@ index 5c0b7def039..151184bc98c 100644
      assert(fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
        s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
-index 0acb21f3e6f..1f9c3fd13fc 100644
+index 0acb21f3..1f9c3fd1 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
 @@ -27,7 +27,7 @@ import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
@@ -3197,7 +3233,7 @@ index 0acb21f3e6f..1f9c3fd13fc 100644
  
      withTempPath { dir =>
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTypeWideningSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTypeWideningSuite.scala
-index 09ed6955a51..6f9174c9545 100644
+index 09ed6955..6f9174c9 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTypeWideningSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTypeWideningSuite.scala
 @@ -24,7 +24,7 @@ import org.apache.parquet.format.converter.ParquetMetadataConverter
@@ -3299,7 +3335,7 @@ index 09ed6955a51..6f9174c9545 100644
      checkAllParquetReaders(
        values = Seq("1.23", "10.34"),
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetVariantShreddingSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetVariantShreddingSuite.scala
-index 458b5dfc0f4..d209f3c85bc 100644
+index 458b5dfc..d209f3c8 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetVariantShreddingSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetVariantShreddingSuite.scala
 @@ -26,7 +26,7 @@ import org.apache.parquet.hadoop.util.HadoopInputFile
@@ -3323,7 +3359,7 @@ index 458b5dfc0f4..d209f3c85bc 100644
    private def testWithTempDir(name: String)(block: File => Unit): Unit = test(name) {
      withTempDir { dir =>
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
-index b8f3ea3c6f3..bbd44221288 100644
+index b8f3ea3c..bbd44221 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
 @@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.debug
@@ -3345,7 +3381,7 @@ index b8f3ea3c6f3..bbd44221288 100644
        val workDirPath = workDir.getAbsolutePath
        val input = spark.range(5).toDF("id")
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
-index 0dd90925d3c..7d53ec845ef 100644
+index 0dd90925..7d53ec84 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
 @@ -46,8 +46,10 @@ import org.apache.spark.sql.util.QueryExecutionListener
@@ -3371,7 +3407,7 @@ index 0dd90925d3c..7d53ec845ef 100644
        spark.range(10).selectExpr("id", "id % 3 as p")
          .write.partitionBy("p").saveAsTable("testDataForScan")
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
-index 0ab8691801d..b18a5bea944 100644
+index 0ab86918..b18a5bea 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
 @@ -18,6 +18,7 @@
@@ -3429,7 +3465,7 @@ index 0ab8691801d..b18a5bea944 100644
            assert(scanNodes.length == 1)
            // $"a" is not null and $"a" > 1
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
-index 7838e62013d..8fa09652921 100644
+index 7838e620..8fa09652 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
 @@ -37,8 +37,10 @@ import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryException,
@@ -3445,7 +3481,7 @@ index 7838e62013d..8fa09652921 100644
    import testImplicits._
  
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
-index c4b09c4b289..75c3437788e 100644
+index c4b09c4b..75c34377 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
 @@ -26,10 +26,11 @@ import org.apache.spark.sql.catalyst.expressions
@@ -3602,7 +3638,7 @@ index c4b09c4b289..75c3437788e 100644
                  assert(scans.isEmpty)
                }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
-index 95c2fcbd7b5..e2d4a20c5d9 100644
+index 95c2fcbd..e2d4a20c 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
 @@ -20,6 +20,7 @@ package org.apache.spark.sql.sources
@@ -3626,7 +3662,7 @@ index 95c2fcbd7b5..e2d4a20c5d9 100644
  
    protected override lazy val sql = spark.sql _
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala
-index c5c56f081d8..6cc51f93b4f 100644
+index c5c56f08..6cc51f93 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala
 @@ -18,6 +18,7 @@
@@ -3651,7 +3687,7 @@ index c5c56f081d8..6cc51f93b4f 100644
      }
  
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
-index 9742a004545..4e0417d730a 100644
+index 9742a004..4e0417d7 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
 @@ -34,6 +34,7 @@ import org.apache.spark.paths.SparkPath
@@ -3672,7 +3708,7 @@ index 9742a004545..4e0417d730a 100644
          fail(s"No FileScan in query\n${df.queryExecution}")
        }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
-index b0967d5ffdf..3d567f913de 100644
+index b0967d5f..3d567f91 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
 @@ -40,6 +40,7 @@ import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
@@ -3708,7 +3744,7 @@ index b0967d5ffdf..3d567f913de 100644
        }
      }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationDistributionSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationDistributionSuite.scala
-index b4c4ec7acbf..20579284856 100644
+index b4c4ec7a..20579284 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationDistributionSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationDistributionSuite.scala
 @@ -23,6 +23,7 @@ import org.apache.commons.io.FileUtils
@@ -3736,7 +3772,7 @@ index b4c4ec7acbf..20579284856 100644
  
          val aggregateExecsWithoutPartialAgg = allAggregateExecs.filter {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
-index d3c44dcead3..8096bce4436 100644
+index d3c44dce..8096bce4 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
 @@ -33,7 +33,7 @@ import org.apache.spark.sql.{DataFrame, Row, SparkSession}
@@ -3786,7 +3822,7 @@ index d3c44dcead3..8096bce4436 100644
    }
  
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
-index e33d4f1f6ab..ce0a21d1e9d 100644
+index e33d4f1f..ce0a21d1 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
 @@ -44,7 +44,7 @@ import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
@@ -3808,7 +3844,7 @@ index e33d4f1f6ab..ce0a21d1e9d 100644
  
          assert(shuffleOpt.nonEmpty, "No shuffle exchange found in the query plan")
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
-index 86c4e49f6f6..2e639e5f38d 100644
+index 86c4e49f..2e639e5f 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
 @@ -22,7 +22,7 @@ import java.util
@@ -3831,7 +3867,7 @@ index 86c4e49f6f6..2e639e5f38d 100644
      val tblTargetName = "tbl_target"
      val tblSourceQualified = s"default.$tblSourceName"
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
-index f0f3f94b811..f77b54dcef9 100644
+index f0f3f94b..f77b54dc 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
 @@ -27,13 +27,14 @@ import scala.jdk.CollectionConverters._
@@ -3928,7 +3964,7 @@ index f0f3f94b811..f77b54dcef9 100644
  
      spark.internalCreateDataFrame(withoutFilters.execute(), schema)
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala b/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
-index 245219c1756..a611836f086 100644
+index 245219c1..a611836f 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
 @@ -75,6 +75,27 @@ trait SharedSparkSessionBase
@@ -3960,7 +3996,7 @@ index 245219c1756..a611836f086 100644
        StaticSQLConf.WAREHOUSE_PATH,
        conf.get(StaticSQLConf.WAREHOUSE_PATH) + "/" + getClass.getCanonicalName)
 diff --git a/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceWithActualMetricsSuite.scala b/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceWithActualMetricsSuite.scala
-index 982d57fb287..6017f36c440 100644
+index 982d57fb..6017f36c 100644
 --- a/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceWithActualMetricsSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceWithActualMetricsSuite.scala
 @@ -46,7 +46,7 @@ class SqlResourceWithActualMetricsSuite
@@ -3973,7 +4009,7 @@ index 982d57fb287..6017f36c440 100644
    implicit val formats: DefaultFormats = new DefaultFormats {
      override def dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
 diff --git a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
-index 52abd248f3a..7a199931a08 100644
+index 52abd248..7a199931 100644
 --- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
 +++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
 @@ -19,6 +19,7 @@ package org.apache.spark.sql.hive
@@ -3995,7 +4031,7 @@ index 52abd248f3a..7a199931a08 100644
          case d: DynamicPruningExpression => d.child
        }
 diff --git a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveUDFDynamicLoadSuite.scala b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveUDFDynamicLoadSuite.scala
-index 4b27082e188..6710c90c789 100644
+index 4b27082e..6710c90c 100644
 --- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveUDFDynamicLoadSuite.scala
 +++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveUDFDynamicLoadSuite.scala
 @@ -147,7 +147,9 @@ class HiveUDFDynamicLoadSuite extends QueryTest with SQLTestUtils with TestHiveS
@@ -4010,7 +4046,7 @@ index 4b27082e188..6710c90c789 100644
  
      test("Spark should be able to run Hive UDF using jar regardless of " +
 diff --git a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
-index cc7bb193731..06555d48da7 100644
+index cc7bb193..06555d48 100644
 --- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
 +++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
 @@ -818,7 +818,8 @@ class InsertSuite extends QueryTest with TestHiveSingleton with BeforeAndAfter
@@ -4024,7 +4060,7 @@ index cc7bb193731..06555d48da7 100644
        withTempDir { dir =>
          val file = new File(dir, "test.hex")
 diff --git a/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionedTablePerfStatsSuite.scala b/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionedTablePerfStatsSuite.scala
-index b67370f6eb9..746b3974b29 100644
+index b67370f6..746b3974 100644
 --- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionedTablePerfStatsSuite.scala
 +++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionedTablePerfStatsSuite.scala
 @@ -23,14 +23,15 @@ import java.util.concurrent.{Executors, TimeUnit}
@@ -4046,7 +4082,7 @@ index b67370f6eb9..746b3974b29 100644
    override def beforeEach(): Unit = {
      super.beforeEach()
 diff --git a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
-index a394d0b7393..a4bc3d3fd8e 100644
+index a394d0b7..a4bc3d3f 100644
 --- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
 +++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
 @@ -53,24 +53,41 @@ object TestHive

--- a/spark/src/main/scala/org/apache/comet/serde/CometAggregateExpressionSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/CometAggregateExpressionSerde.scala
@@ -50,6 +50,20 @@ trait CometAggregateExpressionSerde[T <: AggregateFunction] {
   def getSupportLevel(expr: T): SupportLevel = Compatible(None)
 
   /**
+   * Indicates whether this aggregate function supports "Spark partial / Comet final" mixed
+   * execution. This requires the intermediate buffer format to be compatible between Spark and
+   * Comet.
+   *
+   * Only aggregates with simple, compatible intermediate buffers should return true. Aggregates
+   * with complex buffers or those with known incompatibilities (e.g., decimal overflow handling
+   * differences) should return false.
+   *
+   * @return
+   *   true if the aggregate can safely run with Spark partial and Comet final, false otherwise
+   */
+  def supportsSparkPartialCometFinal: Boolean = false
+
+  /**
    * Convert a Spark expression into a protocol buffer representation that can be passed into
    * native code.
    *

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -271,6 +271,23 @@ object QueryPlanSerde extends Logging with CometExprShim {
     classOf[VariancePop] -> CometVariancePop,
     classOf[VarianceSamp] -> CometVarianceSamp)
 
+  /**
+   * Checks if the given aggregate function supports "Spark partial / Comet final" mixed
+   * execution. This is used to determine if Comet can process a final aggregate even when the
+   * partial aggregate was performed by Spark.
+   *
+   * @param fn
+   *   The aggregate function to check
+   * @return
+   *   true if the aggregate supports mixed execution, false otherwise
+   */
+  def aggSupportsMixedExecution(fn: AggregateFunction): Boolean = {
+    aggrSerdeMap.get(fn.getClass) match {
+      case Some(handler) => handler.supportsSparkPartialCometFinal
+      case None => false
+    }
+  }
+
   //  A unique id for each expression. ~used to look up QueryContext during error creation.
   private val exprIdCounter = new AtomicLong(0)
 

--- a/spark/src/main/scala/org/apache/comet/serde/aggregates.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/aggregates.scala
@@ -34,6 +34,9 @@ import org.apache.comet.shims.CometEvalModeUtil
 
 object CometMin extends CometAggregateExpressionSerde[Min] {
 
+  // Min has a simple intermediate buffer (single value) compatible between Spark and Comet
+  override def supportsSparkPartialCometFinal: Boolean = true
+
   override def convert(
       aggExpr: AggregateExpression,
       expr: Min,
@@ -81,6 +84,9 @@ object CometMin extends CometAggregateExpressionSerde[Min] {
 
 object CometMax extends CometAggregateExpressionSerde[Max] {
 
+  // Max has a simple intermediate buffer (single value) compatible between Spark and Comet
+  override def supportsSparkPartialCometFinal: Boolean = true
+
   override def convert(
       aggExpr: AggregateExpression,
       expr: Max,
@@ -127,6 +133,10 @@ object CometMax extends CometAggregateExpressionSerde[Max] {
 }
 
 object CometCount extends CometAggregateExpressionSerde[Count] {
+
+  // Count has a simple intermediate buffer (single Long) compatible between Spark and Comet
+  override def supportsSparkPartialCometFinal: Boolean = true
+
   override def convert(
       aggExpr: AggregateExpression,
       expr: Count,
@@ -306,6 +316,11 @@ object CometLast extends CometAggregateExpressionSerde[Last] {
 }
 
 object CometBitAndAgg extends CometAggregateExpressionSerde[BitAndAgg] {
+
+  // BitAnd has a simple intermediate buffer (single integral value)
+  // compatible between Spark and Comet
+  override def supportsSparkPartialCometFinal: Boolean = true
+
   override def convert(
       aggExpr: AggregateExpression,
       bitAnd: BitAndAgg,
@@ -340,6 +355,11 @@ object CometBitAndAgg extends CometAggregateExpressionSerde[BitAndAgg] {
 }
 
 object CometBitOrAgg extends CometAggregateExpressionSerde[BitOrAgg] {
+
+  // BitOr has a simple intermediate buffer (single integral value)
+  // compatible between Spark and Comet
+  override def supportsSparkPartialCometFinal: Boolean = true
+
   override def convert(
       aggExpr: AggregateExpression,
       bitOr: BitOrAgg,
@@ -374,6 +394,11 @@ object CometBitOrAgg extends CometAggregateExpressionSerde[BitOrAgg] {
 }
 
 object CometBitXOrAgg extends CometAggregateExpressionSerde[BitXorAgg] {
+
+  // BitXor has a simple intermediate buffer (single integral value)
+  // compatible between Spark and Comet
+  override def supportsSparkPartialCometFinal: Boolean = true
+
   override def convert(
       aggExpr: AggregateExpression,
       bitXor: BitXorAgg,

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -42,7 +42,7 @@ import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, HashJoin, ShuffledHashJoinExec, SortMergeJoinExec}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{ArrayType, BooleanType, ByteType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, MapType, ShortType, StringType, TimestampNTZType}
+import org.apache.spark.sql.types.{ArrayType, BooleanType, ByteType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, MapType, ShortType, StringType, StructType, TimestampNTZType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.SerializableConfiguration
 import org.apache.spark.util.io.ChunkedByteBuffer
@@ -1365,11 +1365,21 @@ trait CometBaseAggregate {
       return None
     }
 
-    if (groupingExpressions.exists(expr =>
-        expr.dataType match {
-          case _: MapType => true
-          case _ => false
-        })) {
+    // Aggregate expressions with filter are not supported yet.
+    if (aggregateExpressions.exists(_.filter.isDefined)) {
+      withInfo(aggregate, "Aggregate expression with filter is not supported")
+      return None
+    }
+
+    def containsMapType(dt: DataType): Boolean = dt match {
+      case _: MapType => true
+      case a: ArrayType => containsMapType(a.elementType)
+      case s: StructType => s.fields.exists(f => containsMapType(f.dataType))
+      case _ => false
+    }
+    val mapTypeGroupings =
+      groupingExpressions.filter(expr => containsMapType(expr.dataType))
+    if (mapTypeGroupings.nonEmpty) {
       withInfo(aggregate, "Grouping on map types is not supported")
       return None
     }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -55,7 +55,7 @@ import org.apache.comet.CometSparkSessionExtensions.{isCometShuffleEnabled, with
 import org.apache.comet.parquet.CometParquetUtils
 import org.apache.comet.serde.{CometOperatorSerde, Compatible, Incompatible, OperatorOuterClass, SupportLevel, Unsupported}
 import org.apache.comet.serde.OperatorOuterClass.{AggregateMode => CometAggregateMode, Operator}
-import org.apache.comet.serde.QueryPlanSerde.{aggExprToProto, exprToProto, supportedSortType}
+import org.apache.comet.serde.QueryPlanSerde.{aggExprToProto, aggSupportsMixedExecution, exprToProto, supportedSortType}
 import org.apache.comet.serde.operator.CometSink
 
 /**
@@ -1343,11 +1343,14 @@ trait CometBaseAggregate {
     val modes = aggregate.aggregateExpressions.map(_.mode).distinct
     // In distinct aggregates there can be a combination of modes
     val multiMode = modes.size > 1
-    // For a final mode HashAggregate, we only need to transform the HashAggregate
-    // if there is Comet partial aggregation.
+    // For a final mode HashAggregate, check if there is Comet partial aggregation.
+    // If not, we can still proceed if all aggregates support mixed execution
+    // (Spark partial / Comet final). See https://github.com/apache/datafusion-comet/issues/2894
     val sparkFinalMode = modes.contains(Final) && findCometPartialAgg(aggregate.child).isEmpty
+    val allSupportMixedExecution = aggregate.aggregateExpressions.forall(expr =>
+      aggSupportsMixedExecution(expr.aggregateFunction))
 
-    if (multiMode || sparkFinalMode) {
+    if (multiMode || (sparkFinalMode && !allSupportMixedExecution)) {
       return None
     }
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -1365,12 +1365,6 @@ trait CometBaseAggregate {
       return None
     }
 
-    // Aggregate expressions with filter are not supported yet.
-    if (aggregateExpressions.exists(_.filter.isDefined)) {
-      withInfo(aggregate, "Aggregate expression with filter is not supported")
-      return None
-    }
-
     def containsMapType(dt: DataType): Boolean = dt match {
       case _: MapType => true
       case a: ArrayType => containsMapType(a.elementType)

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q10.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q10.native_datafusion/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+- HashAggregate
-   +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
       +- CometColumnarExchange
          +- HashAggregate
             +- Project
@@ -64,4 +64,4 @@ TakeOrderedAndProject
                            +- CometFilter
                               +- CometNativeScan parquet spark_catalog.default.customer_demographics
 
-Comet accelerated 21 out of 54 eligible operators (38%). Final plan contains 11 transitions between Spark and Comet.
+Comet accelerated 23 out of 54 eligible operators (42%). Final plan contains 11 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q10.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q10.native_iceberg_compat/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+- HashAggregate
-   +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
       +- CometColumnarExchange
          +- HashAggregate
             +- Project
@@ -60,4 +60,4 @@ TakeOrderedAndProject
                            +- CometFilter
                               +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
 
-Comet accelerated 35 out of 54 eligible operators (64%). Final plan contains 7 transitions between Spark and Comet.
+Comet accelerated 37 out of 54 eligible operators (68%). Final plan contains 7 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q23a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q23a.native_datafusion/extended.txt
@@ -20,10 +20,10 @@ CometNativeColumnarToRow
             :     :     :           :                    +- CometFilter
             :     :     :           :                       +- CometNativeScan parquet spark_catalog.default.date_dim
             :     :     :           +- BroadcastExchange
-            :     :     :              +- Project
-            :     :     :                 +- Filter
-            :     :     :                    +- HashAggregate
-            :     :     :                       +- CometNativeColumnarToRow
+            :     :     :              +- CometNativeColumnarToRow
+            :     :     :                 +- CometProject
+            :     :     :                    +- CometFilter
+            :     :     :                       +- CometHashAggregate
             :     :     :                          +- CometColumnarExchange
             :     :     :                             +- HashAggregate
             :     :     :                                +- Project
@@ -52,8 +52,8 @@ CometNativeColumnarToRow
             :     :        +- CometProject
             :     :           +- CometFilter
             :     :              :  +- Subquery
-            :     :              :     +- HashAggregate
-            :     :              :        +- CometNativeColumnarToRow
+            :     :              :     +- CometNativeColumnarToRow
+            :     :              :        +- CometHashAggregate
             :     :              :           +- CometColumnarExchange
             :     :              :              +- HashAggregate
             :     :              :                 +- HashAggregate
@@ -109,10 +109,10 @@ CometNativeColumnarToRow
                   :     :           :  +-  Scan parquet spark_catalog.default.web_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
                   :     :           :        +- ReusedSubquery
                   :     :           +- BroadcastExchange
-                  :     :              +- Project
-                  :     :                 +- Filter
-                  :     :                    +- HashAggregate
-                  :     :                       +- CometNativeColumnarToRow
+                  :     :              +- CometNativeColumnarToRow
+                  :     :                 +- CometProject
+                  :     :                    +- CometFilter
+                  :     :                       +- CometHashAggregate
                   :     :                          +- CometColumnarExchange
                   :     :                             +- HashAggregate
                   :     :                                +- Project
@@ -157,4 +157,4 @@ CometNativeColumnarToRow
                         +- CometFilter
                            +- CometNativeScan parquet spark_catalog.default.date_dim
 
-Comet accelerated 83 out of 138 eligible operators (60%). Final plan contains 20 transitions between Spark and Comet.
+Comet accelerated 90 out of 138 eligible operators (65%). Final plan contains 20 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q23b.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q23b.native_datafusion/extended.txt
@@ -23,10 +23,10 @@ CometNativeColumnarToRow
       :              :     :  :           :                       +- CometFilter
       :              :     :  :           :                          +- CometNativeScan parquet spark_catalog.default.date_dim
       :              :     :  :           +- BroadcastExchange
-      :              :     :  :              +- Project
-      :              :     :  :                 +- Filter
-      :              :     :  :                    +- HashAggregate
-      :              :     :  :                       +- CometNativeColumnarToRow
+      :              :     :  :              +- CometNativeColumnarToRow
+      :              :     :  :                 +- CometProject
+      :              :     :  :                    +- CometFilter
+      :              :     :  :                       +- CometHashAggregate
       :              :     :  :                          +- CometColumnarExchange
       :              :     :  :                             +- HashAggregate
       :              :     :  :                                +- Project
@@ -55,8 +55,8 @@ CometNativeColumnarToRow
       :              :     :     +- CometProject
       :              :     :        +- CometFilter
       :              :     :           :  +- Subquery
-      :              :     :           :     +- HashAggregate
-      :              :     :           :        +- CometNativeColumnarToRow
+      :              :     :           :     +- CometNativeColumnarToRow
+      :              :     :           :        +- CometHashAggregate
       :              :     :           :           +- CometColumnarExchange
       :              :     :           :              +- HashAggregate
       :              :     :           :                 +- HashAggregate
@@ -139,10 +139,10 @@ CometNativeColumnarToRow
                      :     :  :           :     +-  Scan parquet spark_catalog.default.web_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
                      :     :  :           :           +- ReusedSubquery
                      :     :  :           +- BroadcastExchange
-                     :     :  :              +- Project
-                     :     :  :                 +- Filter
-                     :     :  :                    +- HashAggregate
-                     :     :  :                       +- CometNativeColumnarToRow
+                     :     :  :              +- CometNativeColumnarToRow
+                     :     :  :                 +- CometProject
+                     :     :  :                    +- CometFilter
+                     :     :  :                       +- CometHashAggregate
                      :     :  :                          +- CometColumnarExchange
                      :     :  :                             +- HashAggregate
                      :     :  :                                +- Project
@@ -209,4 +209,4 @@ CometNativeColumnarToRow
                            +- CometFilter
                               +- CometNativeScan parquet spark_catalog.default.date_dim
 
-Comet accelerated 131 out of 190 eligible operators (68%). Final plan contains 20 transitions between Spark and Comet.
+Comet accelerated 138 out of 190 eligible operators (72%). Final plan contains 20 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q34.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q34.native_datafusion/extended.txt
@@ -1,47 +1,45 @@
 CometNativeColumnarToRow
 +- CometSort
-   +- CometColumnarExchange
-      +- Project
-         +- BroadcastHashJoin
-            :- Filter
-            :  +- HashAggregate
-            :     +- CometNativeColumnarToRow
-            :        +- CometColumnarExchange
-            :           +- HashAggregate
-            :              +- Project
-            :                 +- BroadcastHashJoin
-            :                    :- Project
-            :                    :  +- BroadcastHashJoin
-            :                    :     :- Project
-            :                    :     :  +- BroadcastHashJoin
-            :                    :     :     :- Filter
-            :                    :     :     :  +- ColumnarToRow
-            :                    :     :     :     +-  Scan parquet spark_catalog.default.store_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
-            :                    :     :     :           +- SubqueryBroadcast
-            :                    :     :     :              +- BroadcastExchange
-            :                    :     :     :                 +- CometNativeColumnarToRow
-            :                    :     :     :                    +- CometProject
-            :                    :     :     :                       +- CometFilter
-            :                    :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
-            :                    :     :     +- BroadcastExchange
-            :                    :     :        +- CometNativeColumnarToRow
-            :                    :     :           +- CometProject
-            :                    :     :              +- CometFilter
-            :                    :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
-            :                    :     +- BroadcastExchange
-            :                    :        +- CometNativeColumnarToRow
-            :                    :           +- CometProject
-            :                    :              +- CometFilter
-            :                    :                 +- CometNativeScan parquet spark_catalog.default.store
-            :                    +- BroadcastExchange
-            :                       +- CometNativeColumnarToRow
-            :                          +- CometProject
-            :                             +- CometFilter
-            :                                +- CometNativeScan parquet spark_catalog.default.household_demographics
-            +- BroadcastExchange
-               +- CometNativeColumnarToRow
-                  +- CometProject
-                     +- CometFilter
-                        +- CometNativeScan parquet spark_catalog.default.customer
+   +- CometExchange
+      +- CometProject
+         +- CometBroadcastHashJoin
+            :- CometFilter
+            :  +- CometHashAggregate
+            :     +- CometColumnarExchange
+            :        +- HashAggregate
+            :           +- Project
+            :              +- BroadcastHashJoin
+            :                 :- Project
+            :                 :  +- BroadcastHashJoin
+            :                 :     :- Project
+            :                 :     :  +- BroadcastHashJoin
+            :                 :     :     :- Filter
+            :                 :     :     :  +- ColumnarToRow
+            :                 :     :     :     +-  Scan parquet spark_catalog.default.store_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
+            :                 :     :     :           +- SubqueryBroadcast
+            :                 :     :     :              +- BroadcastExchange
+            :                 :     :     :                 +- CometNativeColumnarToRow
+            :                 :     :     :                    +- CometProject
+            :                 :     :     :                       +- CometFilter
+            :                 :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     +- BroadcastExchange
+            :                 :     :        +- CometNativeColumnarToRow
+            :                 :     :           +- CometProject
+            :                 :     :              +- CometFilter
+            :                 :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     +- BroadcastExchange
+            :                 :        +- CometNativeColumnarToRow
+            :                 :           +- CometProject
+            :                 :              +- CometFilter
+            :                 :                 +- CometNativeScan parquet spark_catalog.default.store
+            :                 +- BroadcastExchange
+            :                    +- CometNativeColumnarToRow
+            :                       +- CometProject
+            :                          +- CometFilter
+            :                             +- CometNativeScan parquet spark_catalog.default.household_demographics
+            +- CometBroadcastExchange
+               +- CometProject
+                  +- CometFilter
+                     +- CometNativeScan parquet spark_catalog.default.customer
 
-Comet accelerated 18 out of 37 eligible operators (48%). Final plan contains 8 transitions between Spark and Comet.
+Comet accelerated 23 out of 37 eligible operators (62%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q54.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q54.native_datafusion/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+- HashAggregate
-   +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
       +- CometColumnarExchange
          +- HashAggregate
             +- HashAggregate
@@ -113,4 +113,4 @@ TakeOrderedAndProject
                                           :                       +- CometNativeScan parquet spark_catalog.default.date_dim
                                           +- CometNativeScan parquet spark_catalog.default.date_dim
 
-Comet accelerated 51 out of 96 eligible operators (53%). Final plan contains 18 transitions between Spark and Comet.
+Comet accelerated 53 out of 96 eligible operators (55%). Final plan contains 18 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q6.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q6.native_datafusion/extended.txt
@@ -1,7 +1,7 @@
-TakeOrderedAndProject
-+- Filter
-   +- HashAggregate
-      +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometFilter
+      +- CometHashAggregate
          +- CometColumnarExchange
             +- HashAggregate
                +- Project
@@ -65,4 +65,4 @@ TakeOrderedAndProject
                                                    +- CometFilter
                                                       +- CometNativeScan parquet spark_catalog.default.item
 
-Comet accelerated 39 out of 58 eligible operators (67%). Final plan contains 8 transitions between Spark and Comet.
+Comet accelerated 42 out of 58 eligible operators (72%). Final plan contains 8 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q69.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q69.native_datafusion/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+- HashAggregate
-   +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
       +- CometColumnarExchange
          +- HashAggregate
             +- Project
@@ -63,4 +63,4 @@ TakeOrderedAndProject
                            +- CometFilter
                               +- CometNativeScan parquet spark_catalog.default.customer_demographics
 
-Comet accelerated 21 out of 53 eligible operators (39%). Final plan contains 11 transitions between Spark and Comet.
+Comet accelerated 23 out of 53 eligible operators (43%). Final plan contains 11 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q69.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q69.native_iceberg_compat/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+- HashAggregate
-   +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
       +- CometColumnarExchange
          +- HashAggregate
             +- Project
@@ -59,4 +59,4 @@ TakeOrderedAndProject
                            +- CometFilter
                               +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
 
-Comet accelerated 35 out of 53 eligible operators (66%). Final plan contains 7 transitions between Spark and Comet.
+Comet accelerated 37 out of 53 eligible operators (69%). Final plan contains 7 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q73.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q73.native_datafusion/extended.txt
@@ -1,47 +1,45 @@
 CometNativeColumnarToRow
 +- CometSort
-   +- CometColumnarExchange
-      +- Project
-         +- BroadcastHashJoin
-            :- Filter
-            :  +- HashAggregate
-            :     +- CometNativeColumnarToRow
-            :        +- CometColumnarExchange
-            :           +- HashAggregate
-            :              +- Project
-            :                 +- BroadcastHashJoin
-            :                    :- Project
-            :                    :  +- BroadcastHashJoin
-            :                    :     :- Project
-            :                    :     :  +- BroadcastHashJoin
-            :                    :     :     :- Filter
-            :                    :     :     :  +- ColumnarToRow
-            :                    :     :     :     +-  Scan parquet spark_catalog.default.store_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
-            :                    :     :     :           +- SubqueryBroadcast
-            :                    :     :     :              +- BroadcastExchange
-            :                    :     :     :                 +- CometNativeColumnarToRow
-            :                    :     :     :                    +- CometProject
-            :                    :     :     :                       +- CometFilter
-            :                    :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
-            :                    :     :     +- BroadcastExchange
-            :                    :     :        +- CometNativeColumnarToRow
-            :                    :     :           +- CometProject
-            :                    :     :              +- CometFilter
-            :                    :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
-            :                    :     +- BroadcastExchange
-            :                    :        +- CometNativeColumnarToRow
-            :                    :           +- CometProject
-            :                    :              +- CometFilter
-            :                    :                 +- CometNativeScan parquet spark_catalog.default.store
-            :                    +- BroadcastExchange
-            :                       +- CometNativeColumnarToRow
-            :                          +- CometProject
-            :                             +- CometFilter
-            :                                +- CometNativeScan parquet spark_catalog.default.household_demographics
-            +- BroadcastExchange
-               +- CometNativeColumnarToRow
-                  +- CometProject
-                     +- CometFilter
-                        +- CometNativeScan parquet spark_catalog.default.customer
+   +- CometExchange
+      +- CometProject
+         +- CometBroadcastHashJoin
+            :- CometFilter
+            :  +- CometHashAggregate
+            :     +- CometColumnarExchange
+            :        +- HashAggregate
+            :           +- Project
+            :              +- BroadcastHashJoin
+            :                 :- Project
+            :                 :  +- BroadcastHashJoin
+            :                 :     :- Project
+            :                 :     :  +- BroadcastHashJoin
+            :                 :     :     :- Filter
+            :                 :     :     :  +- ColumnarToRow
+            :                 :     :     :     +-  Scan parquet spark_catalog.default.store_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
+            :                 :     :     :           +- SubqueryBroadcast
+            :                 :     :     :              +- BroadcastExchange
+            :                 :     :     :                 +- CometNativeColumnarToRow
+            :                 :     :     :                    +- CometProject
+            :                 :     :     :                       +- CometFilter
+            :                 :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     +- BroadcastExchange
+            :                 :     :        +- CometNativeColumnarToRow
+            :                 :     :           +- CometProject
+            :                 :     :              +- CometFilter
+            :                 :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     +- BroadcastExchange
+            :                 :        +- CometNativeColumnarToRow
+            :                 :           +- CometProject
+            :                 :              +- CometFilter
+            :                 :                 +- CometNativeScan parquet spark_catalog.default.store
+            :                 +- BroadcastExchange
+            :                    +- CometNativeColumnarToRow
+            :                       +- CometProject
+            :                          +- CometFilter
+            :                             +- CometNativeScan parquet spark_catalog.default.household_demographics
+            +- CometBroadcastExchange
+               +- CometProject
+                  +- CometFilter
+                     +- CometNativeScan parquet spark_catalog.default.customer
 
-Comet accelerated 18 out of 37 eligible operators (48%). Final plan contains 8 transitions between Spark and Comet.
+Comet accelerated 23 out of 37 eligible operators (62%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q87.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q87.native_datafusion/extended.txt
@@ -1,5 +1,5 @@
-HashAggregate
-+- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometHashAggregate
    +- CometColumnarExchange
       +- HashAggregate
          +- Project
@@ -79,4 +79,4 @@ HashAggregate
                                              +- CometFilter
                                                 +- CometNativeScan parquet spark_catalog.default.customer
 
-Comet accelerated 28 out of 66 eligible operators (42%). Final plan contains 14 transitions between Spark and Comet.
+Comet accelerated 29 out of 66 eligible operators (43%). Final plan contains 14 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q87.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q87.native_iceberg_compat/extended.txt
@@ -1,5 +1,5 @@
-HashAggregate
-+- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometHashAggregate
    +- CometColumnarExchange
       +- HashAggregate
          +- Project
@@ -70,4 +70,4 @@ HashAggregate
                                           +- CometFilter
                                              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
 
-Comet accelerated 55 out of 66 eligible operators (83%). Final plan contains 5 transitions between Spark and Comet.
+Comet accelerated 56 out of 66 eligible operators (84%). Final plan contains 5 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q10.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q10.native_datafusion/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+- HashAggregate
-   +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
       +- CometColumnarExchange
          +- HashAggregate
             +- Project
@@ -64,4 +64,4 @@ TakeOrderedAndProject
                            +- CometFilter
                               +- CometNativeScan parquet spark_catalog.default.customer_demographics
 
-Comet accelerated 21 out of 54 eligible operators (38%). Final plan contains 11 transitions between Spark and Comet.
+Comet accelerated 23 out of 54 eligible operators (42%). Final plan contains 11 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q10.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q10.native_iceberg_compat/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+- HashAggregate
-   +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
       +- CometColumnarExchange
          +- HashAggregate
             +- Project
@@ -60,4 +60,4 @@ TakeOrderedAndProject
                            +- CometFilter
                               +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
 
-Comet accelerated 35 out of 54 eligible operators (64%). Final plan contains 7 transitions between Spark and Comet.
+Comet accelerated 37 out of 54 eligible operators (68%). Final plan contains 7 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q23a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q23a.native_datafusion/extended.txt
@@ -20,10 +20,10 @@ CometNativeColumnarToRow
             :     :     :           :                    +- CometFilter
             :     :     :           :                       +- CometNativeScan parquet spark_catalog.default.date_dim
             :     :     :           +- BroadcastExchange
-            :     :     :              +- Project
-            :     :     :                 +- Filter
-            :     :     :                    +- HashAggregate
-            :     :     :                       +- CometNativeColumnarToRow
+            :     :     :              +- CometNativeColumnarToRow
+            :     :     :                 +- CometProject
+            :     :     :                    +- CometFilter
+            :     :     :                       +- CometHashAggregate
             :     :     :                          +- CometColumnarExchange
             :     :     :                             +- HashAggregate
             :     :     :                                +- Project
@@ -52,8 +52,8 @@ CometNativeColumnarToRow
             :     :        +- CometProject
             :     :           +- CometFilter
             :     :              :  +- Subquery
-            :     :              :     +- HashAggregate
-            :     :              :        +- CometNativeColumnarToRow
+            :     :              :     +- CometNativeColumnarToRow
+            :     :              :        +- CometHashAggregate
             :     :              :           +- CometColumnarExchange
             :     :              :              +- HashAggregate
             :     :              :                 +- HashAggregate
@@ -109,10 +109,10 @@ CometNativeColumnarToRow
                   :     :           :  +-  Scan parquet spark_catalog.default.web_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
                   :     :           :        +- ReusedSubquery
                   :     :           +- BroadcastExchange
-                  :     :              +- Project
-                  :     :                 +- Filter
-                  :     :                    +- HashAggregate
-                  :     :                       +- CometNativeColumnarToRow
+                  :     :              +- CometNativeColumnarToRow
+                  :     :                 +- CometProject
+                  :     :                    +- CometFilter
+                  :     :                       +- CometHashAggregate
                   :     :                          +- CometColumnarExchange
                   :     :                             +- HashAggregate
                   :     :                                +- Project
@@ -157,4 +157,4 @@ CometNativeColumnarToRow
                         +- CometFilter
                            +- CometNativeScan parquet spark_catalog.default.date_dim
 
-Comet accelerated 83 out of 138 eligible operators (60%). Final plan contains 20 transitions between Spark and Comet.
+Comet accelerated 90 out of 138 eligible operators (65%). Final plan contains 20 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q23b.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q23b.native_datafusion/extended.txt
@@ -23,10 +23,10 @@ CometNativeColumnarToRow
       :              :     :  :           :                       +- CometFilter
       :              :     :  :           :                          +- CometNativeScan parquet spark_catalog.default.date_dim
       :              :     :  :           +- BroadcastExchange
-      :              :     :  :              +- Project
-      :              :     :  :                 +- Filter
-      :              :     :  :                    +- HashAggregate
-      :              :     :  :                       +- CometNativeColumnarToRow
+      :              :     :  :              +- CometNativeColumnarToRow
+      :              :     :  :                 +- CometProject
+      :              :     :  :                    +- CometFilter
+      :              :     :  :                       +- CometHashAggregate
       :              :     :  :                          +- CometColumnarExchange
       :              :     :  :                             +- HashAggregate
       :              :     :  :                                +- Project
@@ -55,8 +55,8 @@ CometNativeColumnarToRow
       :              :     :     +- CometProject
       :              :     :        +- CometFilter
       :              :     :           :  +- Subquery
-      :              :     :           :     +- HashAggregate
-      :              :     :           :        +- CometNativeColumnarToRow
+      :              :     :           :     +- CometNativeColumnarToRow
+      :              :     :           :        +- CometHashAggregate
       :              :     :           :           +- CometColumnarExchange
       :              :     :           :              +- HashAggregate
       :              :     :           :                 +- HashAggregate
@@ -139,10 +139,10 @@ CometNativeColumnarToRow
                      :     :  :           :     +-  Scan parquet spark_catalog.default.web_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
                      :     :  :           :           +- ReusedSubquery
                      :     :  :           +- BroadcastExchange
-                     :     :  :              +- Project
-                     :     :  :                 +- Filter
-                     :     :  :                    +- HashAggregate
-                     :     :  :                       +- CometNativeColumnarToRow
+                     :     :  :              +- CometNativeColumnarToRow
+                     :     :  :                 +- CometProject
+                     :     :  :                    +- CometFilter
+                     :     :  :                       +- CometHashAggregate
                      :     :  :                          +- CometColumnarExchange
                      :     :  :                             +- HashAggregate
                      :     :  :                                +- Project
@@ -209,4 +209,4 @@ CometNativeColumnarToRow
                            +- CometFilter
                               +- CometNativeScan parquet spark_catalog.default.date_dim
 
-Comet accelerated 131 out of 190 eligible operators (68%). Final plan contains 20 transitions between Spark and Comet.
+Comet accelerated 138 out of 190 eligible operators (72%). Final plan contains 20 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q34.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q34.native_datafusion/extended.txt
@@ -1,47 +1,45 @@
 CometNativeColumnarToRow
 +- CometSort
-   +- CometColumnarExchange
-      +- Project
-         +- BroadcastHashJoin
-            :- Filter
-            :  +- HashAggregate
-            :     +- CometNativeColumnarToRow
-            :        +- CometColumnarExchange
-            :           +- HashAggregate
-            :              +- Project
-            :                 +- BroadcastHashJoin
-            :                    :- Project
-            :                    :  +- BroadcastHashJoin
-            :                    :     :- Project
-            :                    :     :  +- BroadcastHashJoin
-            :                    :     :     :- Filter
-            :                    :     :     :  +- ColumnarToRow
-            :                    :     :     :     +-  Scan parquet spark_catalog.default.store_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
-            :                    :     :     :           +- SubqueryBroadcast
-            :                    :     :     :              +- BroadcastExchange
-            :                    :     :     :                 +- CometNativeColumnarToRow
-            :                    :     :     :                    +- CometProject
-            :                    :     :     :                       +- CometFilter
-            :                    :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
-            :                    :     :     +- BroadcastExchange
-            :                    :     :        +- CometNativeColumnarToRow
-            :                    :     :           +- CometProject
-            :                    :     :              +- CometFilter
-            :                    :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
-            :                    :     +- BroadcastExchange
-            :                    :        +- CometNativeColumnarToRow
-            :                    :           +- CometProject
-            :                    :              +- CometFilter
-            :                    :                 +- CometNativeScan parquet spark_catalog.default.store
-            :                    +- BroadcastExchange
-            :                       +- CometNativeColumnarToRow
-            :                          +- CometProject
-            :                             +- CometFilter
-            :                                +- CometNativeScan parquet spark_catalog.default.household_demographics
-            +- BroadcastExchange
-               +- CometNativeColumnarToRow
-                  +- CometProject
-                     +- CometFilter
-                        +- CometNativeScan parquet spark_catalog.default.customer
+   +- CometExchange
+      +- CometProject
+         +- CometBroadcastHashJoin
+            :- CometFilter
+            :  +- CometHashAggregate
+            :     +- CometColumnarExchange
+            :        +- HashAggregate
+            :           +- Project
+            :              +- BroadcastHashJoin
+            :                 :- Project
+            :                 :  +- BroadcastHashJoin
+            :                 :     :- Project
+            :                 :     :  +- BroadcastHashJoin
+            :                 :     :     :- Filter
+            :                 :     :     :  +- ColumnarToRow
+            :                 :     :     :     +-  Scan parquet spark_catalog.default.store_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
+            :                 :     :     :           +- SubqueryBroadcast
+            :                 :     :     :              +- BroadcastExchange
+            :                 :     :     :                 +- CometNativeColumnarToRow
+            :                 :     :     :                    +- CometProject
+            :                 :     :     :                       +- CometFilter
+            :                 :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     +- BroadcastExchange
+            :                 :     :        +- CometNativeColumnarToRow
+            :                 :     :           +- CometProject
+            :                 :     :              +- CometFilter
+            :                 :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     +- BroadcastExchange
+            :                 :        +- CometNativeColumnarToRow
+            :                 :           +- CometProject
+            :                 :              +- CometFilter
+            :                 :                 +- CometNativeScan parquet spark_catalog.default.store
+            :                 +- BroadcastExchange
+            :                    +- CometNativeColumnarToRow
+            :                       +- CometProject
+            :                          +- CometFilter
+            :                             +- CometNativeScan parquet spark_catalog.default.household_demographics
+            +- CometBroadcastExchange
+               +- CometProject
+                  +- CometFilter
+                     +- CometNativeScan parquet spark_catalog.default.customer
 
-Comet accelerated 18 out of 37 eligible operators (48%). Final plan contains 8 transitions between Spark and Comet.
+Comet accelerated 23 out of 37 eligible operators (62%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q54.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q54.native_datafusion/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+- HashAggregate
-   +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
       +- CometColumnarExchange
          +- HashAggregate
             +- HashAggregate
@@ -117,4 +117,4 @@ TakeOrderedAndProject
                                                                   +- CometFilter
                                                                      +- CometNativeScan parquet spark_catalog.default.date_dim
 
-Comet accelerated 51 out of 100 eligible operators (51%). Final plan contains 18 transitions between Spark and Comet.
+Comet accelerated 53 out of 100 eligible operators (53%). Final plan contains 18 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q6.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q6.native_datafusion/extended.txt
@@ -1,7 +1,7 @@
-TakeOrderedAndProject
-+- Filter
-   +- HashAggregate
-      +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometFilter
+      +- CometHashAggregate
          +- CometColumnarExchange
             +- HashAggregate
                +- Project
@@ -67,4 +67,4 @@ TakeOrderedAndProject
                                                    +- CometFilter
                                                       +- CometNativeScan parquet spark_catalog.default.item
 
-Comet accelerated 39 out of 60 eligible operators (65%). Final plan contains 8 transitions between Spark and Comet.
+Comet accelerated 42 out of 60 eligible operators (70%). Final plan contains 8 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q69.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q69.native_datafusion/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+- HashAggregate
-   +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
       +- CometColumnarExchange
          +- HashAggregate
             +- Project
@@ -63,4 +63,4 @@ TakeOrderedAndProject
                            +- CometFilter
                               +- CometNativeScan parquet spark_catalog.default.customer_demographics
 
-Comet accelerated 21 out of 53 eligible operators (39%). Final plan contains 11 transitions between Spark and Comet.
+Comet accelerated 23 out of 53 eligible operators (43%). Final plan contains 11 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q69.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q69.native_iceberg_compat/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+- HashAggregate
-   +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
       +- CometColumnarExchange
          +- HashAggregate
             +- Project
@@ -59,4 +59,4 @@ TakeOrderedAndProject
                            +- CometFilter
                               +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
 
-Comet accelerated 35 out of 53 eligible operators (66%). Final plan contains 7 transitions between Spark and Comet.
+Comet accelerated 37 out of 53 eligible operators (69%). Final plan contains 7 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q73.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q73.native_datafusion/extended.txt
@@ -1,47 +1,45 @@
 CometNativeColumnarToRow
 +- CometSort
-   +- CometColumnarExchange
-      +- Project
-         +- BroadcastHashJoin
-            :- Filter
-            :  +- HashAggregate
-            :     +- CometNativeColumnarToRow
-            :        +- CometColumnarExchange
-            :           +- HashAggregate
-            :              +- Project
-            :                 +- BroadcastHashJoin
-            :                    :- Project
-            :                    :  +- BroadcastHashJoin
-            :                    :     :- Project
-            :                    :     :  +- BroadcastHashJoin
-            :                    :     :     :- Filter
-            :                    :     :     :  +- ColumnarToRow
-            :                    :     :     :     +-  Scan parquet spark_catalog.default.store_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
-            :                    :     :     :           +- SubqueryBroadcast
-            :                    :     :     :              +- BroadcastExchange
-            :                    :     :     :                 +- CometNativeColumnarToRow
-            :                    :     :     :                    +- CometProject
-            :                    :     :     :                       +- CometFilter
-            :                    :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
-            :                    :     :     +- BroadcastExchange
-            :                    :     :        +- CometNativeColumnarToRow
-            :                    :     :           +- CometProject
-            :                    :     :              +- CometFilter
-            :                    :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
-            :                    :     +- BroadcastExchange
-            :                    :        +- CometNativeColumnarToRow
-            :                    :           +- CometProject
-            :                    :              +- CometFilter
-            :                    :                 +- CometNativeScan parquet spark_catalog.default.store
-            :                    +- BroadcastExchange
-            :                       +- CometNativeColumnarToRow
-            :                          +- CometProject
-            :                             +- CometFilter
-            :                                +- CometNativeScan parquet spark_catalog.default.household_demographics
-            +- BroadcastExchange
-               +- CometNativeColumnarToRow
-                  +- CometProject
-                     +- CometFilter
-                        +- CometNativeScan parquet spark_catalog.default.customer
+   +- CometExchange
+      +- CometProject
+         +- CometBroadcastHashJoin
+            :- CometFilter
+            :  +- CometHashAggregate
+            :     +- CometColumnarExchange
+            :        +- HashAggregate
+            :           +- Project
+            :              +- BroadcastHashJoin
+            :                 :- Project
+            :                 :  +- BroadcastHashJoin
+            :                 :     :- Project
+            :                 :     :  +- BroadcastHashJoin
+            :                 :     :     :- Filter
+            :                 :     :     :  +- ColumnarToRow
+            :                 :     :     :     +-  Scan parquet spark_catalog.default.store_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
+            :                 :     :     :           +- SubqueryBroadcast
+            :                 :     :     :              +- BroadcastExchange
+            :                 :     :     :                 +- CometNativeColumnarToRow
+            :                 :     :     :                    +- CometProject
+            :                 :     :     :                       +- CometFilter
+            :                 :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     +- BroadcastExchange
+            :                 :     :        +- CometNativeColumnarToRow
+            :                 :     :           +- CometProject
+            :                 :     :              +- CometFilter
+            :                 :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     +- BroadcastExchange
+            :                 :        +- CometNativeColumnarToRow
+            :                 :           +- CometProject
+            :                 :              +- CometFilter
+            :                 :                 +- CometNativeScan parquet spark_catalog.default.store
+            :                 +- BroadcastExchange
+            :                    +- CometNativeColumnarToRow
+            :                       +- CometProject
+            :                          +- CometFilter
+            :                             +- CometNativeScan parquet spark_catalog.default.household_demographics
+            +- CometBroadcastExchange
+               +- CometProject
+                  +- CometFilter
+                     +- CometNativeScan parquet spark_catalog.default.customer
 
-Comet accelerated 18 out of 37 eligible operators (48%). Final plan contains 8 transitions between Spark and Comet.
+Comet accelerated 23 out of 37 eligible operators (62%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q87.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q87.native_datafusion/extended.txt
@@ -1,5 +1,5 @@
-HashAggregate
-+- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometHashAggregate
    +- CometColumnarExchange
       +- HashAggregate
          +- Project
@@ -79,4 +79,4 @@ HashAggregate
                                              +- CometFilter
                                                 +- CometNativeScan parquet spark_catalog.default.customer
 
-Comet accelerated 28 out of 66 eligible operators (42%). Final plan contains 14 transitions between Spark and Comet.
+Comet accelerated 29 out of 66 eligible operators (43%). Final plan contains 14 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q87.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q87.native_iceberg_compat/extended.txt
@@ -1,5 +1,5 @@
-HashAggregate
-+- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometHashAggregate
    +- CometColumnarExchange
       +- HashAggregate
          +- Project
@@ -70,4 +70,4 @@ HashAggregate
                                           +- CometFilter
                                              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
 
-Comet accelerated 55 out of 66 eligible operators (83%). Final plan contains 5 transitions between Spark and Comet.
+Comet accelerated 56 out of 66 eligible operators (84%). Final plan contains 5 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10.native_datafusion/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+- HashAggregate
-   +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
       +- CometColumnarExchange
          +- HashAggregate
             +- Project
@@ -64,4 +64,4 @@ TakeOrderedAndProject
                            +- CometFilter
                               +- CometNativeScan parquet spark_catalog.default.customer_demographics
 
-Comet accelerated 21 out of 54 eligible operators (38%). Final plan contains 11 transitions between Spark and Comet.
+Comet accelerated 23 out of 54 eligible operators (42%). Final plan contains 11 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10.native_iceberg_compat/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+- HashAggregate
-   +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
       +- CometColumnarExchange
          +- HashAggregate
             +- Project
@@ -60,4 +60,4 @@ TakeOrderedAndProject
                            +- CometFilter
                               +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
 
-Comet accelerated 35 out of 54 eligible operators (64%). Final plan contains 7 transitions between Spark and Comet.
+Comet accelerated 37 out of 54 eligible operators (68%). Final plan contains 7 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a.native_datafusion/extended.txt
@@ -20,10 +20,10 @@ CometNativeColumnarToRow
             :     :     :           :                    +- CometFilter
             :     :     :           :                       +- CometNativeScan parquet spark_catalog.default.date_dim
             :     :     :           +- BroadcastExchange
-            :     :     :              +- Project
-            :     :     :                 +- Filter
-            :     :     :                    +- HashAggregate
-            :     :     :                       +- CometNativeColumnarToRow
+            :     :     :              +- CometNativeColumnarToRow
+            :     :     :                 +- CometProject
+            :     :     :                    +- CometFilter
+            :     :     :                       +- CometHashAggregate
             :     :     :                          +- CometColumnarExchange
             :     :     :                             +- HashAggregate
             :     :     :                                +- Project
@@ -52,8 +52,8 @@ CometNativeColumnarToRow
             :     :        +- CometProject
             :     :           +- CometFilter
             :     :              :  +- Subquery
-            :     :              :     +- HashAggregate
-            :     :              :        +- CometNativeColumnarToRow
+            :     :              :     +- CometNativeColumnarToRow
+            :     :              :        +- CometHashAggregate
             :     :              :           +- CometColumnarExchange
             :     :              :              +- HashAggregate
             :     :              :                 +- HashAggregate
@@ -109,10 +109,10 @@ CometNativeColumnarToRow
                   :     :           :  +-  Scan parquet spark_catalog.default.web_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
                   :     :           :        +- ReusedSubquery
                   :     :           +- BroadcastExchange
-                  :     :              +- Project
-                  :     :                 +- Filter
-                  :     :                    +- HashAggregate
-                  :     :                       +- CometNativeColumnarToRow
+                  :     :              +- CometNativeColumnarToRow
+                  :     :                 +- CometProject
+                  :     :                    +- CometFilter
+                  :     :                       +- CometHashAggregate
                   :     :                          +- CometColumnarExchange
                   :     :                             +- HashAggregate
                   :     :                                +- Project
@@ -157,4 +157,4 @@ CometNativeColumnarToRow
                         +- CometFilter
                            +- CometNativeScan parquet spark_catalog.default.date_dim
 
-Comet accelerated 83 out of 138 eligible operators (60%). Final plan contains 20 transitions between Spark and Comet.
+Comet accelerated 90 out of 138 eligible operators (65%). Final plan contains 20 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b.native_datafusion/extended.txt
@@ -23,10 +23,10 @@ CometNativeColumnarToRow
       :              :     :  :           :                       +- CometFilter
       :              :     :  :           :                          +- CometNativeScan parquet spark_catalog.default.date_dim
       :              :     :  :           +- BroadcastExchange
-      :              :     :  :              +- Project
-      :              :     :  :                 +- Filter
-      :              :     :  :                    +- HashAggregate
-      :              :     :  :                       +- CometNativeColumnarToRow
+      :              :     :  :              +- CometNativeColumnarToRow
+      :              :     :  :                 +- CometProject
+      :              :     :  :                    +- CometFilter
+      :              :     :  :                       +- CometHashAggregate
       :              :     :  :                          +- CometColumnarExchange
       :              :     :  :                             +- HashAggregate
       :              :     :  :                                +- Project
@@ -55,8 +55,8 @@ CometNativeColumnarToRow
       :              :     :     +- CometProject
       :              :     :        +- CometFilter
       :              :     :           :  +- Subquery
-      :              :     :           :     +- HashAggregate
-      :              :     :           :        +- CometNativeColumnarToRow
+      :              :     :           :     +- CometNativeColumnarToRow
+      :              :     :           :        +- CometHashAggregate
       :              :     :           :           +- CometColumnarExchange
       :              :     :           :              +- HashAggregate
       :              :     :           :                 +- HashAggregate
@@ -139,10 +139,10 @@ CometNativeColumnarToRow
                      :     :  :           :     +-  Scan parquet spark_catalog.default.web_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
                      :     :  :           :           +- ReusedSubquery
                      :     :  :           +- BroadcastExchange
-                     :     :  :              +- Project
-                     :     :  :                 +- Filter
-                     :     :  :                    +- HashAggregate
-                     :     :  :                       +- CometNativeColumnarToRow
+                     :     :  :              +- CometNativeColumnarToRow
+                     :     :  :                 +- CometProject
+                     :     :  :                    +- CometFilter
+                     :     :  :                       +- CometHashAggregate
                      :     :  :                          +- CometColumnarExchange
                      :     :  :                             +- HashAggregate
                      :     :  :                                +- Project
@@ -209,4 +209,4 @@ CometNativeColumnarToRow
                            +- CometFilter
                               +- CometNativeScan parquet spark_catalog.default.date_dim
 
-Comet accelerated 131 out of 190 eligible operators (68%). Final plan contains 20 transitions between Spark and Comet.
+Comet accelerated 138 out of 190 eligible operators (72%). Final plan contains 20 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q34.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q34.native_datafusion/extended.txt
@@ -1,47 +1,45 @@
 CometNativeColumnarToRow
 +- CometSort
-   +- CometColumnarExchange
-      +- Project
-         +- BroadcastHashJoin
-            :- Filter
-            :  +- HashAggregate
-            :     +- CometNativeColumnarToRow
-            :        +- CometColumnarExchange
-            :           +- HashAggregate
-            :              +- Project
-            :                 +- BroadcastHashJoin
-            :                    :- Project
-            :                    :  +- BroadcastHashJoin
-            :                    :     :- Project
-            :                    :     :  +- BroadcastHashJoin
-            :                    :     :     :- Filter
-            :                    :     :     :  +- ColumnarToRow
-            :                    :     :     :     +-  Scan parquet spark_catalog.default.store_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
-            :                    :     :     :           +- SubqueryBroadcast
-            :                    :     :     :              +- BroadcastExchange
-            :                    :     :     :                 +- CometNativeColumnarToRow
-            :                    :     :     :                    +- CometProject
-            :                    :     :     :                       +- CometFilter
-            :                    :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
-            :                    :     :     +- BroadcastExchange
-            :                    :     :        +- CometNativeColumnarToRow
-            :                    :     :           +- CometProject
-            :                    :     :              +- CometFilter
-            :                    :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
-            :                    :     +- BroadcastExchange
-            :                    :        +- CometNativeColumnarToRow
-            :                    :           +- CometProject
-            :                    :              +- CometFilter
-            :                    :                 +- CometNativeScan parquet spark_catalog.default.store
-            :                    +- BroadcastExchange
-            :                       +- CometNativeColumnarToRow
-            :                          +- CometProject
-            :                             +- CometFilter
-            :                                +- CometNativeScan parquet spark_catalog.default.household_demographics
-            +- BroadcastExchange
-               +- CometNativeColumnarToRow
-                  +- CometProject
-                     +- CometFilter
-                        +- CometNativeScan parquet spark_catalog.default.customer
+   +- CometExchange
+      +- CometProject
+         +- CometBroadcastHashJoin
+            :- CometFilter
+            :  +- CometHashAggregate
+            :     +- CometColumnarExchange
+            :        +- HashAggregate
+            :           +- Project
+            :              +- BroadcastHashJoin
+            :                 :- Project
+            :                 :  +- BroadcastHashJoin
+            :                 :     :- Project
+            :                 :     :  +- BroadcastHashJoin
+            :                 :     :     :- Filter
+            :                 :     :     :  +- ColumnarToRow
+            :                 :     :     :     +-  Scan parquet spark_catalog.default.store_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
+            :                 :     :     :           +- SubqueryBroadcast
+            :                 :     :     :              +- BroadcastExchange
+            :                 :     :     :                 +- CometNativeColumnarToRow
+            :                 :     :     :                    +- CometProject
+            :                 :     :     :                       +- CometFilter
+            :                 :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     +- BroadcastExchange
+            :                 :     :        +- CometNativeColumnarToRow
+            :                 :     :           +- CometProject
+            :                 :     :              +- CometFilter
+            :                 :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     +- BroadcastExchange
+            :                 :        +- CometNativeColumnarToRow
+            :                 :           +- CometProject
+            :                 :              +- CometFilter
+            :                 :                 +- CometNativeScan parquet spark_catalog.default.store
+            :                 +- BroadcastExchange
+            :                    +- CometNativeColumnarToRow
+            :                       +- CometProject
+            :                          +- CometFilter
+            :                             +- CometNativeScan parquet spark_catalog.default.household_demographics
+            +- CometBroadcastExchange
+               +- CometProject
+                  +- CometFilter
+                     +- CometNativeScan parquet spark_catalog.default.customer
 
-Comet accelerated 18 out of 37 eligible operators (48%). Final plan contains 8 transitions between Spark and Comet.
+Comet accelerated 23 out of 37 eligible operators (62%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.native_datafusion/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+- HashAggregate
-   +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
       +- CometColumnarExchange
          +- HashAggregate
             +- HashAggregate
@@ -113,4 +113,4 @@ TakeOrderedAndProject
                                           :                       +- CometNativeScan parquet spark_catalog.default.date_dim
                                           +- CometNativeScan parquet spark_catalog.default.date_dim
 
-Comet accelerated 51 out of 96 eligible operators (53%). Final plan contains 18 transitions between Spark and Comet.
+Comet accelerated 53 out of 96 eligible operators (55%). Final plan contains 18 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q6.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q6.native_datafusion/extended.txt
@@ -1,7 +1,7 @@
-TakeOrderedAndProject
-+- Filter
-   +- HashAggregate
-      +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometFilter
+      +- CometHashAggregate
          +- CometColumnarExchange
             +- HashAggregate
                +- Project
@@ -65,4 +65,4 @@ TakeOrderedAndProject
                                                    +- CometFilter
                                                       +- CometNativeScan parquet spark_catalog.default.item
 
-Comet accelerated 39 out of 58 eligible operators (67%). Final plan contains 8 transitions between Spark and Comet.
+Comet accelerated 42 out of 58 eligible operators (72%). Final plan contains 8 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.native_datafusion/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+- HashAggregate
-   +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
       +- CometColumnarExchange
          +- HashAggregate
             +- Project
@@ -63,4 +63,4 @@ TakeOrderedAndProject
                            +- CometFilter
                               +- CometNativeScan parquet spark_catalog.default.customer_demographics
 
-Comet accelerated 21 out of 53 eligible operators (39%). Final plan contains 11 transitions between Spark and Comet.
+Comet accelerated 23 out of 53 eligible operators (43%). Final plan contains 11 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.native_iceberg_compat/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+- HashAggregate
-   +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
       +- CometColumnarExchange
          +- HashAggregate
             +- Project
@@ -59,4 +59,4 @@ TakeOrderedAndProject
                            +- CometFilter
                               +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
 
-Comet accelerated 35 out of 53 eligible operators (66%). Final plan contains 7 transitions between Spark and Comet.
+Comet accelerated 37 out of 53 eligible operators (69%). Final plan contains 7 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73.native_datafusion/extended.txt
@@ -1,47 +1,45 @@
 CometNativeColumnarToRow
 +- CometSort
-   +- CometColumnarExchange
-      +- Project
-         +- BroadcastHashJoin
-            :- Filter
-            :  +- HashAggregate
-            :     +- CometNativeColumnarToRow
-            :        +- CometColumnarExchange
-            :           +- HashAggregate
-            :              +- Project
-            :                 +- BroadcastHashJoin
-            :                    :- Project
-            :                    :  +- BroadcastHashJoin
-            :                    :     :- Project
-            :                    :     :  +- BroadcastHashJoin
-            :                    :     :     :- Filter
-            :                    :     :     :  +- ColumnarToRow
-            :                    :     :     :     +-  Scan parquet spark_catalog.default.store_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
-            :                    :     :     :           +- SubqueryBroadcast
-            :                    :     :     :              +- BroadcastExchange
-            :                    :     :     :                 +- CometNativeColumnarToRow
-            :                    :     :     :                    +- CometProject
-            :                    :     :     :                       +- CometFilter
-            :                    :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
-            :                    :     :     +- BroadcastExchange
-            :                    :     :        +- CometNativeColumnarToRow
-            :                    :     :           +- CometProject
-            :                    :     :              +- CometFilter
-            :                    :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
-            :                    :     +- BroadcastExchange
-            :                    :        +- CometNativeColumnarToRow
-            :                    :           +- CometProject
-            :                    :              +- CometFilter
-            :                    :                 +- CometNativeScan parquet spark_catalog.default.store
-            :                    +- BroadcastExchange
-            :                       +- CometNativeColumnarToRow
-            :                          +- CometProject
-            :                             +- CometFilter
-            :                                +- CometNativeScan parquet spark_catalog.default.household_demographics
-            +- BroadcastExchange
-               +- CometNativeColumnarToRow
-                  +- CometProject
-                     +- CometFilter
-                        +- CometNativeScan parquet spark_catalog.default.customer
+   +- CometExchange
+      +- CometProject
+         +- CometBroadcastHashJoin
+            :- CometFilter
+            :  +- CometHashAggregate
+            :     +- CometColumnarExchange
+            :        +- HashAggregate
+            :           +- Project
+            :              +- BroadcastHashJoin
+            :                 :- Project
+            :                 :  +- BroadcastHashJoin
+            :                 :     :- Project
+            :                 :     :  +- BroadcastHashJoin
+            :                 :     :     :- Filter
+            :                 :     :     :  +- ColumnarToRow
+            :                 :     :     :     +-  Scan parquet spark_catalog.default.store_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
+            :                 :     :     :           +- SubqueryBroadcast
+            :                 :     :     :              +- BroadcastExchange
+            :                 :     :     :                 +- CometNativeColumnarToRow
+            :                 :     :     :                    +- CometProject
+            :                 :     :     :                       +- CometFilter
+            :                 :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     +- BroadcastExchange
+            :                 :     :        +- CometNativeColumnarToRow
+            :                 :     :           +- CometProject
+            :                 :     :              +- CometFilter
+            :                 :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     +- BroadcastExchange
+            :                 :        +- CometNativeColumnarToRow
+            :                 :           +- CometProject
+            :                 :              +- CometFilter
+            :                 :                 +- CometNativeScan parquet spark_catalog.default.store
+            :                 +- BroadcastExchange
+            :                    +- CometNativeColumnarToRow
+            :                       +- CometProject
+            :                          +- CometFilter
+            :                             +- CometNativeScan parquet spark_catalog.default.household_demographics
+            +- CometBroadcastExchange
+               +- CometProject
+                  +- CometFilter
+                     +- CometNativeScan parquet spark_catalog.default.customer
 
-Comet accelerated 18 out of 37 eligible operators (48%). Final plan contains 8 transitions between Spark and Comet.
+Comet accelerated 23 out of 37 eligible operators (62%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87.native_datafusion/extended.txt
@@ -1,5 +1,5 @@
-HashAggregate
-+- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometHashAggregate
    +- CometColumnarExchange
       +- HashAggregate
          +- Project
@@ -79,4 +79,4 @@ HashAggregate
                                              +- CometFilter
                                                 +- CometNativeScan parquet spark_catalog.default.customer
 
-Comet accelerated 28 out of 66 eligible operators (42%). Final plan contains 14 transitions between Spark and Comet.
+Comet accelerated 29 out of 66 eligible operators (43%). Final plan contains 14 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87.native_iceberg_compat/extended.txt
@@ -1,5 +1,5 @@
-HashAggregate
-+- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometHashAggregate
    +- CometColumnarExchange
       +- HashAggregate
          +- Project
@@ -70,4 +70,4 @@ HashAggregate
                                           +- CometFilter
                                              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
 
-Comet accelerated 55 out of 66 eligible operators (83%). Final plan contains 5 transitions between Spark and Comet.
+Comet accelerated 56 out of 66 eligible operators (84%). Final plan contains 5 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark3_5/q10a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark3_5/q10a.native_datafusion/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+- HashAggregate
-   +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
       +- CometColumnarExchange
          +- HashAggregate
             +- Project
@@ -62,4 +62,4 @@ TakeOrderedAndProject
                            +- CometFilter
                               +- CometNativeScan parquet spark_catalog.default.customer_demographics
 
-Comet accelerated 21 out of 52 eligible operators (40%). Final plan contains 11 transitions between Spark and Comet.
+Comet accelerated 23 out of 52 eligible operators (44%). Final plan contains 11 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark3_5/q34.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark3_5/q34.native_datafusion/extended.txt
@@ -1,47 +1,45 @@
 CometNativeColumnarToRow
 +- CometSort
-   +- CometColumnarExchange
-      +- Project
-         +- BroadcastHashJoin
-            :- Filter
-            :  +- HashAggregate
-            :     +- CometNativeColumnarToRow
-            :        +- CometColumnarExchange
-            :           +- HashAggregate
-            :              +- Project
-            :                 +- BroadcastHashJoin
-            :                    :- Project
-            :                    :  +- BroadcastHashJoin
-            :                    :     :- Project
-            :                    :     :  +- BroadcastHashJoin
-            :                    :     :     :- Filter
-            :                    :     :     :  +- ColumnarToRow
-            :                    :     :     :     +-  Scan parquet spark_catalog.default.store_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
-            :                    :     :     :           +- SubqueryBroadcast
-            :                    :     :     :              +- BroadcastExchange
-            :                    :     :     :                 +- CometNativeColumnarToRow
-            :                    :     :     :                    +- CometProject
-            :                    :     :     :                       +- CometFilter
-            :                    :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
-            :                    :     :     +- BroadcastExchange
-            :                    :     :        +- CometNativeColumnarToRow
-            :                    :     :           +- CometProject
-            :                    :     :              +- CometFilter
-            :                    :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
-            :                    :     +- BroadcastExchange
-            :                    :        +- CometNativeColumnarToRow
-            :                    :           +- CometProject
-            :                    :              +- CometFilter
-            :                    :                 +- CometNativeScan parquet spark_catalog.default.store
-            :                    +- BroadcastExchange
-            :                       +- CometNativeColumnarToRow
-            :                          +- CometProject
-            :                             +- CometFilter
-            :                                +- CometNativeScan parquet spark_catalog.default.household_demographics
-            +- BroadcastExchange
-               +- CometNativeColumnarToRow
-                  +- CometProject
-                     +- CometFilter
-                        +- CometNativeScan parquet spark_catalog.default.customer
+   +- CometExchange
+      +- CometProject
+         +- CometBroadcastHashJoin
+            :- CometFilter
+            :  +- CometHashAggregate
+            :     +- CometColumnarExchange
+            :        +- HashAggregate
+            :           +- Project
+            :              +- BroadcastHashJoin
+            :                 :- Project
+            :                 :  +- BroadcastHashJoin
+            :                 :     :- Project
+            :                 :     :  +- BroadcastHashJoin
+            :                 :     :     :- Filter
+            :                 :     :     :  +- ColumnarToRow
+            :                 :     :     :     +-  Scan parquet spark_catalog.default.store_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
+            :                 :     :     :           +- SubqueryBroadcast
+            :                 :     :     :              +- BroadcastExchange
+            :                 :     :     :                 +- CometNativeColumnarToRow
+            :                 :     :     :                    +- CometProject
+            :                 :     :     :                       +- CometFilter
+            :                 :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     +- BroadcastExchange
+            :                 :     :        +- CometNativeColumnarToRow
+            :                 :     :           +- CometProject
+            :                 :     :              +- CometFilter
+            :                 :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     +- BroadcastExchange
+            :                 :        +- CometNativeColumnarToRow
+            :                 :           +- CometProject
+            :                 :              +- CometFilter
+            :                 :                 +- CometNativeScan parquet spark_catalog.default.store
+            :                 +- BroadcastExchange
+            :                    +- CometNativeColumnarToRow
+            :                       +- CometProject
+            :                          +- CometFilter
+            :                             +- CometNativeScan parquet spark_catalog.default.household_demographics
+            +- CometBroadcastExchange
+               +- CometProject
+                  +- CometFilter
+                     +- CometNativeScan parquet spark_catalog.default.customer
 
-Comet accelerated 18 out of 37 eligible operators (48%). Final plan contains 8 transitions between Spark and Comet.
+Comet accelerated 23 out of 37 eligible operators (62%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark3_5/q6.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark3_5/q6.native_datafusion/extended.txt
@@ -1,7 +1,7 @@
-TakeOrderedAndProject
-+- Filter
-   +- HashAggregate
-      +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometFilter
+      +- CometHashAggregate
          +- CometColumnarExchange
             +- HashAggregate
                +- Project
@@ -65,4 +65,4 @@ TakeOrderedAndProject
                                                    +- CometFilter
                                                       +- CometNativeScan parquet spark_catalog.default.item
 
-Comet accelerated 39 out of 58 eligible operators (67%). Final plan contains 8 transitions between Spark and Comet.
+Comet accelerated 42 out of 58 eligible operators (72%). Final plan contains 8 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_0/q10a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_0/q10a.native_datafusion/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+- HashAggregate
-   +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
       +- CometColumnarExchange
          +- HashAggregate
             +- Project
@@ -62,4 +62,4 @@ TakeOrderedAndProject
                            +- CometFilter
                               +- CometNativeScan parquet spark_catalog.default.customer_demographics
 
-Comet accelerated 21 out of 52 eligible operators (40%). Final plan contains 11 transitions between Spark and Comet.
+Comet accelerated 23 out of 52 eligible operators (44%). Final plan contains 11 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_0/q34.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_0/q34.native_datafusion/extended.txt
@@ -1,47 +1,45 @@
 CometNativeColumnarToRow
 +- CometSort
-   +- CometColumnarExchange
-      +- Project
-         +- BroadcastHashJoin
-            :- Filter
-            :  +- HashAggregate
-            :     +- CometNativeColumnarToRow
-            :        +- CometColumnarExchange
-            :           +- HashAggregate
-            :              +- Project
-            :                 +- BroadcastHashJoin
-            :                    :- Project
-            :                    :  +- BroadcastHashJoin
-            :                    :     :- Project
-            :                    :     :  +- BroadcastHashJoin
-            :                    :     :     :- Filter
-            :                    :     :     :  +- ColumnarToRow
-            :                    :     :     :     +-  Scan parquet spark_catalog.default.store_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
-            :                    :     :     :           +- SubqueryBroadcast
-            :                    :     :     :              +- BroadcastExchange
-            :                    :     :     :                 +- CometNativeColumnarToRow
-            :                    :     :     :                    +- CometProject
-            :                    :     :     :                       +- CometFilter
-            :                    :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
-            :                    :     :     +- BroadcastExchange
-            :                    :     :        +- CometNativeColumnarToRow
-            :                    :     :           +- CometProject
-            :                    :     :              +- CometFilter
-            :                    :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
-            :                    :     +- BroadcastExchange
-            :                    :        +- CometNativeColumnarToRow
-            :                    :           +- CometProject
-            :                    :              +- CometFilter
-            :                    :                 +- CometNativeScan parquet spark_catalog.default.store
-            :                    +- BroadcastExchange
-            :                       +- CometNativeColumnarToRow
-            :                          +- CometProject
-            :                             +- CometFilter
-            :                                +- CometNativeScan parquet spark_catalog.default.household_demographics
-            +- BroadcastExchange
-               +- CometNativeColumnarToRow
-                  +- CometProject
-                     +- CometFilter
-                        +- CometNativeScan parquet spark_catalog.default.customer
+   +- CometExchange
+      +- CometProject
+         +- CometBroadcastHashJoin
+            :- CometFilter
+            :  +- CometHashAggregate
+            :     +- CometColumnarExchange
+            :        +- HashAggregate
+            :           +- Project
+            :              +- BroadcastHashJoin
+            :                 :- Project
+            :                 :  +- BroadcastHashJoin
+            :                 :     :- Project
+            :                 :     :  +- BroadcastHashJoin
+            :                 :     :     :- Filter
+            :                 :     :     :  +- ColumnarToRow
+            :                 :     :     :     +-  Scan parquet spark_catalog.default.store_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
+            :                 :     :     :           +- SubqueryBroadcast
+            :                 :     :     :              +- BroadcastExchange
+            :                 :     :     :                 +- CometNativeColumnarToRow
+            :                 :     :     :                    +- CometProject
+            :                 :     :     :                       +- CometFilter
+            :                 :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     +- BroadcastExchange
+            :                 :     :        +- CometNativeColumnarToRow
+            :                 :     :           +- CometProject
+            :                 :     :              +- CometFilter
+            :                 :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     +- BroadcastExchange
+            :                 :        +- CometNativeColumnarToRow
+            :                 :           +- CometProject
+            :                 :              +- CometFilter
+            :                 :                 +- CometNativeScan parquet spark_catalog.default.store
+            :                 +- BroadcastExchange
+            :                    +- CometNativeColumnarToRow
+            :                       +- CometProject
+            :                          +- CometFilter
+            :                             +- CometNativeScan parquet spark_catalog.default.household_demographics
+            +- CometBroadcastExchange
+               +- CometProject
+                  +- CometFilter
+                     +- CometNativeScan parquet spark_catalog.default.customer
 
-Comet accelerated 18 out of 37 eligible operators (48%). Final plan contains 8 transitions between Spark and Comet.
+Comet accelerated 23 out of 37 eligible operators (62%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_0/q6.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_0/q6.native_datafusion/extended.txt
@@ -1,7 +1,7 @@
-TakeOrderedAndProject
-+- Filter
-   +- HashAggregate
-      +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometFilter
+      +- CometHashAggregate
          +- CometColumnarExchange
             +- HashAggregate
                +- Project
@@ -67,4 +67,4 @@ TakeOrderedAndProject
                                                    +- CometFilter
                                                       +- CometNativeScan parquet spark_catalog.default.item
 
-Comet accelerated 39 out of 60 eligible operators (65%). Final plan contains 8 transitions between Spark and Comet.
+Comet accelerated 42 out of 60 eligible operators (70%). Final plan contains 8 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.native_datafusion/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+- HashAggregate
-   +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
       +- CometColumnarExchange
          +- HashAggregate
             +- Project
@@ -62,4 +62,4 @@ TakeOrderedAndProject
                            +- CometFilter
                               +- CometNativeScan parquet spark_catalog.default.customer_demographics
 
-Comet accelerated 21 out of 52 eligible operators (40%). Final plan contains 11 transitions between Spark and Comet.
+Comet accelerated 23 out of 52 eligible operators (44%). Final plan contains 11 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34.native_datafusion/extended.txt
@@ -1,47 +1,45 @@
 CometNativeColumnarToRow
 +- CometSort
-   +- CometColumnarExchange
-      +- Project
-         +- BroadcastHashJoin
-            :- Filter
-            :  +- HashAggregate
-            :     +- CometNativeColumnarToRow
-            :        +- CometColumnarExchange
-            :           +- HashAggregate
-            :              +- Project
-            :                 +- BroadcastHashJoin
-            :                    :- Project
-            :                    :  +- BroadcastHashJoin
-            :                    :     :- Project
-            :                    :     :  +- BroadcastHashJoin
-            :                    :     :     :- Filter
-            :                    :     :     :  +- ColumnarToRow
-            :                    :     :     :     +-  Scan parquet spark_catalog.default.store_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
-            :                    :     :     :           +- SubqueryBroadcast
-            :                    :     :     :              +- BroadcastExchange
-            :                    :     :     :                 +- CometNativeColumnarToRow
-            :                    :     :     :                    +- CometProject
-            :                    :     :     :                       +- CometFilter
-            :                    :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
-            :                    :     :     +- BroadcastExchange
-            :                    :     :        +- CometNativeColumnarToRow
-            :                    :     :           +- CometProject
-            :                    :     :              +- CometFilter
-            :                    :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
-            :                    :     +- BroadcastExchange
-            :                    :        +- CometNativeColumnarToRow
-            :                    :           +- CometProject
-            :                    :              +- CometFilter
-            :                    :                 +- CometNativeScan parquet spark_catalog.default.store
-            :                    +- BroadcastExchange
-            :                       +- CometNativeColumnarToRow
-            :                          +- CometProject
-            :                             +- CometFilter
-            :                                +- CometNativeScan parquet spark_catalog.default.household_demographics
-            +- BroadcastExchange
-               +- CometNativeColumnarToRow
-                  +- CometProject
-                     +- CometFilter
-                        +- CometNativeScan parquet spark_catalog.default.customer
+   +- CometExchange
+      +- CometProject
+         +- CometBroadcastHashJoin
+            :- CometFilter
+            :  +- CometHashAggregate
+            :     +- CometColumnarExchange
+            :        +- HashAggregate
+            :           +- Project
+            :              +- BroadcastHashJoin
+            :                 :- Project
+            :                 :  +- BroadcastHashJoin
+            :                 :     :- Project
+            :                 :     :  +- BroadcastHashJoin
+            :                 :     :     :- Filter
+            :                 :     :     :  +- ColumnarToRow
+            :                 :     :     :     +-  Scan parquet spark_catalog.default.store_sales [COMET: Native DataFusion scan does not support subqueries/dynamic pruning]
+            :                 :     :     :           +- SubqueryBroadcast
+            :                 :     :     :              +- BroadcastExchange
+            :                 :     :     :                 +- CometNativeColumnarToRow
+            :                 :     :     :                    +- CometProject
+            :                 :     :     :                       +- CometFilter
+            :                 :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     +- BroadcastExchange
+            :                 :     :        +- CometNativeColumnarToRow
+            :                 :     :           +- CometProject
+            :                 :     :              +- CometFilter
+            :                 :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     +- BroadcastExchange
+            :                 :        +- CometNativeColumnarToRow
+            :                 :           +- CometProject
+            :                 :              +- CometFilter
+            :                 :                 +- CometNativeScan parquet spark_catalog.default.store
+            :                 +- BroadcastExchange
+            :                    +- CometNativeColumnarToRow
+            :                       +- CometProject
+            :                          +- CometFilter
+            :                             +- CometNativeScan parquet spark_catalog.default.household_demographics
+            +- CometBroadcastExchange
+               +- CometProject
+                  +- CometFilter
+                     +- CometNativeScan parquet spark_catalog.default.customer
 
-Comet accelerated 18 out of 37 eligible operators (48%). Final plan contains 8 transitions between Spark and Comet.
+Comet accelerated 23 out of 37 eligible operators (62%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.native_datafusion/extended.txt
@@ -1,7 +1,7 @@
-TakeOrderedAndProject
-+- Filter
-   +- HashAggregate
-      +- CometNativeColumnarToRow
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometFilter
+      +- CometHashAggregate
          +- CometColumnarExchange
             +- HashAggregate
                +- Project
@@ -65,4 +65,4 @@ TakeOrderedAndProject
                                                    +- CometFilter
                                                       +- CometNativeScan parquet spark_catalog.default.item
 
-Comet accelerated 39 out of 58 eligible operators (67%). Final plan contains 8 transitions between Spark and Comet.
+Comet accelerated 42 out of 58 eligible operators (72%). Final plan contains 8 transitions between Spark and Comet.

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -1984,6 +1984,23 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("sum of double division with filter matches Spark precision") {
+    // Reproduces the aggregates_part3.sql failure where sum(1/ten) filter (where ten > 0)
+    // produces a different floating point result in Comet vs Spark due to different
+    // accumulation order in vectorized vs row-by-row processing.
+    // tenk1-like table: 10000 rows, "ten" column has values 0-9, each 1000 times.
+    val data = (0 until 10000).map(i => (i, i % 10))
+    withParquetTable(data, "tenk1_test") {
+      // Exact match test -- this is what the Spark SQL golden file tests expect
+      checkSparkAnswer(
+        "SELECT sum(1.0 / _2) FROM tenk1_test WHERE _2 > 0")
+
+      // With FILTER clause syntax if supported
+      checkSparkAnswer(
+        "SELECT sum(CAST(1 AS DOUBLE) / _2) FROM tenk1_test WHERE _2 > 0")
+    }
+  }
+
   protected def checkSparkAnswerAndNumOfAggregates(query: String, numAggregates: Int): Unit = {
     val df = sql(query)
     checkSparkAnswer(df)

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -1292,6 +1292,34 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("bitwise aggregates allow Spark partial and Comet final") {
+    withSQLConf(
+      CometConf.COMET_EXEC_SHUFFLE_ENABLED.key -> "true",
+      CometConf.COMET_SHUFFLE_MODE.key -> "jvm",
+      CometConf.COMET_ENABLE_PARTIAL_HASH_AGGREGATE.key -> "false",
+      CometConf.COMET_ENABLE_FINAL_HASH_AGGREGATE.key -> "true",
+      CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true") {
+      val table = "bitwise_mixed"
+      withTable(table) {
+        sql(
+          s"create table $table(col1 long, col2 int, col3 short, col4 byte, grp int) using parquet")
+        sql(
+          s"insert into $table values" +
+            "(4, 1, 1, 3, 0), (4, 1, 1, 3, 0), (3, 3, 1, 4, 1)," +
+            " (2, 4, 2, 5, 1), (1, 3, 2, 6, 0)")
+
+        // Partial aggregate stays in Spark, final aggregate runs in Comet.
+        checkSparkAnswerAndNumOfAggregates(
+          s"SELECT grp, BIT_AND(col1), BIT_OR(col1), BIT_XOR(col1)," +
+            " BIT_AND(col2), BIT_OR(col2), BIT_XOR(col2)," +
+            " BIT_AND(col3), BIT_OR(col3), BIT_XOR(col3)," +
+            " BIT_AND(col4), BIT_OR(col4), BIT_XOR(col4)" +
+            s" FROM $table GROUP BY grp",
+          1)
+      }
+    }
+  }
+
   def setupAndTestAggregates(
       table: String,
       data: Seq[(Any, Any, Any)],

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -1310,7 +1310,7 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
 
         // Partial aggregate stays in Spark, final aggregate runs in Comet.
         checkSparkAnswerAndNumOfAggregates(
-          s"SELECT grp, BIT_AND(col1), BIT_OR(col1), BIT_XOR(col1)," +
+          "SELECT grp, BIT_AND(col1), BIT_OR(col1), BIT_XOR(col1)," +
             " BIT_AND(col2), BIT_OR(col2), BIT_XOR(col2)," +
             " BIT_AND(col3), BIT_OR(col3), BIT_XOR(col3)," +
             " BIT_AND(col4), BIT_OR(col4), BIT_XOR(col4)" +

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -2173,6 +2173,32 @@ class CometExecSuite extends CometTestBase {
     }
   }
 
+  test("correlated IN subquery with count and OR") {
+    // Reproduces the "count bug" where count(*) in a correlated subquery
+    // should return 0 (not null) when no rows match the correlation predicate.
+    // This specifically tests the OR case where two IN subqueries are combined,
+    // which triggers a different decorrelation plan structure.
+    withSQLConf(
+      CometConf.COMET_EXEC_SHUFFLE_ENABLED.key -> "true",
+      CometConf.COMET_SHUFFLE_MODE.key -> "jvm") {
+      withTempView("t1", "t2") {
+        sql("CREATE TEMPORARY VIEW t1(c1, c2) AS VALUES (0, 1), (1, 2)")
+        sql("CREATE TEMPORARY VIEW t2(c1, c2) AS VALUES (0, 2), (0, 3)")
+
+        // Single IN subquery with count(*) -- baseline
+        checkSparkAnswer(
+          "SELECT * FROM t1 WHERE c1 IN " +
+            "(SELECT count(*) + 1 FROM t2 WHERE t2.c1 = t1.c1)")
+
+        // Two IN subqueries combined with OR -- the failing case
+        checkSparkAnswer(
+          "SELECT * FROM t1 WHERE " +
+            "c1 IN (SELECT count(*) + 1 FROM t2 WHERE t2.c1 = t1.c1) OR " +
+            "c2 IN (SELECT count(*) - 1 FROM t2 WHERE t2.c1 = t1.c1)")
+      }
+    }
+  }
+
 }
 
 case class BucketedTableTestSpec(

--- a/spark/src/test/scala/org/apache/comet/rules/CometExecRuleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/CometExecRuleSuite.scala
@@ -22,7 +22,7 @@ package org.apache.comet.rules
 import scala.util.Random
 
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Literal}
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.expressions.aggregate.{Average, BitAndAgg, BitOrAgg, BitXorAgg, Count, Max, Min, Sum}
 import org.apache.spark.sql.comet._
 import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec


### PR DESCRIPTION
## Which issue does this PR close?

Closes #2894

## Rationale for this change

Comet currently falls back to Spark for ALL final hash aggregates when there's no Comet partial aggregate in the child plan. This is overly conservative because some aggregates have compatible intermediate buffer formats between Spark and Comet.
For example, MIN, MAX, COUNT, and bitwise aggregates (BIT_AND, BIT_OR, BIT_XOR) have simple intermediate buffers (single value) that are compatible between Spark and Comet. These can safely run with "Spark partial / Comet final" execution.
Other aggregates like SUM, AVG, VARIANCE, etc. have known incompatibilities (e.g., decimal overflow handling differences, complex intermediate buffers) and should continue to fall back when there's no Comet partial aggregate.
## What changes are included in this PR?

Added supportsSparkPartialCometFinal method to CometAggregateExpressionSerde trait - Default is false

Added helper function - aggSupportsMixedExecution() in QueryPlanSerde

## How are these changes tested?

"CometExecRule should not allow Spark partial and Comet final for unsafe aggregates" - Verifies SUM still falls back to Spark

"CometExecRule should allow Spark partial and Comet final for safe aggregates" - Verifies MIN/MAX/COUNT can use Comet final with Spark partial
