### PR TITLE
build: use `install` instead of `compile` in TPC CI jobs

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -351,7 +351,7 @@ jobs:
 
       - name: Build project
         run: |
-          ./mvnw -B -Prelease compile test-compile -DskipTests
+          ./mvnw -B -Prelease install -DskipTests
 
       - name: Generate TPC-H data (SF=1)
         if: steps.cache-tpch.outputs.cache-hit != 'true'
@@ -407,7 +407,7 @@ jobs:
 
       - name: Build project
         run: |
-          ./mvnw -B -Prelease compile test-compile -DskipTests
+          ./mvnw -B -Prelease install -DskipTests
 
       - name: Checkout tpcds-kit
         if: steps.cache-tpcds.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
- Fix TPC-H and TPC-DS verification jobs that fail with "Could not resolve dependencies" error
- The jobs were failing because Maven couldn't find `comet-common` when running from the `spark/` subdirectory

## Root Cause
The "Generate data" steps run Maven from within the spark/ subdirectory:
```bash
cd spark && MAVEN_OPTS='-Xmx20g' ../mvnw -B -Prelease exec:java ...
```

When Maven runs from a submodule directory, it doesn't see the reactor build and tries to resolve `comet-common` as a dependency from `~/.m2/repository` or remote repos. Since the previous "Build project" step only ran `compile test-compile`, the artifact was never installed locally.

## Fix
Change `compile test-compile -DskipTests` to `install -DskipTests` so that the common module JAR is installed to the local Maven repository before the data generation step.

## Test plan
- [ ] CI passes on this PR
- [ ] TPC-H and TPC-DS verification jobs complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)