### PR TITLE
perf: reuse CometConf.COMET_TRACING_ENABLED, Native, NativeUtil in NativeBatchDecoderIterator

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometBlockStoreShuffleReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometBlockStoreShuffleReader.scala
@@ -35,6 +35,9 @@ import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.storage.ShuffleBlockFetcherIterator
 import org.apache.spark.util.CompletionIterator
 
+import org.apache.comet.{CometConf, Native}
+import org.apache.comet.vector.NativeUtil
+
 /**
  * Shuffle reader that reads data from the block manager. It reads Arrow-serialized data (IPC
  * format) and returns an iterator of ColumnarBatch.
@@ -86,8 +89,11 @@ class CometBlockStoreShuffleReader[K, C](
   /** Read the combined key-values for this reduce task */
   override def read(): Iterator[Product2[K, C]] = {
     var currentReadIterator: NativeBatchDecoderIterator = null
+    val nativeLib = new Native()
+    val nativeUtil = new NativeUtil()
+    val tracingEnabled = CometConf.COMET_TRACING_ENABLED.get()
 
-    // Closes last read iterator after the task is finished.
+    // Closes last read iterator and shared resources after the task is finished.
     // We need to close read iterator during iterating input streams,
     // instead of one callback per read iterator. Otherwise if there are too many
     // read iterators, it may blow up the call stack and cause OOM.
@@ -95,6 +101,7 @@ class CometBlockStoreShuffleReader[K, C](
       if (currentReadIterator != null) {
         currentReadIterator.close()
       }
+      nativeUtil.close()
     }
 
     val recordIter: Iterator[(Int, ColumnarBatch)] = fetchIterator
@@ -102,8 +109,12 @@ class CometBlockStoreShuffleReader[K, C](
         if (currentReadIterator != null) {
           currentReadIterator.close()
         }
-        currentReadIterator =
-          NativeBatchDecoderIterator(blockIdAndStream._2, context, dep.decodeTime)
+        currentReadIterator = NativeBatchDecoderIterator(
+          blockIdAndStream._2,
+          dep.decodeTime,
+          nativeLib,
+          nativeUtil,
+          tracingEnabled)
         currentReadIterator
       })
       .map(b => (0, b))

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/NativeBatchDecoderIterator.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/NativeBatchDecoderIterator.scala
@@ -23,11 +23,10 @@ import java.io.{EOFException, InputStream}
 import java.nio.{ByteBuffer, ByteOrder}
 import java.nio.channels.{Channels, ReadableByteChannel}
 
-import org.apache.spark.TaskContext
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-import org.apache.comet.{CometConf, Native}
+import org.apache.comet.Native
 import org.apache.comet.vector.NativeUtil
 
 /**
@@ -37,25 +36,18 @@ import org.apache.comet.vector.NativeUtil
  */
 case class NativeBatchDecoderIterator(
     in: InputStream,
-    taskContext: TaskContext,
-    decodeTime: SQLMetric)
+    decodeTime: SQLMetric,
+    nativeLib: Native,
+    nativeUtil: NativeUtil,
+    tracingEnabled: Boolean)
     extends Iterator[ColumnarBatch] {
 
   private var isClosed = false
   private val longBuf = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN)
-  private val native = new Native()
-  private val nativeUtil = new NativeUtil()
-  private val tracingEnabled = CometConf.COMET_TRACING_ENABLED.get()
   private var currentBatch: ColumnarBatch = null
   private var batch = fetchNext()
 
   import NativeBatchDecoderIterator._
-
-  if (taskContext != null) {
-    taskContext.addTaskCompletionListener[Unit](_ => {
-      close()
-    })
-  }
 
   private val channel: ReadableByteChannel = if (in != null) {
     Channels.newChannel(in)
@@ -163,7 +155,7 @@ case class NativeBatchDecoderIterator(
     val batch = nativeUtil.getNextBatch(
       fieldCount,
       (arrayAddrs, schemaAddrs) => {
-        native.decodeShuffleBlock(
+        nativeLib.decodeShuffleBlock(
           dataBuf,
           bytesToRead.toInt,
           arrayAddrs,
@@ -183,7 +175,6 @@ case class NativeBatchDecoderIterator(
           currentBatch = null
         }
         in.close()
-        nativeUtil.close()
         resetDataBuf()
         isClosed = true
       }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

JFR profiling shows ~1.5% of on-CPU time in `NativeBatchDecoderIterator.<init>`, mostly in `SQLConf.get()` called from `CometConf.COMET_TRACING_ENABLED.get()`. `SQLConf.get` is surprisingly expensive: it reads a thread-local, checks whether a conf is set via string key lookups in the underlying Hadoop `Configuration` (which holds a `Properties` map), and may trigger synchronized access. This constructor runs once per shuffle block, so for high-partition shuffles with thousands of blocks per task, the cost accumulates.

Additionally, `Native` (stateless JNI stub) and `NativeUtil` (allocates a `CDataDictionaryProvider` backed by native memory) are created and destroyed per block. These didn’t show up a ton in the profiling, but might as well hoist it out as well.

<img width="1930" height="320" alt="Screenshot 2026-03-03 at 3 41 09 PM" src="https://github.com/user-attachments/assets/75adaf5d-32be-40dd-a3f2-74f28516485f" />

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Hoist `Native`, `NativeUtil`, and `tracingEnabled` out of `NativeBatchDecoderIterator` into `CometBlockStoreShuffleReader.read()`, so they are created once per task instead of once per shuffle block. `NativeUtil` is now closed in the reader's task completion listener.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests.