### PR TITLE
perf: [iceberg] reduce nativeIcebergScanMetadata serialization points

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometIcebergNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometIcebergNativeScanExec.scala
@@ -166,8 +166,7 @@ case class CometIcebergNativeScanExec(
         this.metadataLocation == other.metadataLocation &&
         this.output == other.output &&
         this.serializedPlanOpt == other.serializedPlanOpt &&
-        this.numPartitions == other.numPartitions &&
-        this.nativeIcebergScanMetadata == other.nativeIcebergScanMetadata
+        this.numPartitions == other.numPartitions
       case _ =>
         false
     }
@@ -178,8 +177,7 @@ case class CometIcebergNativeScanExec(
       metadataLocation,
       output.asJava,
       serializedPlanOpt,
-      numPartitions: java.lang.Integer,
-      nativeIcebergScanMetadata)
+      numPartitions: java.lang.Integer)
 }
 
 object CometIcebergNativeScanExec {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

During Iceberg workloads, profiling revealed high GC time caused by Java deserialization of `List$SerializationProxy` objects (22.1 MiB allocations per task).

`CometIcebergNativeScanMetadata` contains heavyweight Iceberg objects (FileScanTasks list, table, schemas) with nested Scala collections. These were being included in `equals()`/`hashCode()` methods, causing Java serializer to recursively traverse the entire object graph during task serialization, creating allocation pressure.

The metadata is only needed during query planning to convert Iceberg metadata to protobuf. After conversion, all necessary information exists in the serialized `nativeOp`, making the metadata unnecessary.

## What changes are included in this PR?

1. Mark `nativeIcebergScanMetadata` as `@transient` in `CometBatchScanExec` to prevent serialization to executors
2. Remove `nativeIcebergScanMetadata` from `equals()`/`hashCode()` in both `CometBatchScanExec` and `CometIcebergNativeScanExec` to prevent object graph traversal during plan comparison
3. Set `nativeIcebergScanMetadata = None` in `CometBatchScanExec.doCanonicalize()` to free driver memory during plan optimization

Equivalence checking remains correct because `wrappedScan.equals()` already compares the underlying `BatchScanExec` with all its Iceberg metadata.

## How are these changes tested?

Existing tests. I will try to benchmark it locally as well.