### PR TITLE
perf: set DataFusion session context's target_partitions to match Spark's spark.task.cpus

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -78,6 +78,7 @@ class CometExecIterator(
   private val nativeLib = new Native()
   private val nativeUtil = new NativeUtil()
   private val taskAttemptId = TaskContext.get().taskAttemptId
+  private val taskCPUs = TaskContext.get().cpus()
   private val cometTaskMemoryManager = new CometTaskMemoryManager(id, taskAttemptId)
   private val cometBatchIterators = inputs.map { iterator =>
     new CometBatchIterator(iterator, nativeUtil)
@@ -121,6 +122,7 @@ class CometExecIterator(
       memoryConfig.memoryLimit,
       memoryConfig.memoryLimitPerTask,
       taskAttemptId,
+      taskCPUs,
       keyUnwrapper)
   }
 

--- a/spark/src/main/scala/org/apache/comet/Native.scala
+++ b/spark/src/main/scala/org/apache/comet/Native.scala
@@ -68,6 +68,7 @@ class Native extends NativeBase {
       memoryLimit: Long,
       memoryLimitPerTask: Long,
       taskAttemptId: Long,
+      taskCPUs: Long,
       keyUnwrapper: CometFileKeyUnwrapper): Long
   // scalastyle:on
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

While trying to understand some Tokio mutex thrashing in Iceberg scans, I noticed that each DataFusion session context's `target_partitions` is the default, which is the number of CPUs on a system. However, on Spark executors with a large number of cores, tasks running in parallel will all try to use the number of CPUs, resulting in high scheduling overhead because each task has its own session context.

All DataFusion sessions share the same singleton Tokio worker pool, which also defaults to the number of CPUs. So, in an executor that has 64 cores, the default `spark.task.cpus=1`, then 64 concurrent tasks could be trying to use 64 threads each from the same pool, which leaves it significantly oversubscribed.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Set each task's DataFusion context parallelism to the Spark config `spark.task.cpus`.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests. Most tests that create their own session context actually hard code it to 1, which is the default for `spark.task.cpus`.