### PR TITLE
chore: Remove IgnoreCometNativeScan from ParquetEncryptionSuite in 3.5.7 diff

### DIFF
--- a/dev/diffs/3.5.7.diff
+++ b/dev/diffs/3.5.7.diff
@@ -2941,49 +2941,6 @@ index 52abd248f3a..7a199931a08 100644
        case h: HiveTableScanExec => h.partitionPruningPred.collect {
          case d: DynamicPruningExpression => d.child
        }
-diff --git a/sql/hive/src/test/scala/org/apache/spark/sql/hive/ParquetEncryptionSuite.scala b/sql/hive/src/test/scala/org/apache/spark/sql/hive/ParquetEncryptionSuite.scala
-index 549431ef4f4..e48f1730da6 100644
---- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/ParquetEncryptionSuite.scala
-+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/ParquetEncryptionSuite.scala
-@@ -22,7 +22,7 @@ import java.io.RandomAccessFile
- import java.nio.charset.StandardCharsets
- import java.util.Base64
- 
--import org.apache.spark.sql.QueryTest
-+import org.apache.spark.sql.{IgnoreCometNativeScan, QueryTest}
- import org.apache.spark.sql.hive.test.TestHiveSingleton
- 
- /**
-@@ -37,7 +37,8 @@ class ParquetEncryptionSuite extends QueryTest with TestHiveSingleton {
-   private val key1 = encoder.encodeToString("1234567890123450".getBytes(StandardCharsets.UTF_8))
-   private val key2 = encoder.encodeToString("1234567890123451".getBytes(StandardCharsets.UTF_8))
- 
--  test("SPARK-34990: Write and read an encrypted parquet") {
-+  test("SPARK-34990: Write and read an encrypted parquet",
-+    IgnoreCometNativeScan("no encryption support yet")) {
-     withTempDir { dir =>
-       withSQLConf(
-         "parquet.crypto.factory.class" ->
-@@ -64,7 +65,8 @@ class ParquetEncryptionSuite extends QueryTest with TestHiveSingleton {
-     }
-   }
- 
--  test("SPARK-37117: Can't read files in Parquet encryption external key material mode") {
-+  test("SPARK-37117: Can't read files in Parquet encryption external key material mode",
-+    IgnoreCometNativeScan("no encryption support yet")) {
-     withTempDir { dir =>
-       withSQLConf(
-         "parquet.crypto.factory.class" ->
-@@ -91,7 +93,8 @@ class ParquetEncryptionSuite extends QueryTest with TestHiveSingleton {
-     }
-   }
- 
--  test("SPARK-42114: Test of uniform parquet encryption") {
-+  test("SPARK-42114: Test of uniform parquet encryption",
-+    IgnoreCometNativeScan("no encryption support yet")) {
-     withTempDir { dir =>
-       withSQLConf(
-         "parquet.crypto.factory.class" ->
 diff --git a/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionedTablePerfStatsSuite.scala b/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionedTablePerfStatsSuite.scala
 index de3b1ffccf0..2a76d127093 100644
 --- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionedTablePerfStatsSuite.scala


### PR DESCRIPTION
## Summary

- Remove `IgnoreCometNativeScan` annotations from three Parquet encryption tests in the Spark 3.5.7 diff
- The tests (`SPARK-34990`, `SPARK-37117`, `SPARK-42114`) now pass with both `native_datafusion` and `native_iceberg_compat` scan implementations

## Test plan

- [x] Ran `ParquetEncryptionSuite` with `COMET_PARQUET_SCAN_IMPL=native_datafusion` — all 3 tests pass
- [x] Ran `ParquetEncryptionSuite` with `COMET_PARQUET_SCAN_IMPL=native_iceberg_compat` — all 3 tests pass
- [ ] CI Spark SQL tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)