### PR TITLE
feat: support Spark format_string expression

### DIFF
--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -55,6 +55,7 @@ use datafusion_spark::function::math::hex::SparkHex;
 use datafusion_spark::function::math::width_bucket::SparkWidthBucket;
 use datafusion_spark::function::string::char::CharFunc;
 use datafusion_spark::function::string::concat::SparkConcat;
+use datafusion_spark::function::string::format_string::FormatStringFunc;
 use futures::poll;
 use futures::stream::StreamExt;
 use jni::objects::JByteBuffer;
@@ -400,6 +401,7 @@ fn register_datafusion_spark_function(session_ctx: &SessionContext) {
     session_ctx.register_udf(ScalarUDF::new_from_impl(SparkWidthBucket::default()));
     session_ctx.register_udf(ScalarUDF::new_from_impl(MapFromEntries::default()));
     session_ctx.register_udf(ScalarUDF::new_from_impl(SparkCrc32::default()));
+    session_ctx.register_udf(ScalarUDF::new_from_impl(FormatStringFunc::default()));
 }
 
 /// Prepares arrow arrays for output.

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -154,6 +154,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
     classOf[Concat] -> CometConcat,
     classOf[Contains] -> CometScalarFunction("contains"),
     classOf[EndsWith] -> CometScalarFunction("ends_with"),
+    classOf[FormatString] -> CometScalarFunction("format_string"),
     classOf[InitCap] -> CometInitCap,
     classOf[Length] -> CometLength,
     classOf[Like] -> CometLike,

--- a/spark/src/test/scala/org/apache/comet/CometStringExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometStringExpressionSuite.scala
@@ -148,6 +148,14 @@ class CometStringExpressionSuite extends CometTestBase {
     }
   }
 
+  test("format_string") {
+    withParquetTable(Seq(("hello", 42), ("world", 100), (null, 0)), "tbl") {
+      checkSparkAnswerAndOperator("SELECT format_string('%s has %d items', _1, _2) FROM tbl")
+      checkSparkAnswerAndOperator("SELECT format_string('value: %05d', _2) FROM tbl")
+      checkSparkAnswerAndOperator("SELECT format_string('%s', NULL) FROM tbl")
+    }
+  }
+
   test("split string basic") {
     withSQLConf("spark.comet.expression.StringSplit.allowIncompatible" -> "true") {
       withParquetTable((0 until 5).map(i => (s"value$i,test$i", i)), "tbl") {


### PR DESCRIPTION
## Summary
  - Wire `format_string` from the `datafusion-spark` crate (`FormatStringFunc`) to Comet
  - Register in `jni_api.rs` and add serde mapping via `CometScalarFunction` in `QueryPlanSerde.scala`

  ## Test plan
  - [x] New test in `CometStringExpressionSuite` — passes
  - [x] Spotless formatting check passes
  - [x] Rust native build passes
