### PR TITLE
fix: disable ANSI mode in benchmarks to avoid exceptions on invalid input

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
@@ -63,6 +63,8 @@ trait CometBenchmarkBase
     sparkSession.conf.set(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key, "true")
     sparkSession.conf.set(CometConf.COMET_ENABLED.key, "false")
     sparkSession.conf.set(CometConf.COMET_EXEC_ENABLED.key, "false")
+    // Benchmarks use invalid input values that should produce NULL, not exceptions
+    sparkSession.conf.set(SQLConf.ANSI_ENABLED.key, "false")
 
     sparkSession
   }


### PR DESCRIPTION
In Spark 4, benchmarks default spark.sql.ansi.enabled to true, causing CAST on intentionally invalid benchmark data to throw instead of returning NULL. The benchmarks assume that invalid data will not cause an exception so we should always set it to false.

