### PR TITLE
bug: Fix supported types for Bool type casts

### DIFF
--- a/native/spark-expr/src/conversion_funcs/cast.rs
+++ b/native/spark-expr/src/conversion_funcs/cast.rs
@@ -3117,13 +3117,12 @@ fn trim_end(s: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use arrow::array::StringArray;
     use arrow::datatypes::TimestampMicrosecondType;
     use arrow::datatypes::{Field, Fields, TimeUnit};
     use core::f64;
     use std::str::FromStr;
-
-    use super::*;
 
     /// Test helper that wraps the mode-specific parse functions
     fn cast_string_to_i8(str: &str, eval_mode: EvalMode) -> SparkResult<Option<i8>> {
@@ -3744,5 +3743,16 @@ mod tests {
         assert_eq!(r#"[1, null]"#, string_array.value(1));
         assert_eq!(r#"[null]"#, string_array.value(2));
         assert_eq!(r#"[]"#, string_array.value(3));
+    }
+
+    #[test]
+    fn test_cast_supported_boolean_to_string() {
+        let options = SparkCastOptions::new(EvalMode::Legacy, "UTC", false);
+        let is_cast_supported = is_datafusion_spark_compatible(&DataType::Boolean, &DataType::Utf8);
+        assert!(is_cast_supported);
+        assert_eq!(
+            cast_supported(&DataType::Boolean, &DataType::Utf8, &options),
+            is_cast_supported
+        );
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?


Breaking down bug fixes from : https://github.com/apache/datafusion-comet/pull/3491 into a separate PR

Essentially we have the matches macro which supports bool to string cast but the `can_cast_to_boolean' doesnt`. Given that the latter is only called on nested type casts, this was an edge case whose occurrence was not prevalent and the bug prevailed. This test is to fix that bug and ensure consistency all over

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3509  .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
