### PR TITLE
Use datafusion-spark SparkArrayContains for three-valued NULL semantics

### DIFF
--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -55,6 +55,7 @@ use datafusion_spark::function::math::expm1::SparkExpm1;
 use datafusion_spark::function::math::hex::SparkHex;
 use datafusion_spark::function::math::width_bucket::SparkWidthBucket;
 use datafusion_spark::function::string::char::CharFunc;
+use datafusion_spark::function::array::array_contains::SparkArrayContains;
 use datafusion_spark::function::string::concat::SparkConcat;
 use datafusion_spark::function::string::space::SparkSpace;
 use futures::poll;
@@ -387,6 +388,7 @@ fn prepare_datafusion_session_context(
 
 // register UDFs from datafusion-spark crate
 fn register_datafusion_spark_function(session_ctx: &SessionContext) {
+    session_ctx.register_udf(ScalarUDF::new_from_impl(SparkArrayContains::default()));
     session_ctx.register_udf(ScalarUDF::new_from_impl(SparkExpm1::default()));
     session_ctx.register_udf(ScalarUDF::new_from_impl(SparkSha2::default()));
     session_ctx.register_udf(ScalarUDF::new_from_impl(CharFunc::default()));

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -133,36 +133,11 @@ object CometArrayContains extends CometExpressionSerde[ArrayContains] {
     val arrayExprProto = exprToProto(expr.children.head, inputs, binding)
     val keyExprProto = exprToProto(expr.children(1), inputs, binding)
 
-    val arrayContainsScalarExpr =
-      scalarFunctionExprToProto("array_has", arrayExprProto, keyExprProto)
-
-    // Handle NULL array input - return NULL if array is NULL (matching Spark's behavior)
-    val isNotNullExpr = createUnaryExpr(
-      expr,
-      expr.children.head,
-      inputs,
-      binding,
-      (builder, unaryExpr) => builder.setIsNotNull(unaryExpr))
-
-    val nullLiteralProto = exprToProto(Literal(null, BooleanType), Seq.empty)
-
-    if (arrayContainsScalarExpr.isDefined && isNotNullExpr.isDefined &&
-      nullLiteralProto.isDefined) {
-      val caseWhenExpr = ExprOuterClass.CaseWhen
-        .newBuilder()
-        .addWhen(isNotNullExpr.get)
-        .addThen(arrayContainsScalarExpr.get)
-        .setElseExpr(nullLiteralProto.get)
-        .build()
-      Some(
-        ExprOuterClass.Expr
-          .newBuilder()
-          .setCaseWhen(caseWhenExpr)
-          .build())
-    } else {
-      withInfo(expr, expr.children: _*)
-      None
-    }
+    // Delegates to datafusion-spark's SparkArrayContains which handles
+    // Spark's three-valued NULL semantics natively (no CASE WHEN needed).
+    val arrayContainsExpr =
+      scalarFunctionExprToProto("array_contains", arrayExprProto, keyExprProto)
+    optExprWithInfo(arrayContainsExpr, expr)
   }
 }
 


### PR DESCRIPTION
 - Replace the CASE WHEN wrapper around array_has with a direct call to datafusion-spark's
  SparkArrayContains, which handles Spark's three-valued NULL semantics natively
  - When an element is not found and the array contains NULL elements, the result is now correctly NULL
  instead of false
  - Net reduction of ~25 lines by removing the manual NULL handling logic

  Depends on

  - apache/datafusion#20685 (adds SparkArrayContains to datafusion-spark crate)

  Test plan

  - Existing CometArrayExpressionSuite tests pass
  - Verify three-valued NULL semantics: array_contains(array(1, NULL, 3), 2) returns NULL
