### PR TITLE
fix: CometShuffleManager hang by deferring SparkEnv access

### DIFF
--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -59,10 +59,6 @@ jobs:
           - {name: "sql_hive-1", args1: "", args2: "hive/testOnly * -- -l org.apache.spark.tags.ExtendedHiveTest -l org.apache.spark.tags.SlowHiveTest"}
           - {name: "sql_hive-2", args1: "", args2: "hive/testOnly * -- -n org.apache.spark.tags.ExtendedHiveTest"}
           - {name: "sql_hive-3", args1: "", args2: "hive/testOnly * -- -n org.apache.spark.tags.SlowHiveTest"}
-        # Skip sql_hive-1 for Spark 4.0 due to https://github.com/apache/datafusion-comet/issues/2946
-        exclude:
-          - spark-version: {short: '4.0', full: '4.0.1', java: 17}
-            module: {name: "sql_hive-1", args1: "", args2: "hive/testOnly * -- -l org.apache.spark.tags.ExtendedHiveTest -l org.apache.spark.tags.SlowHiveTest"}
       fail-fast: false
     name: spark-sql-${{ matrix.module.name }}/${{ matrix.os }}/spark-${{ matrix.spark-version.full }}/java-${{ matrix.spark-version.java }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Which issue does this PR close?


Closes https://github.com/apache/datafusion-comet/issues/2946

## Rationale for this change

The sql_hive-1 tests for Spark 4.0 were timing out (hanging indefinitely) when Comet was enabled. The last test shown in logs was HivePartitionFilteringSuite. Investigation showed that CometShuffleManager accessed SparkEnv.get.executorId during initialization via a lazy val, which could hang when SparkEnv wasn't fully initialized (e.g., during Hive metastore operations in Spark 4.0).
This fix defers SparkEnv access until task execution (when getWriter()/getReader() is called), ensuring SparkEnv is available and preventing the hang.

## What changes are included in this PR?

Changed shuffleExecutorComponents from a lazy val that accessed SparkEnv.get during construction to a @volatile variable with double-checked locking

Added a null check with a clear error message if SparkEnv is unexpectedly null

## How are these changes tested?

CI verification: Re-enabled sql_hive-1 tests for Spark 4.0 in the GitHub Actions workflow. These tests will run as part of the CI pipeline to verify the fix.