### PR TITLE
chore: add confirmation before tarball is released

### DIFF
--- a/dev/release/release-tarball.sh
+++ b/dev/release/release-tarball.sh
@@ -43,6 +43,13 @@ fi
 version=$1
 rc=$2
 
+read -r -p "Proceed to release tarball for ${version}-rc${rc}? [y/N]: " answer
+answer=${answer:-no}
+if [ "${answer}" != "y" ]; then
+  echo "Cancelled tarball release!"
+  exit 1
+fi
+
 tmp_dir=tmp-apache-datafusion-comet-dist
 
 echo "Recreate temporary directory: ${tmp_dir}"


### PR DESCRIPTION
## Which issue does this PR close?


Closes #.

## Rationale for this change

Add confirmation dialogue to confirm tarball release, as it could be triggered by accident 

## What changes are included in this PR?

Update `tarball-release.sh` to ask `y/N` confirmation before it proceeds to release upload

## How are these changes tested?

manual test
