### PR TITLE
fix: Fix scan metrics test to run with both native_datafusion and native_iceberg_compat

### DIFF
--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -558,35 +558,50 @@ class CometExecSuite extends CometTestBase {
   }
 
   test("Comet native metrics: scan") {
-    withSQLConf(CometConf.COMET_EXEC_ENABLED.key -> "true") {
-      withTempDir { dir =>
-        val path = new Path(dir.toURI.toString, "native-scan.parquet")
-        makeParquetFileAllPrimitiveTypes(path, dictionaryEnabled = true, 10000)
-        withParquetTable(path.toString, "tbl") {
-          val df = sql("SELECT * FROM tbl WHERE _2 > _3")
-          df.collect()
+    Seq(CometConf.SCAN_NATIVE_DATAFUSION, CometConf.SCAN_NATIVE_ICEBERG_COMPAT).foreach {
+      scanMode =>
+        withSQLConf(
+          CometConf.COMET_EXEC_ENABLED.key -> "true",
+          CometConf.COMET_NATIVE_SCAN_IMPL.key -> scanMode) {
+          withTempDir { dir =>
+            val path = new Path(dir.toURI.toString, "native-scan.parquet")
+            makeParquetFileAllPrimitiveTypes(path, dictionaryEnabled = true, 10000)
+            withParquetTable(path.toString, "tbl") {
+              val df = sql("SELECT * FROM tbl")
+              df.collect()
 
-          find(df.queryExecution.executedPlan)(s =>
-            s.isInstanceOf[CometScanExec] || s.isInstanceOf[CometNativeScanExec])
-            .foreach(scan => {
-              val metrics = scan.metrics
+              val scan = find(df.queryExecution.executedPlan)(s =>
+                s.isInstanceOf[CometScanExec] || s.isInstanceOf[CometNativeScanExec])
+              assert(scan.isDefined, s"Expected to find a Comet scan node for $scanMode")
+              val metrics = scan.get.metrics
 
-              assert(metrics.contains("time_elapsed_scanning_total"))
+              assert(
+                metrics.contains("time_elapsed_scanning_total"),
+                s"[$scanMode] Missing time_elapsed_scanning_total. Available: ${metrics.keys}")
               assert(metrics.contains("bytes_scanned"))
               assert(metrics.contains("output_rows"))
               assert(metrics.contains("time_elapsed_opening"))
               assert(metrics.contains("time_elapsed_processing"))
               assert(metrics.contains("time_elapsed_scanning_until_data"))
-              assert(metrics("time_elapsed_scanning_total").value > 0)
-              assert(metrics("bytes_scanned").value > 0)
-              assert(metrics("output_rows").value > 0)
-              assert(metrics("time_elapsed_opening").value > 0)
-              assert(metrics("time_elapsed_processing").value > 0)
-              assert(metrics("time_elapsed_scanning_until_data").value > 0)
-            })
-
+              assert(
+                metrics("time_elapsed_scanning_total").value > 0,
+                s"[$scanMode] time_elapsed_scanning_total should be > 0")
+              assert(
+                metrics("bytes_scanned").value > 0,
+                s"[$scanMode] bytes_scanned should be > 0")
+              assert(metrics("output_rows").value > 0, s"[$scanMode] output_rows should be > 0")
+              assert(
+                metrics("time_elapsed_opening").value > 0,
+                s"[$scanMode] time_elapsed_opening should be > 0")
+              assert(
+                metrics("time_elapsed_processing").value > 0,
+                s"[$scanMode] time_elapsed_processing should be > 0")
+              assert(
+                metrics("time_elapsed_scanning_until_data").value > 0,
+                s"[$scanMode] time_elapsed_scanning_until_data should be > 0")
+            }
+          }
         }
-      }
     }
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A - test coverage improvement

## Rationale for this change

The "Comet native metrics: scan" test in `CometExecSuite` only ran with `SCAN_AUTO` (which resolves to `native_iceberg_compat`), providing no coverage for the `native_datafusion` scan mode. Additionally, the test used `find().foreach()` which silently passed if no scan node was found.

## What changes are included in this PR?

- Run the scan metrics test with both `SCAN_NATIVE_DATAFUSION` and `SCAN_NATIVE_ICEBERG_COMPAT` explicitly
- Use `find()` with `assert(scan.isDefined, ...)` instead of `find().foreach()` to fail explicitly if no scan node is found
- Remove the `WHERE _2 > _3` filter clause. With `native_datafusion`, predicate pushdown pruned all 10,000 rows (since `_2` and `_3` have identical values with dictionary encoding), resulting in `output_rows = 0` and the metric assertions failing. The test's purpose is to verify metrics plumbing, not filter behavior.
- Add scan mode context to assertion messages for easier debugging

## How are these changes tested?

The PR itself is a test improvement. Verified by running `CometExecSuite` — all 88 tests pass.