### PR TITLE
docs: add SAFETY comments to all unsafe blocks in shuffle spark_unsafe module

### DIFF
--- a/native/core/src/execution/shuffle/spark_unsafe/map.rs
+++ b/native/core/src/execution/shuffle/spark_unsafe/map.rs
@@ -30,7 +30,8 @@ pub struct SparkUnsafeMap {
 impl SparkUnsafeMap {
     /// Creates a `SparkUnsafeMap` which points to the given address and size in bytes.
     pub(crate) fn new(addr: i64, size: i32) -> Self {
-        // Read the number of bytes of key array from the first 8 bytes.
+        // SAFETY: addr points to valid Spark UnsafeMap data from the JVM.
+        // The first 8 bytes contain the key array size as a little-endian i64.
         let slice: &[u8] = unsafe { std::slice::from_raw_parts(addr as *const u8, 8) };
         let key_array_size = i64::from_le_bytes(slice.try_into().unwrap());
 


### PR DESCRIPTION
## Summary

- Add `// SAFETY:` comments to all 25 existing `unsafe` blocks in the `spark_unsafe` shuffle module (`row.rs`, `list.rs`, `map.rs`)
- Add a `# Safety` documentation section to the `SparkUnsafeObject` trait documenting invariants for implementors
- No functional changes

All unsafe in this module falls into one category: reading/writing JVM-allocated Spark `UnsafeRow`/`UnsafeArray`/`UnsafeMap` memory via raw pointers received through JNI. The safety invariants are:
- Pointers come from the JVM and remain valid for the batch lifetime (guaranteed by JNI pinning)
- Memory layout follows Spark's documented `UnsafeRow`/`UnsafeArray` format
- Index bounds are enforced by the caller (schema-driven iteration)

## Test plan

- [ ] Documentation-only change, no functional impact
- [ ] Verified `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)