### PR TITLE
chore: Add changelog for 0.14.0 release

### DIFF
--- a/dev/changelog/0.14.0.md
+++ b/dev/changelog/0.14.0.md
@@ -19,7 +19,7 @@ under the License.
 
 # DataFusion Comet 0.14.0 Changelog
 
-This release consists of 182 commits from 21 contributors. See credits at the end of this changelog for more information.
+This release consists of 189 commits from 21 contributors. See credits at the end of this changelog for more information.
 
 **Fixed bugs:**
 
@@ -41,6 +41,7 @@ This release consists of 182 commits from 21 contributors. See credits at the en
 - fix: disable native C2R for legacy Iceberg scans [iceberg] [#3663](https://github.com/apache/datafusion-comet/pull/3663) (mbutrovich)
 - fix: resolve Miri UB in null struct field test, re-enable Miri on PRs [#3669](https://github.com/apache/datafusion-comet/pull/3669) (andygrove)
 - fix: Support on all-literal RLIKE expression [#3647](https://github.com/apache/datafusion-comet/pull/3647) (0lai0)
+- fix: Fix scan metrics test to run with both native_datafusion and native_iceberg_compat [#3690](https://github.com/apache/datafusion-comet/pull/3690) (andygrove)
 
 **Performance related:**
 
@@ -102,6 +103,7 @@ This release consists of 182 commits from 21 contributors. See credits at the en
 - docs: add SAFETY comments to all unsafe blocks in shuffle spark_unsafe module [#3603](https://github.com/apache/datafusion-comet/pull/3603) (andygrove)
 - docs: Fix link to overview page [#3625](https://github.com/apache/datafusion-comet/pull/3625) (manuzhang)
 - doc: Document sql query error propagation [#3651](https://github.com/apache/datafusion-comet/pull/3651) (parthchandra)
+- docs: update Iceberg docs in advance of 0.14.0 [#3691](https://github.com/apache/datafusion-comet/pull/3691) (mbutrovich)
 
 **Other:**
 
@@ -217,15 +219,20 @@ This release consists of 182 commits from 21 contributors. See credits at the en
 - chore: Remove deprecated SCAN_NATIVE_COMET constant and related test code [#3671](https://github.com/apache/datafusion-comet/pull/3671) (andygrove)
 - chore: Upgrade to DF 52.3.0 [#3672](https://github.com/apache/datafusion-comet/pull/3672) (andygrove)
 - deps: update to iceberg-rust 0.9.0 rc1 [iceberg] [#3657](https://github.com/apache/datafusion-comet/pull/3657) (mbutrovich)
+- chore: Mark expressions with known correctness issues as incompatible [#3675](https://github.com/apache/datafusion-comet/pull/3675) (andygrove)
+- chore(deps): bump actions/setup-java from 4 to 5 [#3683](https://github.com/apache/datafusion-comet/pull/3683) (dependabot[bot])
+- chore(deps): bump runs-on/action from 2.0.3 to 2.1.0 [#3684](https://github.com/apache/datafusion-comet/pull/3684) (dependabot[bot])
+- chore(deps): bump actions/checkout from 4 to 6 [#3685](https://github.com/apache/datafusion-comet/pull/3685) (dependabot[bot])
+- ci: remove Java Iceberg integration tests from CI [iceberg] [#3673](https://github.com/apache/datafusion-comet/pull/3673) (andygrove)
 
 ## Credits
 
 Thank you to everyone who contributed to this release. Here is a breakdown of commits (PRs merged) per contributor.
 
 ```
-    78	Andy Grove
-    31	dependabot[bot]
-    18	Matt Butrovich
+    81	Andy Grove
+    34	dependabot[bot]
+    19	Matt Butrovich
      9	B Vadlamani
      8	Oleks V
      7	Kazantsev Maksim


### PR DESCRIPTION
## Which issue does this PR close?

Part of the release process for 0.14.0.

## Rationale for this change

Release prep.

## What changes are included in this PR?

Adds the auto-generated changelog for the 0.14.0 release covering 182 commits from 21 contributors since the 0.13.0 release.

- [Rendered Version](https://github.com/andygrove/datafusion-comet/blob/changelog-0.14.0/dev/changelog/0.14.0.md)

## How are these changes tested?

This is a documentation-only change (changelog markdown file).