### PR TITLE
fix: handle inf/-inf/nan in ShimSparkErrorConverter cast overflow

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -338,6 +338,7 @@ jobs:
               org.apache.comet.CometCsvExpressionSuite
               org.apache.comet.CometJsonExpressionSuite
               org.apache.comet.CometDateTimeUtilsSuite
+              org.apache.comet.SparkErrorConverterSuite
               org.apache.comet.expressions.conditional.CometIfSuite
               org.apache.comet.expressions.conditional.CometCoalesceSuite
               org.apache.comet.expressions.conditional.CometCaseWhenSuite

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -213,6 +213,7 @@ jobs:
               org.apache.comet.CometJsonExpressionSuite
               org.apache.comet.CometCsvExpressionSuite
               org.apache.comet.CometDateTimeUtilsSuite
+              org.apache.comet.SparkErrorConverterSuite
               org.apache.comet.expressions.conditional.CometIfSuite
               org.apache.comet.expressions.conditional.CometCoalesceSuite
               org.apache.comet.expressions.conditional.CometCaseWhenSuite

--- a/spark/src/main/spark-3.4/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
+++ b/spark/src/main/spark-3.4/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
@@ -44,6 +44,25 @@ trait ShimSparkErrorConverter {
   private def sqlCtx(context: Array[QueryContext]): SQLQueryContext =
     context.headOption.map(_.asInstanceOf[SQLQueryContext]).getOrElse(null)
 
+  private def parseFloatLiteral(value: String): Float = {
+    value.toLowerCase match {
+      case "inf" | "+inf" | "infinity" | "+infinity" => Float.PositiveInfinity
+      case "-inf" | "-infinity" => Float.NegativeInfinity
+      case "nan" | "+nan" | "-nan" => Float.NaN
+      case _ => value.toFloat
+    }
+  }
+
+  private def parseDoubleLiteral(value: String): Double = {
+    val normalized = value.toLowerCase.stripSuffix("d")
+    normalized match {
+      case "inf" | "+inf" | "infinity" | "+infinity" => Double.PositiveInfinity
+      case "-inf" | "-infinity" => Double.NegativeInfinity
+      case "nan" | "+nan" | "-nan" => Double.NaN
+      case _ => normalized.toDouble
+    }
+  }
+
   def convertErrorType(
       errorType: String,
       errorClass: String,
@@ -207,8 +226,8 @@ trait ShimSparkErrorConverter {
           case LongType =>
             val cleanStr = if (valueStr.endsWith("L")) valueStr.dropRight(1) else valueStr
             cleanStr.toLong
-          case FloatType => valueStr.toFloat
-          case DoubleType => valueStr.toDouble
+          case FloatType => parseFloatLiteral(valueStr)
+          case DoubleType => parseDoubleLiteral(valueStr)
           case StringType => UTF8String.fromString(valueStr)
           case _ => valueStr
         }

--- a/spark/src/main/spark-3.5/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
+++ b/spark/src/main/spark-3.5/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
@@ -44,6 +44,25 @@ trait ShimSparkErrorConverter {
   private def sqlCtx(context: Array[QueryContext]): SQLQueryContext =
     context.headOption.map(_.asInstanceOf[SQLQueryContext]).getOrElse(null)
 
+  private def parseFloatLiteral(value: String): Float = {
+    value.toLowerCase match {
+      case "inf" | "+inf" | "infinity" | "+infinity" => Float.PositiveInfinity
+      case "-inf" | "-infinity" => Float.NegativeInfinity
+      case "nan" | "+nan" | "-nan" => Float.NaN
+      case _ => value.toFloat
+    }
+  }
+
+  private def parseDoubleLiteral(value: String): Double = {
+    val normalized = value.toLowerCase.stripSuffix("d")
+    normalized match {
+      case "inf" | "+inf" | "infinity" | "+infinity" => Double.PositiveInfinity
+      case "-inf" | "-infinity" => Double.NegativeInfinity
+      case "nan" | "+nan" | "-nan" => Double.NaN
+      case _ => normalized.toDouble
+    }
+  }
+
   def convertErrorType(
       errorType: String,
       errorClass: String,
@@ -205,8 +224,8 @@ trait ShimSparkErrorConverter {
           case LongType =>
             val cleanStr = if (valueStr.endsWith("L")) valueStr.dropRight(1) else valueStr
             cleanStr.toLong
-          case FloatType => valueStr.toFloat
-          case DoubleType => valueStr.toDouble
+          case FloatType => parseFloatLiteral(valueStr)
+          case DoubleType => parseDoubleLiteral(valueStr)
           case StringType => UTF8String.fromString(valueStr)
           case _ => valueStr
         }

--- a/spark/src/main/spark-4.0/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
+++ b/spark/src/main/spark-4.0/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
@@ -37,6 +37,25 @@ object ShimSparkErrorConverter {
  */
 trait ShimSparkErrorConverter {
 
+  private def parseFloatLiteral(value: String): Float = {
+    value.toLowerCase match {
+      case "inf" | "+inf" | "infinity" | "+infinity" => Float.PositiveInfinity
+      case "-inf" | "-infinity" => Float.NegativeInfinity
+      case "nan" | "+nan" | "-nan" => Float.NaN
+      case _ => value.toFloat
+    }
+  }
+
+  private def parseDoubleLiteral(value: String): Double = {
+    val normalized = value.toLowerCase.stripSuffix("d")
+    normalized match {
+      case "inf" | "+inf" | "infinity" | "+infinity" => Double.PositiveInfinity
+      case "-inf" | "-infinity" => Double.NegativeInfinity
+      case "nan" | "+nan" | "-nan" => Double.NaN
+      case _ => normalized.toDouble
+    }
+  }
+
   /**
    * Convert error type string and parameters to appropriate Spark exception. Version-specific
    * implementations call the correct QueryExecutionErrors.* methods.
@@ -213,8 +232,8 @@ trait ShimSparkErrorConverter {
             // Strip "L" suffix for BIGINT literals
             val cleanStr = if (valueStr.endsWith("L")) valueStr.dropRight(1) else valueStr
             cleanStr.toLong
-          case FloatType => valueStr.toFloat
-          case DoubleType => valueStr.toDouble
+          case FloatType => parseFloatLiteral(valueStr)
+          case DoubleType => parseDoubleLiteral(valueStr)
           case StringType => UTF8String.fromString(valueStr)
           case _ => valueStr // Fallback to string
         }

--- a/spark/src/test/scala/org/apache/comet/SparkErrorConverterSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/SparkErrorConverterSuite.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class SparkErrorConverterSuite extends AnyFunSuite {
+  private def castOverflowError(fromType: String, value: String): Throwable = {
+    SparkErrorConverter
+      .convertErrorType(
+        "CastOverFlow",
+        "CAST_OVERFLOW",
+        Map("fromType" -> fromType, "toType" -> "INT", "value" -> value),
+        Array.empty,
+        null)
+      .getOrElse(fail("Expected CastOverFlow to be converted to a Spark exception"))
+  }
+
+  private def assertCastOverflowContains(
+      fromType: String,
+      value: String,
+      expectedMessagePart: String): Unit = {
+    val err = castOverflowError(fromType, value)
+    assert(
+      !err.isInstanceOf[NumberFormatException],
+      s"Unexpected parse failure for $fromType $value")
+    assert(
+      err.getMessage.contains(expectedMessagePart),
+      s"Expected '${err.getMessage}' to contain '$expectedMessagePart' for $fromType $value")
+  }
+
+  private def assertCastOverflowContainsNaN(fromType: String, value: String): Unit = {
+    val err = castOverflowError(fromType, value)
+    assert(
+      !err.isInstanceOf[NumberFormatException],
+      s"Unexpected parse failure for $fromType $value")
+    assert(
+      err.getMessage.toLowerCase.contains("nan"),
+      s"Expected '${err.getMessage}' to contain NaN for $fromType $value")
+  }
+
+  test("CastOverFlow conversion handles all float positive infinity literals") {
+    Seq("inf", "+inf", "infinity", "+infinity").foreach { value =>
+      assertCastOverflowContains("FLOAT", value, "Infinity")
+    }
+  }
+
+  test("CastOverFlow conversion handles all float negative infinity literals") {
+    Seq("-inf", "-infinity").foreach { value =>
+      assertCastOverflowContains("FLOAT", value, "-Infinity")
+    }
+  }
+
+  test("CastOverFlow conversion handles all float NaN literals") {
+    Seq("nan", "+nan", "-nan").foreach { value =>
+      assertCastOverflowContainsNaN("FLOAT", value)
+    }
+  }
+
+  test("CastOverFlow conversion handles float standard numeric literal fallback") {
+    assertCastOverflowContains("FLOAT", "1.5", "1.5")
+  }
+
+  test("CastOverFlow conversion handles all double positive infinity literals") {
+    Seq("inf", "infd", "+inf", "+infd", "infinity", "infinityd", "+infinity", "+infinityd")
+      .foreach { value =>
+        assertCastOverflowContains("DOUBLE", value, "Infinity")
+      }
+  }
+
+  test("CastOverFlow conversion handles all double negative infinity literals") {
+    Seq("-inf", "-infd", "-infinity", "-infinityd").foreach { value =>
+      assertCastOverflowContains("DOUBLE", value, "-Infinity")
+    }
+  }
+
+  test("CastOverFlow conversion handles all double NaN literals") {
+    Seq("nan", "nand", "+nan", "+nand", "-nan", "-nand").foreach { value =>
+      assertCastOverflowContainsNaN("DOUBLE", value)
+    }
+  }
+
+  test("CastOverFlow conversion handles double standard numeric literal fallback") {
+    assertCastOverflowContains("DOUBLE", "1.5", "1.5")
+    assertCastOverflowContains("DOUBLE", "1.5d", "1.5")
+  }
+}


### PR DESCRIPTION

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3767.

## Rationale for this change

Fixes incorrect exception translation for overflow cases involving infinity literals and aligns Comet behavior with Spark expectations in ANSI mode.

## What changes are included in this PR?

Normalize inf literals for float/double cast overflow conversion across Spark 3.4/3.5/4.0 and add unit tests in SparkErrorConverterSuite.

## How are these changes tested?

Add new UT SparkErrorConverterSuite.
