### PR TITLE
feat: [iceberg] Pass table master key ID to native scan

### DIFF
--- a/native/core/src/execution/operators/iceberg_scan.rs
+++ b/native/core/src/execution/operators/iceberg_scan.rs
@@ -62,6 +62,7 @@ pub struct IcebergScanExec {
     file_task_groups: Vec<Vec<iceberg::scan::FileScanTask>>,
     /// Metrics
     metrics: ExecutionPlanMetricsSet,
+    #[allow(dead_code)]
     /// Optional master key ID for encrypted Iceberg table
     table_master_key: Option<String>,
 }

--- a/native/core/src/execution/operators/iceberg_scan.rs
+++ b/native/core/src/execution/operators/iceberg_scan.rs
@@ -62,6 +62,8 @@ pub struct IcebergScanExec {
     file_task_groups: Vec<Vec<iceberg::scan::FileScanTask>>,
     /// Metrics
     metrics: ExecutionPlanMetricsSet,
+    /// Optional master key ID for encrypted Iceberg table
+    table_master_key: Option<String>,
 }
 
 impl IcebergScanExec {
@@ -70,6 +72,7 @@ impl IcebergScanExec {
         schema: SchemaRef,
         catalog_properties: HashMap<String, String>,
         file_task_groups: Vec<Vec<iceberg::scan::FileScanTask>>,
+        table_master_key: Option<String>,
     ) -> Result<Self, ExecutionError> {
         let output_schema = schema;
         let num_partitions = file_task_groups.len();
@@ -84,6 +87,7 @@ impl IcebergScanExec {
             catalog_properties,
             file_task_groups,
             metrics,
+            table_master_key,
         })
     }
 
@@ -166,6 +170,7 @@ impl IcebergScanExec {
 
         let task_stream = futures::stream::iter(tasks.into_iter().map(Ok)).boxed();
 
+        // TODO: pass table master key to Iceberg Rust ArrowReaderBuilder
         let reader = iceberg::arrow::ArrowReaderBuilder::new(file_io)
             .with_batch_size(batch_size)
             .with_data_file_concurrency_limit(context.session_config().target_partitions())

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -1180,6 +1180,7 @@ impl PhysicalPlanner {
                     required_schema,
                     catalog_properties,
                     file_task_groups,
+                    scan.table_master_key.clone(),
                 )?;
 
                 Ok((

--- a/native/proto/src/proto/operator.proto
+++ b/native/proto/src/proto/operator.proto
@@ -132,6 +132,7 @@ message IcebergScan {
   repeated string partition_data_pool = 10;
   repeated DeleteFileList delete_files_pool = 11;
   repeated spark.spark_expression.Expr residual_pool = 12;
+  optional string table_master_key = 13;
 }
 
 // Helper message for deduplicating field ID lists


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to #. https://github.com/apache/datafusion-comet/issues/2921

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

 - Iceberg's support to Parquet Modular Encryption [requires](https://iceberg.apache.org/docs/nightly/encryption/#encryption) 2 properties: one catalog-level property `encryption.kms-impl` and the other table-level property `encryption.key-id`.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
 - This PR pass the table-level property, `encryption.key-id`, to native scan so that we can pass to Iceberg Rust reader for KMS management.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
