### PR TITLE
chore: update documentation links for 0.14.0 release

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -25,9 +25,9 @@ mkdir temp
 cp -rf source/* temp/
 
 # Add user guide from published releases
-rm -rf comet-0.10
 rm -rf comet-0.11
 rm -rf comet-0.12
+rm -rf comet-0.13
 python3 generate-versions.py
 
 # Generate dynamic content (configs, compatibility matrices) for latest docs

--- a/docs/generate-versions.py
+++ b/docs/generate-versions.py
@@ -104,6 +104,6 @@ This is **out-of-date** documentation. The latest Comet release is version {late
 if __name__ == "__main__":
     print("Generating versioned user guide docs...")
     snapshot_version = get_version_from_pom()
-    latest_released_version = "0.13.0"
-    previous_versions = ["0.10.1", "0.11.0", "0.12.0"]
+    latest_released_version = "0.14.0"
+    previous_versions = ["0.11.0", "0.12.0", "0.13.0"]
     generate_docs(snapshot_version, latest_released_version, previous_versions)

--- a/docs/source/user-guide/index.md
+++ b/docs/source/user-guide/index.md
@@ -23,9 +23,9 @@ under the License.
 :maxdepth: 2
 :caption: User Guides
 
-0.14.0-SNAPSHOT <latest/index>
+0.15.0-SNAPSHOT <latest/index>
+0.14.x <0.14/index>
 0.13.x <0.13/index>
 0.12.x <0.12/index>
 0.11.x <0.11/index>
-0.10.x <0.10/index>
 ```


### PR DESCRIPTION
## Which issue does this PR close?

Part of the 0.14.0 release process.

## Rationale for this change

Now that branch-0.14 has been created, the documentation links on main need to be updated to reflect the new release and prepare for the next development cycle.

## What changes are included in this PR?

- Update `generate-versions.py` to set latest released version to 0.14.0 and move 0.13.0 to previous versions (dropping 0.10.1)
- Update `build.sh` to clean up `comet-0.13` instead of `comet-0.10`
- Update `user-guide/index.md` to add 0.14.x link, update snapshot to 0.15.0-SNAPSHOT, and drop 0.10.x

## How are these changes tested?

These are documentation configuration changes. They can be verified by building the docs locally following the instructions in `docs/README.md`.