### PR TITLE
chore: keep original error message for failed SQL test

### DIFF
--- a/spark/src/test/scala/org/apache/comet/CometSqlFileTestSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometSqlFileTestSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 class CometSqlFileTestSuite extends CometTestBase with AdaptiveSparkPlanHelper {
 
   override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit
-                                                                                 pos: Position): Unit = {
+      pos: Position): Unit = {
     super.test(testName, testTags: _*) {
       withSQLConf(CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_AUTO) {
         testFun
@@ -43,7 +43,7 @@ class CometSqlFileTestSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     val current = org.apache.spark.SPARK_VERSION.split("[.-]").take(2).map(_.toInt)
     val required = minVersion.split("[.-]").take(2).map(_.toInt)
     (current(0) > required(0)) ||
-      (current(0) == required(0) && current(1) >= required(1))
+    (current(0) == required(0) && current(1) >= required(1))
   }
 
   private val testResourceDir = {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

The SQL test runner swallows original error message

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
