### PR TITLE
minor: map_from_entries sql tests

### DIFF
--- a/spark/src/test/resources/sql-tests/expressions/map/map_from_entries.sql
+++ b/spark/src/test/resources/sql-tests/expressions/map/map_from_entries.sql
@@ -32,5 +32,6 @@ SELECT map_from_entries(array(struct(cast('x' as binary), 10)))
 query expect_fallback(Using BinaryType as Map values is not allowed in map_from_entries)
 SELECT map_from_entries(array(struct(10, cast('x' as binary))))
 
+-- literal arguments
 query spark_answer_only
 SELECT map_from_entries(array(struct('x', 10), struct('y', 20), struct('z', 30)))


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Part of: https://github.com/apache/datafusion-comet/pull/3328

## What changes are included in this PR?

SQL-file tests have been added for the map_from_entries function.

## How are these changes tested?