### PR TITLE
feat: support ilike expression

### DIFF
--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -55,6 +55,7 @@ use datafusion_spark::function::math::hex::SparkHex;
 use datafusion_spark::function::math::width_bucket::SparkWidthBucket;
 use datafusion_spark::function::string::char::CharFunc;
 use datafusion_spark::function::string::concat::SparkConcat;
+use datafusion_spark::function::string::ilike::SparkILike;
 use futures::poll;
 use futures::stream::StreamExt;
 use jni::objects::JByteBuffer;
@@ -400,6 +401,7 @@ fn register_datafusion_spark_function(session_ctx: &SessionContext) {
     session_ctx.register_udf(ScalarUDF::new_from_impl(SparkWidthBucket::default()));
     session_ctx.register_udf(ScalarUDF::new_from_impl(MapFromEntries::default()));
     session_ctx.register_udf(ScalarUDF::new_from_impl(SparkCrc32::default()));
+    session_ctx.register_udf(ScalarUDF::new_from_impl(SparkILike::default()));
 }
 
 /// Prepares arrow arrays for output.

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -154,6 +154,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
     classOf[Concat] -> CometConcat,
     classOf[Contains] -> CometScalarFunction("contains"),
     classOf[EndsWith] -> CometScalarFunction("ends_with"),
+    classOf[ILike] -> CometILike,
     classOf[InitCap] -> CometInitCap,
     classOf[Length] -> CometLength,
     classOf[Like] -> CometLike,

--- a/spark/src/main/scala/org/apache/comet/serde/strings.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/strings.scala
@@ -21,7 +21,7 @@ package org.apache.comet.serde
 
 import java.util.Locale
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Concat, ConcatWs, Expression, If, InitCap, IsNull, Left, Length, Like, Literal, Lower, RegExpReplace, Right, RLike, StringLPad, StringRepeat, StringRPad, StringSplit, Substring, Upper}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Concat, ConcatWs, Expression, If, ILike, InitCap, IsNull, Left, Length, Like, Literal, Lower, RegExpReplace, Right, RLike, StringLPad, StringRepeat, StringRPad, StringSplit, Substring, Upper}
 import org.apache.spark.sql.types.{BinaryType, DataTypes, LongType, StringType}
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -235,6 +235,19 @@ object CometLike extends CometExpressionSerde[Like] {
       withInfo(expr, s"custom escape character ${expr.escapeChar} not supported in LIKE")
       None
     }
+  }
+}
+
+object CometILike extends CometExpressionSerde[ILike] {
+
+  override def convert(expr: ILike, inputs: Seq[Attribute], binding: Boolean): Option[Expr] = {
+    if (expr.escapeChar != '\\') {
+      withInfo(expr, s"custom escape character ${expr.escapeChar} not supported in ILIKE")
+      return None
+    }
+    val childExpr = expr.children.map(exprToProtoInternal(_, inputs, binding))
+    val optExpr = scalarFunctionExprToProto("ilike", childExpr: _*)
+    optExprWithInfo(optExpr, expr, expr.children: _*)
   }
 }
 


### PR DESCRIPTION
## Summary
  - Wire `ilike` from the `datafusion-spark` crate (`SparkILike`) to Comet
  - Register in `jni_api.rs` and add serde mapping in `QueryPlanSerde.scala`
  - Custom handler `CometILike` in `strings.scala` to reject non-default escape characters
  - ILIKE requires case-insensitive comparison which depends on locale-specific case conversion. When `spark.comet.caseConversion.enabled` is disabled (default), ILIKE falls back to Spark to avoid incompatibilities with Rust's Unicode-based `to_lowercase()` vs Java's locale-aware rules (e.g. Turkish I)

  Please let me know if the `caseConversion` handling is not appropriate

