### PR TITLE
chore: Adapt caching from #3251 to [iceberg] workflows

### DIFF
--- a/.github/workflows/iceberg_spark_test.yml
+++ b/.github/workflows/iceberg_spark_test.yml
@@ -46,15 +46,10 @@ env:
   RUST_VERSION: stable
 
 jobs:
-  # Build native library once per Spark version and share with all test jobs
+  # Build native library once and share with all test jobs
   build-native:
     if: contains(github.event.pull_request.title, '[iceberg]')
-    strategy:
-      matrix:
-        spark-version: [{short: '3.4', full: '3.4.3'}, {short: '3.5', full: '3.5.8'}]
-        scala-version: ['2.13']
-      fail-fast: false
-    name: build-native/spark-${{ matrix.spark-version.short }}/scala-${{ matrix.scala-version }}
+    name: Build Native Library
     runs-on: ubuntu-24.04
     container:
       image: amd64/rust
@@ -80,10 +75,8 @@ jobs:
 
       - name: Build native library
         # Use CI profile for faster builds (no LTO) and to share cache with pr_build_linux.yml.
-        # Move the library to target/release/ where Maven's -Prelease profile expects it.
         run: |
           cd native && cargo build --profile ci
-          mkdir -p target/release && mv target/ci/libcomet.so target/release/
 
       - name: Save Cargo cache
         uses: actions/cache/save@v5
@@ -98,8 +91,8 @@ jobs:
       - name: Upload native library
         uses: actions/upload-artifact@v6
         with:
-          name: native-lib-spark-${{ matrix.spark-version.short }}-scala-${{ matrix.scala-version }}
-          path: native/target/release/libcomet.so
+          name: native-lib-iceberg
+          path: native/target/ci/libcomet.so
           retention-days: 1
 
   iceberg-spark:
@@ -129,7 +122,7 @@ jobs:
       - name: Download native library
         uses: actions/download-artifact@v7
         with:
-          name: native-lib-spark-${{ matrix.spark-version.short }}-scala-${{ matrix.scala-version }}
+          name: native-lib-iceberg
           path: native/target/release/
       - name: Build Comet
         run: |
@@ -173,7 +166,7 @@ jobs:
       - name: Download native library
         uses: actions/download-artifact@v7
         with:
-          name: native-lib-spark-${{ matrix.spark-version.short }}-scala-${{ matrix.scala-version }}
+          name: native-lib-iceberg
           path: native/target/release/
       - name: Build Comet
         run: |
@@ -217,7 +210,7 @@ jobs:
       - name: Download native library
         uses: actions/download-artifact@v7
         with:
-          name: native-lib-spark-${{ matrix.spark-version.short }}-scala-${{ matrix.scala-version }}
+          name: native-lib-iceberg
           path: native/target/release/
       - name: Build Comet
         run: |
@@ -261,7 +254,7 @@ jobs:
       - name: Download native library
         uses: actions/download-artifact@v7
         with:
-          name: native-lib-spark-${{ matrix.spark-version.short }}-scala-${{ matrix.scala-version }}
+          name: native-lib-iceberg
           path: native/target/release/
       - name: Build Comet
         run: |
@@ -305,7 +298,7 @@ jobs:
       - name: Download native library
         uses: actions/download-artifact@v7
         with:
-          name: native-lib-spark-${{ matrix.spark-version.short }}-scala-${{ matrix.scala-version }}
+          name: native-lib-iceberg
           path: native/target/release/
       - name: Build Comet
         run: |
@@ -349,7 +342,7 @@ jobs:
       - name: Download native library
         uses: actions/download-artifact@v7
         with:
-          name: native-lib-spark-${{ matrix.spark-version.short }}-scala-${{ matrix.scala-version }}
+          name: native-lib-iceberg
           path: native/target/release/
       - name: Build Comet
         run: |


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

- #3251 improved caching in the standard PR build workflows. I want to bring the same to the `[iceberg]` workflows.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Add caching of Comet library builds for Spark 3.4 and 3.5 to `[iceberg]` that mimics what #3251 did.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing CI tests. I'll try to confirm that builds went faster.
