### PR TITLE
perf: minor optimizations in `process_sorted_row_partition`

### DIFF
--- a/native/core/src/execution/shuffle/row.rs
+++ b/native/core/src/execution/shuffle/row.rs
@@ -814,7 +814,7 @@ pub fn process_sorted_row_partition(
         }
 
         // Writes a record batch generated from the array builders to the output file.
-        // Note: finish() resets the builder, making it reusable for the next batch.
+        // Note: builder_to_array calls finish() which resets the builder, making it reusable for the next batch.
         let array_refs: Result<Vec<ArrayRef>, _> = data_builders
             .iter_mut()
             .zip(schema.iter())


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/datafusion-comet/issues/3057

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Try to improve the performance of the sort-based shuffle.

There are minor optimizations that won't have a big impact, but do reduce some allocations and system calls.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Several minor optimizations:
- Re-use arrow builders across batches
- Re-use mutable buffer across batches
- Open file once rather than once per batch

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests
