### PR TITLE
fix: Convert Spark columnar batches to Arrow in CometNativeWriteExec …

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometDataWritingCommand.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometDataWritingCommand.scala
@@ -24,7 +24,7 @@ import java.util.Locale
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.comet.{CometNativeExec, CometNativeWriteExec}
+import org.apache.spark.sql.comet.{CometNativeExec, CometNativeWriteExec, CometPlan, CometSparkToColumnarExec}
 import org.apache.spark.sql.execution.command.DataWritingCommandExec
 import org.apache.spark.sql.execution.datasources.{InsertIntoHadoopFsRelationCommand, WriteFilesExec}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
@@ -160,11 +160,19 @@ object CometDataWritingCommand extends CometOperatorSerde[DataWritingCommandExec
     // Get the child plan from the WriteFilesExec or use the child directly
     val childPlan = op.child match {
       case writeFiles: WriteFilesExec =>
-        // The WriteFilesExec child should already be a Comet operator
         writeFiles.child
       case other =>
-        // Fallback: use the child directly
         other
+    }
+
+    // Wrap with CometSparkToColumnarExec if child is not already a Comet operator.
+    // This ensures the input to CometNativeWriteExec is always in Arrow format.
+    // CometSparkToColumnarExec handles conversion from both:
+    //   - Row-based Spark operators (via rowToArrowBatchIter)
+    //   - Columnar Spark operators like RangeExec (via columnarBatchToArrowBatchIter)
+    val wrappedChild = childPlan match {
+      case _: CometPlan => childPlan // Already produces Arrow batches
+      case _ => CometSparkToColumnarExec(childPlan) // Convert Spark format to Arrow
     }
 
     // Create FileCommitProtocol for atomic writes
@@ -189,7 +197,7 @@ object CometDataWritingCommand extends CometOperatorSerde[DataWritingCommandExec
           throw new SparkException(s"Could not instantiate FileCommitProtocol: ${e.getMessage}")
       }
 
-    CometNativeWriteExec(nativeOp, childPlan, outputPath, committer, jobId)
+    CometNativeWriteExec(nativeOp, wrappedChild, outputPath, committer, jobId)
   }
 
   private def parseCompressionCodec(cmd: InsertIntoHadoopFsRelationCommand) = {

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeWriteExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeWriteExec.scala
@@ -26,19 +26,16 @@ import scala.jdk.CollectionConverters._
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.{Job, TaskAttemptContext, TaskAttemptID, TaskID, TaskType}
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
-import org.apache.spark.TaskContext
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.comet.execution.arrow.CometArrowConverters
 import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.Utils
 
-import org.apache.comet.{CometConf, CometExecIterator}
+import org.apache.comet.CometExecIterator
 import org.apache.comet.serde.OperatorOuterClass.Operator
-import org.apache.comet.vector.CometVector
 
 /**
  * Comet physical operator for native Parquet write operations with FileCommitProtocol support.
@@ -141,23 +138,10 @@ case class CometNativeWriteExec(
   }
 
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
-    // Check if the child produces Arrow/Comet batches or Spark batches
-    val childIsComet = child.isInstanceOf[CometPlan]
-
-    // Get the input data from the child operator
-    val childRDD = if (child.supportsColumnar) {
-      child.executeColumnar()
-    } else {
-      // If child doesn't support columnar, convert rows to Arrow columnar batches
-      val maxRecordsPerBatch = CometConf.COMET_BATCH_SIZE.get(conf)
-      val timeZoneId = conf.sessionLocalTimeZone
-      val schema = child.schema
-      child.execute().mapPartitionsInternal { rowIter =>
-        val context = TaskContext.get()
-        CometArrowConverters
-          .rowToArrowBatchIter(rowIter, schema, maxRecordsPerBatch, timeZoneId, context)
-      }
-    }
+    // Child is guaranteed to be a CometPlan (either already a Comet operator or wrapped
+    // with CometSparkToColumnarExec in CometDataWritingCommand.createExec()).
+    // This ensures we always receive Arrow-format batches.
+    val childRDD = child.executeColumnar()
 
     // Capture metadata before the transformation
     val numPartitions = childRDD.getNumPartitions
@@ -166,10 +150,6 @@ case class CometNativeWriteExec(
     val capturedJobTrackerID = jobTrackerID
     val capturedNativeOp = nativeOp
     val capturedAccumulator = taskCommitMessagesAccum // Capture accumulator for use in tasks
-    val capturedChildIsComet = childIsComet
-    val capturedSchema = child.schema
-    val capturedMaxRecordsPerBatch = CometConf.COMET_BATCH_SIZE.get(conf)
-    val capturedTimeZoneId = conf.sessionLocalTimeZone
 
     // Execute native write operation with task-level commit protocol
     childRDD.mapPartitionsInternal { iter =>
@@ -213,28 +193,9 @@ case class CometNativeWriteExec(
       outputStream.close()
       val planBytes = outputStream.toByteArray
 
-      // Convert Spark columnar batches to Arrow format if child is not a Comet operator.
-      // Comet native execution expects Arrow arrays, but Spark operators like RangeExec
-      // produce OnHeapColumnVector which must be converted.
-      val arrowIter = if (capturedChildIsComet) {
-        // Child is already producing Arrow/Comet batches
-        iter
-      } else {
-        // Convert Spark columnar batches to Arrow format
-        val context = TaskContext.get()
-        iter.flatMap { sparkBatch =>
-          CometArrowConverters.columnarBatchToArrowBatchIter(
-            sparkBatch,
-            capturedSchema,
-            capturedMaxRecordsPerBatch,
-            capturedTimeZoneId,
-            context)
-        }
-      }
-
       val execIterator = new CometExecIterator(
         CometExec.newIterId,
-        Seq(arrowIter),
+        Seq(iter), // Child already produces Arrow batches via CometSparkToColumnarExec
         numOutputCols,
         planBytes,
         nativeMetrics,


### PR DESCRIPTION
Fixes https://github.com/apache/datafusion-comet/issues/2944

This happens because `RangeExec` (and other non-Comet Spark operators) produce Spark's `OnHeapColumnVector` instead of Arrow arrays that the native writer expects.

## What changes are included in this PR?

- Modified `CometNativeWriteExec.doExecuteColumnar()` to detect when the child operator is not a `CometPlan`
- Added automatic conversion of Spark columnar batches to Arrow format using `CometArrowConverters.columnarBatchToArrowBatchIter()`
- Added support for row-based input by converting rows to Arrow batches using `CometArrowConverters.rowToArrowBatchIter()`

## How are these changes tested?

Added two new tests in `CometParquetWriterSuite`:

