### PR TITLE
fix: resolve CI artifact upload conflicts on workflow re-runs

### DIFF
--- a/.github/actions/java-test/action.yaml
+++ b/.github/actions/java-test/action.yaml
@@ -120,27 +120,29 @@ runs:
         MAVEN_OPTS="-Xmx4G -Xms2G -DwildcardSuites=$MAVEN_SUITES -XX:+UnlockDiagnosticVMOptions -XX:+ShowMessageBoxOnError -XX:+HeapDumpOnOutOfMemoryError -XX:ErrorFile=./hs_err_pid%p.log" SPARK_HOME=`pwd` ./mvnw -B -Prelease clean install ${{ inputs.maven_opts }}
     - name: Upload crash logs
       if: failure()
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: crash-logs-${{ inputs.artifact_name }}
         path: "**/hs_err_pid*.log"
+        overwrite: true
     - name: Debug listing
       if: failure()
       shell: bash
-      run: |  
+      run: |
         echo "CWD: $(pwd)"
         ls -lah .
         ls -lah target
         find . -name 'unit-tests.log'
     - name: Upload unit-tests.log
       if: failure()
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: unit-tests-${{ inputs.artifact_name }}
         path: "**/target/unit-tests.log"
+        overwrite: true
     - name: Upload test results
       if: ${{ inputs.upload-test-reports == 'true' }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
          name: java-test-reports-${{ inputs.artifact_name }}
          path: "**/target/surefire-reports/*.txt"


### PR DESCRIPTION
## Which issue does this PR close?

N/A - CI reliability fix.

## Rationale for this change

CI workflows sometimes fail with:
```
Error: Failed to CreateArtifact: Received non-retryable error:
Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

This happens when a failed job is re-run — the artifact from the first attempt already exists and `upload-artifact` refuses to overwrite it.

## What changes are included in this PR?

In `.github/actions/java-test/action.yaml`:
- Added `overwrite: true` to `crash-logs` and `unit-tests` upload steps (the `java-test-reports` step already had it)
- Bumped `actions/upload-artifact` from v6 to v7 for consistency with the workflow files

## How are these changes tested?

This will be validated by re-running failed CI jobs on PRs.