### PR TITLE
fix: Normalize multi-line notes in GenerateDocs

### DIFF
--- a/spark/src/main/scala/org/apache/comet/GenerateDocs.scala
+++ b/spark/src/main/scala/org/apache/comet/GenerateDocs.scala
@@ -180,7 +180,9 @@ object GenerateDocs {
     if (annotations.nonEmpty) {
       w.write("\n**Notes:**\n".getBytes)
       for ((from, to, note) <- annotations.distinct) {
-        w.write(s"- **$from -> $to**: $note\n".getBytes)
+        // Normalize note by replacing newlines with spaces for prettier compatibility
+        val normalizedNote = note.replaceAll("\\s*\\n\\s*", " ")
+        w.write(s"- **$from -> $to**: $normalizedNote\n".getBytes)
       }
     }
   }


### PR DESCRIPTION
GenerateDocs was writing multi-line notes from CometCast annotations directly to the markdown file, which caused formatting issues with prettier. The continuation lines were indented, creating differences when prettier reformatted the file.

This change normalizes multi-line notes by replacing newlines and surrounding whitespace with single spaces before writing to the markdown file, ensuring compatibility with prettier's expected format.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
