### PR TITLE
fix: [iceberg] reduce granularity of metrics updates in IcebergFileStream

### DIFF
--- a/native/core/src/execution/operators/iceberg_scan.rs
+++ b/native/core/src/execution/operators/iceberg_scan.rs
@@ -369,11 +369,7 @@ impl IcebergFileStream {
                         }
                     }
 
-                    match ready!(self
-                        .metrics
-                        .baseline
-                        .record_poll(current.poll_next_unpin(cx)))
-                    {
+                    match ready!(current.poll_next_unpin(cx)) {
                         Some(result) => {
                             // Stop time_scanning_until_data on first batch (idempotent)
                             self.metrics.file_stream.time_scanning_until_data.stop();
@@ -428,7 +424,7 @@ impl Stream for IcebergFileStream {
         self.metrics.file_stream.time_processing.start();
         let result = self.poll_inner(cx);
         self.metrics.file_stream.time_processing.stop();
-        result
+        self.metrics.baseline.record_poll(result)
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A.

## Rationale for this change

Profiling of Iceberg table scans revealed significant overhead from timer calls (`clock_gettime`) in the `IcebergFileStream` state machine.

## What changes are included in this PR?

Move `baseline.record_poll()` from inside the state machine (where it wrapped every batch poll) to the top-level `poll_next()` method, [matching the DataFusion `FileStream` pattern](https://github.com/apache/datafusion/blob/166ef8112152f767babcd4d156775c21f27efff7/datafusion/datasource/src/file_stream.rs#L269):

- Remove nested `record_poll()` in the `Reading` state
- Add `record_poll()` call at the top-level `poll_next()`

## How are these changes tested?

Existing tests.