### PR TITLE
chore: Add Comet writer nested types test assertion

### DIFF
--- a/spark/src/test/scala/org/apache/comet/parquet/CometParquetWriterSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/CometParquetWriterSuite.scala
@@ -447,17 +447,7 @@ class CometParquetWriterSuite extends CometTestBase {
     }
   }
 
-  private def writeWithCometNativeWriteExec(
-      inputPath: String,
-      outputPath: String,
-      num_partitions: Option[Int] = None): Option[SparkPlan] = {
-    val df = spark.read.parquet(inputPath)
-
-    val plan = captureWritePlan(
-      path => num_partitions.fold(df)(n => df.repartition(n)).write.parquet(path),
-      outputPath)
-
-    // Count CometNativeWriteExec instances in the plan
+  private def assertHasCometNativeWriteExec(plan: SparkPlan): Unit = {
     var nativeWriteCount = 0
     plan.foreach {
       case _: CometNativeWriteExec =>
@@ -474,6 +464,19 @@ class CometParquetWriterSuite extends CometTestBase {
     assert(
       nativeWriteCount == 1,
       s"Expected exactly one CometNativeWriteExec in the plan, but found $nativeWriteCount:\n${plan.treeString}")
+  }
+
+  private def writeWithCometNativeWriteExec(
+      inputPath: String,
+      outputPath: String,
+      num_partitions: Option[Int] = None): Option[SparkPlan] = {
+    val df = spark.read.parquet(inputPath)
+
+    val plan = captureWritePlan(
+      path => num_partitions.fold(df)(n => df.repartition(n)).write.parquet(path),
+      outputPath)
+
+    assertHasCometNativeWriteExec(plan)
 
     Some(plan)
   }
@@ -524,7 +527,10 @@ class CometParquetWriterSuite extends CometTestBase {
         SQLConf.SESSION_LOCAL_TIMEZONE.key -> "America/Halifax") {
 
         val parquetDf = spark.read.parquet(inputPath)
-        parquetDf.write.parquet(outputPath)
+
+        // Capture plan and verify CometNativeWriteExec is used
+        val plan = captureWritePlan(path => parquetDf.write.parquet(path), outputPath)
+        assertHasCometNativeWriteExec(plan)
       }
 
       // Verify round-trip: read with Spark and Comet, compare results


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
Upon reviewing #3351 found that nested types writer tests do not assert that Comet writer has been called
Closes #.
Related to #2967 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
