### PR TITLE
perf: Add batch coalescing in BufBatchWriter to reduce IPC schema overhead

### DIFF
--- a/native/core/src/execution/shuffle/partitioners/multi_partition.rs
+++ b/native/core/src/execution/shuffle/partitioners/multi_partition.rs
@@ -442,14 +442,19 @@ impl MultiPartitionShuffleRepartitioner {
         encode_time: &Time,
         write_time: &Time,
         write_buffer_size: usize,
+        batch_size: usize,
     ) -> datafusion::common::Result<()> {
-        let mut buf_batch_writer =
-            BufBatchWriter::new(shuffle_block_writer, output_data, write_buffer_size);
+        let mut buf_batch_writer = BufBatchWriter::new(
+            shuffle_block_writer,
+            output_data,
+            write_buffer_size,
+            batch_size,
+        );
         for batch in partition_iter {
             let batch = batch?;
             buf_batch_writer.write(&batch, encode_time, write_time)?;
         }
-        buf_batch_writer.flush(write_time)?;
+        buf_batch_writer.flush(encode_time, write_time)?;
         Ok(())
     }
 
@@ -508,6 +513,7 @@ impl MultiPartitionShuffleRepartitioner {
                     &self.runtime,
                     &self.metrics,
                     self.write_buffer_size,
+                    self.batch_size,
                 )?;
             }
 
@@ -592,6 +598,7 @@ impl ShufflePartitioner for MultiPartitionShuffleRepartitioner {
                     &self.metrics.encode_time,
                     &self.metrics.write_time,
                     self.write_buffer_size,
+                    self.batch_size,
                 )?;
             }
 

--- a/native/core/src/execution/shuffle/partitioners/single_partition.rs
+++ b/native/core/src/execution/shuffle/partitioners/single_partition.rs
@@ -59,8 +59,12 @@ impl SinglePartitionShufflePartitioner {
             .truncate(true)
             .open(output_data_path)?;
 
-        let output_data_writer =
-            BufBatchWriter::new(shuffle_block_writer, output_data_file, write_buffer_size);
+        let output_data_writer = BufBatchWriter::new(
+            shuffle_block_writer,
+            output_data_file,
+            write_buffer_size,
+            batch_size,
+        );
 
         Ok(Self {
             output_data_writer,
@@ -162,7 +166,8 @@ impl ShufflePartitioner for SinglePartitionShufflePartitioner {
                 &self.metrics.write_time,
             )?;
         }
-        self.output_data_writer.flush(&self.metrics.write_time)?;
+        self.output_data_writer
+            .flush(&self.metrics.encode_time, &self.metrics.write_time)?;
 
         // Write index file. It should only contain 2 entries: 0 and the total number of bytes written
         let index_file = OpenOptions::new()

--- a/native/core/src/execution/shuffle/writers/partition_writer.rs
+++ b/native/core/src/execution/shuffle/writers/partition_writer.rs
@@ -79,6 +79,7 @@ impl PartitionWriter {
         runtime: &RuntimeEnv,
         metrics: &ShufflePartitionerMetrics,
         write_buffer_size: usize,
+        batch_size: usize,
     ) -> datafusion::common::Result<usize> {
         if let Some(batch) = iter.next() {
             self.ensure_spill_file_created(runtime)?;
@@ -88,6 +89,7 @@ impl PartitionWriter {
                     &mut self.shuffle_block_writer,
                     &mut self.spill_file.as_mut().unwrap().file,
                     write_buffer_size,
+                    batch_size,
                 );
                 let mut bytes_written =
                     buf_batch_writer.write(&batch?, &metrics.encode_time, &metrics.write_time)?;
@@ -99,7 +101,7 @@ impl PartitionWriter {
                         &metrics.write_time,
                     )?;
                 }
-                buf_batch_writer.flush(&metrics.write_time)?;
+                buf_batch_writer.flush(&metrics.encode_time, &metrics.write_time)?;
                 bytes_written
             };
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

Closes #.

## Rationale for this change

In the multi-partition shuffle path, each small batch becomes its own IPC block with full schema metadata overhead (~500-2000 bytes). Small batches arise from:

- **Spills under memory pressure**: 200 partitions × frequent spills → ~40 rows per partition per spill event, each becoming a separate IPC block with full schema
- **Trailing batches**: Iterator chunks into `batch_size` (8192), the last chunk is often much smaller
- **Small partitions**: Skewed data or aggregation results may have very few rows per partition

The single-partition path (`SinglePartitionShufflePartitioner`) already coalesces batches before writing. The multi-partition path does not.

## What changes are included in this PR?

Adds batch coalescing to `BufBatchWriter` using Arrow's [`BatchCoalescer`](https://docs.rs/arrow-select/latest/arrow_select/coalesce/struct.BatchCoalescer.html). Instead of serializing every batch immediately into an IPC block, batches are pushed into a `BatchCoalescer` which incrementally builds exactly `batch_size`-row output batches before serialization.

Key design decisions:
- **Uses Arrow's `BatchCoalescer`** rather than manual `Vec<RecordBatch>` + `concat_batches` — avoids the full-batch copy that `concat_batches` requires, using type-specialized `InProgressArray` builders instead
- **Lazy initialization** — the coalescer is created on first `write()` to capture the schema, avoiding the need to thread a `SchemaRef` through all call sites
- **Transparent to callers** — both `shuffle_write_partition` and `PartitionWriter::spill` benefit automatically; the single-partition path already feeds large batches so coalescing is effectively a no-op there

### Files changed

| File | Change |
|---|---|
| `writers/buf_batch_writer.rs` | Replace manual coalescing with `BatchCoalescer`; lazy init on first write; drain completed batches after each push; flush remaining on `flush()` |
| `writers/partition_writer.rs` | Add `batch_size` param to `spill()` |
| `partitioners/multi_partition.rs` | Add `batch_size` param to `shuffle_write_partition()`; pass through at all call sites |
| `partitioners/single_partition.rs` | Update `BufBatchWriter::new()` and `flush()` call signatures |
| `shuffle_writer.rs` | Add coalescing size comparison test |

## How are these changes tested?

New test `test_batch_coalescing_reduces_size` writes 100 small batches (50 rows × 20 int32 columns) through `BufBatchWriter`:
- With `batch_size=8192` (coalescing active) → fewer, larger IPC blocks
- With `batch_size=1` (no coalescing) → many small IPC blocks
- Asserts coalesced output is smaller
- Verifies both roundtrip correctly via `read_ipc_compressed`

All 12 existing shuffle tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)