### PR TITLE
chore: Extract some tied down logic

### DIFF
--- a/native/core/src/execution/shuffle/metrics.rs
+++ b/native/core/src/execution/shuffle/metrics.rs
@@ -1,0 +1,44 @@
+use datafusion::physical_plan::metrics::{
+    BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, Time,
+};
+
+pub(super) struct ShufflePartitionerMetrics {
+    /// metrics
+    pub(super) baseline: BaselineMetrics,
+
+    /// Time to perform repartitioning
+    pub(super) repart_time: Time,
+
+    /// Time encoding batches to IPC format
+    pub(super) encode_time: Time,
+
+    /// Time spent writing to disk. Maps to "shuffleWriteTime" in Spark SQL Metrics.
+    pub(super) write_time: Time,
+
+    /// Number of input batches
+    pub(super) input_batches: Count,
+
+    /// count of spills during the execution of the operator
+    pub(super) spill_count: Count,
+
+    /// total spilled bytes during the execution of the operator
+    pub(super) spilled_bytes: Count,
+
+    /// The original size of spilled data. Different to `spilled_bytes` because of compression.
+    pub(super) data_size: Count,
+}
+
+impl ShufflePartitionerMetrics {
+    pub(super) fn new(metrics: &ExecutionPlanMetricsSet, partition: usize) -> Self {
+        Self {
+            baseline: BaselineMetrics::new(metrics, partition),
+            repart_time: MetricBuilder::new(metrics).subset_time("repart_time", partition),
+            encode_time: MetricBuilder::new(metrics).subset_time("encode_time", partition),
+            write_time: MetricBuilder::new(metrics).subset_time("write_time", partition),
+            input_batches: MetricBuilder::new(metrics).counter("input_batches", partition),
+            spill_count: MetricBuilder::new(metrics).spill_count(partition),
+            spilled_bytes: MetricBuilder::new(metrics).spilled_bytes(partition),
+            data_size: MetricBuilder::new(metrics).counter("data_size", partition),
+        }
+    }
+}

--- a/native/core/src/execution/shuffle/metrics.rs
+++ b/native/core/src/execution/shuffle/metrics.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use datafusion::physical_plan::metrics::{
     BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, Time,
 };

--- a/native/core/src/execution/shuffle/mod.rs
+++ b/native/core/src/execution/shuffle/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod codec;
 mod comet_partitioning;
 mod list;
 mod map;
+mod metrics;
 pub mod row;
 mod shuffle_writer;
 

--- a/native/core/src/execution/shuffle/mod.rs
+++ b/native/core/src/execution/shuffle/mod.rs
@@ -17,6 +17,7 @@
 
 pub(crate) mod codec;
 mod comet_partitioning;
+mod metrics;
 mod shuffle_writer;
 pub mod spark_unsafe;
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Towards [#3354](https://github.com/apache/datafusion-comet/issues/3354)

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Starts separating code so moving the partitioners out of the shuffle_writer file will not look like a mess.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

1. Moved metrics into a separate file.

2. Renamed the struct ShufflePartitionerMetrics, there is some inconsistent use of "partitioner" and "repartitioner" throughout the module, I think partitioner fits better since we only deal from the context of a single partition at all times, and regardless of which variation is chosen I think it's better to make everything uniform.

3. Moved the function that aligns the scratch space with the current buffered batches into the ScratchSpace struct itself, it seems very logical due to the function signature and its actual logic.
Did this mostly because it moves out a big chunk of code that was "stuck" inside the partitioner logic itself, which will make changes there look a bit messy.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

By the usual tests, as there is no change in logic.