### PR TITLE
feat: support url_decode expression via StaticInvoke

### DIFF
--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -55,6 +55,7 @@ use datafusion_spark::function::math::hex::SparkHex;
 use datafusion_spark::function::math::width_bucket::SparkWidthBucket;
 use datafusion_spark::function::string::char::CharFunc;
 use datafusion_spark::function::string::concat::SparkConcat;
+use datafusion_spark::function::url::url_decode::UrlDecode;
 use futures::poll;
 use futures::stream::StreamExt;
 use jni::objects::JByteBuffer;
@@ -400,6 +401,7 @@ fn register_datafusion_spark_function(session_ctx: &SessionContext) {
     session_ctx.register_udf(ScalarUDF::new_from_impl(SparkWidthBucket::default()));
     session_ctx.register_udf(ScalarUDF::new_from_impl(MapFromEntries::default()));
     session_ctx.register_udf(ScalarUDF::new_from_impl(SparkCrc32::default()));
+    session_ctx.register_udf(ScalarUDF::new_from_impl(UrlDecode::default()));
 }
 
 /// Prepares arrow arrays for output.


### PR DESCRIPTION
## Summary
  - Add serde support for Spark's `url_decode` function via StaticInvoke
  - Uses datafusion-spark's built-in `url_decode` function (apache/datafusion#17399)
  - **Blocked on DataFusion 52+ upgrade** (#3574) — the `UrlDecode` struct doesn't exist in datafusion-spark 51.0.0

  ## Test plan
  - Added tests in `CometStringExpressionSuite`
  - Tests cannot run until DataFusion upgrade lands
