### PR TITLE
fix: [df52] make relabel_array recursive for nested type mismatches

### DIFF
--- a/native/core/src/parquet/cast_column.rs
+++ b/native/core/src/parquet/cast_column.rs
@@ -104,8 +104,10 @@ fn relabel_array(array: ArrayRef, target_type: &DataType) -> ArrayRef {
         }
         DataType::Map(target_entries_field, sorted) => {
             let map = array.as_any().downcast_ref::<MapArray>().unwrap();
-            let entries =
-                relabel_array(Arc::new(map.entries().clone()), target_entries_field.data_type());
+            let entries = relabel_array(
+                Arc::new(map.entries().clone()),
+                target_entries_field.data_type(),
+            );
             let entries_struct = entries.as_any().downcast_ref::<StructArray>().unwrap();
             Arc::new(MapArray::new(
                 Arc::clone(target_entries_field),
@@ -552,11 +554,7 @@ mod tests {
 
         let keys = StringArray::from(vec!["a", "b"]);
         let values = Int32Array::from(vec![1, 2]);
-        let entries = StructArray::new(
-            struct_fields,
-            vec![Arc::new(keys), Arc::new(values)],
-            None,
-        );
+        let entries = StructArray::new(struct_fields, vec![Arc::new(keys), Arc::new(values)], None);
         let map = MapArray::new(
             physical_entries_field,
             arrow::buffer::OffsetBuffer::new(vec![0, 2].into()),
@@ -622,8 +620,7 @@ mod tests {
         let physical_fields = Fields::from(vec![physical_struct_field]);
         let logical_fields = Fields::from(vec![logical_struct_field]);
 
-        let struct_arr =
-            StructArray::new(physical_fields, vec![Arc::new(list) as ArrayRef], None);
+        let struct_arr = StructArray::new(physical_fields, vec![Arc::new(list) as ArrayRef], None);
         let array: ArrayRef = Arc::new(struct_arr);
 
         let target_type = DataType::Struct(logical_fields);
@@ -632,7 +629,11 @@ mod tests {
 
         // Verify we can access the nested data without panics
         let result_struct = result.as_any().downcast_ref::<StructArray>().unwrap();
-        let result_list = result_struct.column(0).as_any().downcast_ref::<ListArray>().unwrap();
+        let result_list = result_struct
+            .column(0)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap();
         assert_eq!(result_list.len(), 2);
     }
 }


### PR DESCRIPTION
## Summary
- Makes `relabel_array` in `cast_column.rs` recursive so it correctly handles nested type mismatches (field names/metadata differences) in List, LargeList, Map, and Struct arrays
- The previous shallow `ArrayData` type swap caused panics when Arrow's `ArrayData::build()` validated child types recursively
- Fixes three failure categories: List element naming ("item" vs "element"), Map field naming ("key_value" vs "entries"), and PARQUET:field_id metadata mismatches in nested structures

## Test plan
- [x] Added unit test for List field name relabeling ("item" -> "element")
- [x] Added unit test for Map entries field relabeling ("key_value" -> "entries")
- [x] Added unit test for Struct with PARQUET:field_id metadata stripping
- [x] Added unit test for nested Struct containing List with different field names
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)