### PR TITLE
test: Add additional contains expression tests

### DIFF
--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1181,6 +1181,21 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       // Test with pattern at end
       val queryEnd = sql(s"select id from $table where contains (name, 'Smith')")
       checkSparkAnswerAndOperator(queryEnd)
+
+      // Test with null haystack
+      sql(s"insert into $table values(6, null)")
+      checkSparkAnswerAndOperator(sql(s"select id, contains(name, 'Rose') from $table"))
+
+      // Test case sensitivity (should not match)
+      checkSparkAnswerAndOperator(sql(s"select id from $table where contains(name, 'james')"))
+    }
+  }
+
+  test("contains with both columns") {
+    withParquetTable(
+      Seq(("hello world", "world"), ("foo bar", "baz"), ("abc", ""), (null, "x"), ("test", null)),
+      "tbl") {
+      checkSparkAnswerAndOperator(sql("select contains(_1, _2) from tbl"))
     }
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

Follow-up to #2991.

## Rationale for this change

The optimized `contains` implementation merged in #2991 had good test coverage but was missing a few edge cases.

## What changes are included in this PR?

Adds integration tests for:
- Null haystack (`contains(NULL, 'pattern')`) to verify null propagation
- Case sensitivity (`contains(name, 'james')` vs `'James'`)
- Both-columns path (`contains(col1, col2)`) exercising the array-array code path, including null in either position

## How are these changes tested?

All new tests use `checkSparkAnswerAndOperator` to verify both correctness against Spark and that Comet's native operator is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)