### PR TITLE
tests: fix Iceberg test diffs for Spark 3.4 [iceberg]

### DIFF
--- a/dev/diffs/iceberg-rust/1.10.0.diff
+++ b/dev/diffs/iceberg-rust/1.10.0.diff
@@ -1008,6 +1008,27 @@ index acd4688440..9be94eab2f 100644
              .getOrCreate();
    }
  
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestBase.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
+index 3c32b46936..5ba2c6dd95 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
+@@ -79,6 +79,16 @@ public abstract class TestBase extends SparkTestHelperBase {
+             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
+             .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
 diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
 index 6647a1b483..b8b428229b 100644
 --- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java

--- a/dev/diffs/iceberg-rust/1.10.0.diff
+++ b/dev/diffs/iceberg-rust/1.10.0.diff
@@ -1229,7 +1229,7 @@ index 833a0b6b5e..95007024d1 100644
      TestSparkDataFile.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
    }
 diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
-index 8884654fe0..e666553d91 100644
+index 8884654fe0..aacaf584f3 100644
 --- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
 +++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
 @@ -100,6 +100,16 @@ public class TestSparkDataWrite {
@@ -1249,6 +1249,78 @@ index 8884654fe0..e666553d91 100644
              .getOrCreate();
    }
  
+@@ -144,7 +154,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
+     for (ManifestFile manifest :
+         SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io())) {
+@@ -213,7 +223,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
+   }
+ 
+@@ -258,7 +268,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
+   }
+ 
+@@ -310,7 +320,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
+   }
+ 
+@@ -352,7 +362,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
+   }
+ 
+@@ -391,7 +401,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
+ 
+     List<DataFile> files = Lists.newArrayList();
+@@ -459,7 +469,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
+   }
+ 
+@@ -707,7 +717,7 @@ public class TestSparkDataWrite {
+     // Since write and commit succeeded, the rows should be readable
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual)
+         .hasSize(records.size() + records2.size())
+         .containsExactlyInAnyOrder(
 diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
 index 596d05d30b..e681d81704 100644
 --- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java

--- a/dev/diffs/iceberg-rust/1.10.0.diff
+++ b/dev/diffs/iceberg-rust/1.10.0.diff
@@ -1,5 +1,5 @@
 diff --git a/gradle/libs.versions.toml b/gradle/libs.versions.toml
-index eeabe54f5..867018058 100644
+index eeabe54f5f..4d3160b9f7 100644
 --- a/gradle/libs.versions.toml
 +++ b/gradle/libs.versions.toml
 @@ -37,7 +37,7 @@ awssdk-s3accessgrants = "2.3.0"
@@ -11,10 +11,10 @@ index eeabe54f5..867018058 100644
  datasketches = "6.2.0"
  delta-standalone = "3.3.2"
  delta-spark = "3.3.2"
-diff --git a/spark/v3.5/build.gradle b/spark/v3.5/build.gradle
-index 69700d843..49ea338a4 100644
---- a/spark/v3.5/build.gradle
-+++ b/spark/v3.5/build.gradle
+diff --git a/spark/v3.4/build.gradle b/spark/v3.4/build.gradle
+index 714be0831d..dede65f213 100644
+--- a/spark/v3.4/build.gradle
++++ b/spark/v3.4/build.gradle
 @@ -264,6 +264,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
      integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
      integrationImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
@@ -23,11 +23,11 @@ index 69700d843..49ea338a4 100644
  
      // runtime dependencies for running Hive Catalog based integration test
      integrationRuntimeOnly project(':iceberg-hive-metastore')
-diff --git a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
-index 4c1a50959..44b401644 100644
---- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
-+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
-@@ -59,6 +59,16 @@ public abstract class ExtensionsTestBase extends CatalogTestBase {
+diff --git a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
+index 4c1a509591..91fcd4b844 100644
+--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
++++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
+@@ -59,7 +59,27 @@ public abstract class ExtensionsTestBase extends CatalogTestBase {
              .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
              .config(
                  SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), String.valueOf(RANDOM.nextBoolean()))
@@ -42,12 +42,23 @@ index 4c1a50959..44b401644 100644
 +            .config("spark.comet.use.lazyMaterialization", "false")
 +            .config("spark.comet.schemaEvolution.enabled", "true")
              .enableHiveSupport()
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
              .getOrCreate();
  
-diff --git a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
-index ecf9e6f8a..3475260ca 100644
---- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
-+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+     TestBase.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+diff --git a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+index 58d054bd05..4ead587cc1 100644
+--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
++++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
 @@ -56,6 +56,16 @@ public class TestCallStatementParser {
              .master("local[2]")
              .config("spark.sql.extensions", IcebergSparkSessionExtensions.class.getName())
@@ -65,11 +76,11 @@ index ecf9e6f8a..3475260ca 100644
              .getOrCreate();
      TestCallStatementParser.parser = spark.sessionState().sqlParser();
    }
-diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
-index 64edb1002..0fc10120f 100644
---- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
-+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
-@@ -179,6 +179,16 @@ public class DeleteOrphanFilesBenchmark {
+diff --git a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
+index b6ade2bff3..c12127d618 100644
+--- a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
++++ b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
+@@ -170,6 +170,16 @@ public class DeleteOrphanFilesBenchmark {
              .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
              .config("spark.sql.catalog.spark_catalog.type", "hadoop")
              .config("spark.sql.catalog.spark_catalog.warehouse", catalogWarehouse())
@@ -86,11 +97,11 @@ index 64edb1002..0fc10120f 100644
              .master("local");
      spark = builder.getOrCreate();
    }
-diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
-index 77b79384a..01a4c82dc 100644
---- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
-+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
-@@ -392,6 +392,16 @@ public class IcebergSortCompactionBenchmark {
+diff --git a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
+index 7cd41bd7e7..e2681d6243 100644
+--- a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
++++ b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
+@@ -386,6 +386,16 @@ public class IcebergSortCompactionBenchmark {
                  "spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog")
              .config("spark.sql.catalog.spark_catalog.type", "hadoop")
              .config("spark.sql.catalog.spark_catalog.warehouse", getCatalogWarehouse())
@@ -107,52 +118,10 @@ index 77b79384a..01a4c82dc 100644
              .master("local[*]");
      spark = builder.getOrCreate();
      Configuration sparkHadoopConf = spark.sessionState().newHadoopConf();
-diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
-index c6794e43c..457d2823e 100644
---- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
-+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
-@@ -239,6 +239,16 @@ public class DVReaderBenchmark {
-             .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
-             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
-             .config("spark.sql.catalog.spark_catalog.warehouse", newWarehouseDir())
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .master("local[*]")
-             .getOrCreate();
-   }
-diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
-index ac74fb5a1..eab09293d 100644
---- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
-+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
-@@ -223,6 +223,16 @@ public class DVWriterBenchmark {
-             .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
-             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
-             .config("spark.sql.catalog.spark_catalog.warehouse", newWarehouseDir())
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .master("local[*]")
-             .getOrCreate();
-   }
-diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
-index 68c537e34..1e9e90d53 100644
---- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
-+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
+diff --git a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
+index 68c537e34a..1e9e90d539 100644
+--- a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
++++ b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
 @@ -94,7 +94,19 @@ public abstract class IcebergSourceBenchmark {
    }
  
@@ -174,1407 +143,6 @@ index 68c537e34..1e9e90d53 100644
      if (!enableDictionaryEncoding) {
        builder
            .config("parquet.dictionary.page.size", "1")
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
-index 404ba7284..00e97e96f 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
-@@ -90,6 +90,16 @@ public abstract class SparkDistributedDataScanTestBase
-         .master("local[2]")
-         .config("spark.serializer", serializer)
-         .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
-+        .config("spark.plugins", "org.apache.spark.CometPlugin")
-+        .config(
-+            "spark.shuffle.manager",
-+            "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+        .config("spark.comet.explainFallback.enabled", "true")
-+        .config("spark.comet.scan.icebergNative.enabled", "true")
-+        .config("spark.memory.offHeap.enabled", "true")
-+        .config("spark.memory.offHeap.size", "10g")
-+        .config("spark.comet.use.lazyMaterialization", "false")
-+        .config("spark.comet.schemaEvolution.enabled", "true")
-         .getOrCreate();
-   }
- }
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
-index 659507e4c..9076ec24d 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
-@@ -73,6 +73,16 @@ public class TestSparkDistributedDataScanDeletes
-             .master("local[2]")
-             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
-index a218f965e..eca0125ac 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
-@@ -62,6 +62,16 @@ public class TestSparkDistributedDataScanFilterFiles
-             .master("local[2]")
-             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
-index 2665d7ba8..2381d0aa1 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
-@@ -63,6 +63,16 @@ public class TestSparkDistributedDataScanReporting
-             .master("local[2]")
-             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
-index daf4e29ac..cffe2944e 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
-@@ -79,6 +79,17 @@ public abstract class TestBase extends SparkTestHelperBase {
-             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
-             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
-             .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .config("spark.comet.exec.broadcastExchange.enabled", "false")
-             .enableHiveSupport()
-             .getOrCreate();
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetDictionaryEncodedVectorizedReads.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetDictionaryEncodedVectorizedReads.java
-index 973a17c9a..4490c219d 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetDictionaryEncodedVectorizedReads.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetDictionaryEncodedVectorizedReads.java
-@@ -65,6 +65,16 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
-         SparkSession.builder()
-             .master("local[2]")
-             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
-index 1c5905744..543edf3b2 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
-@@ -61,6 +61,16 @@ public abstract class ScanTestBase extends AvroDataTestBase {
-     ScanTestBase.spark =
-         SparkSession.builder()
-             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .master("local[2]")
-             .getOrCreate();
-     ScanTestBase.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
-index 19ec6d13d..e2d0a84d0 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
-@@ -144,7 +144,20 @@ public class TestCompressionSettings extends CatalogTestBase {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestCompressionSettings.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestCompressionSettings.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @BeforeEach
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
-index a7702b169..e1fdafae8 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
-@@ -74,7 +74,20 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestDataSourceOptions.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestDataSourceOptions.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterAll
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
-index fd7d52178..c8aab2996 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
-@@ -114,6 +114,16 @@ public class TestFilteredScan {
-         SparkSession.builder()
-             .master("local[2]")
-             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
-index 153564f7d..264179459 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
-@@ -98,6 +98,16 @@ public class TestForwardCompatibility {
-         SparkSession.builder()
-             .master("local[2]")
-             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
-index f4f57157e..7dd2ed811 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
-@@ -51,6 +51,16 @@ public class TestIcebergSpark {
-         SparkSession.builder()
-             .master("local[2]")
-             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
-index e1402396f..8b60b8bc4 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
-@@ -118,6 +118,16 @@ public class TestPartitionPruning {
-         SparkSession.builder()
-             .master("local[2]")
-             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-     TestPartitionPruning.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
-index 0b6ab2052..dec4026f3 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
-@@ -112,6 +112,16 @@ public class TestPartitionValues {
-         SparkSession.builder()
-             .master("local[2]")
-             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
-index 11865db7f..bdb9ae32a 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
-@@ -91,6 +91,16 @@ public class TestSnapshotSelection {
-         SparkSession.builder()
-             .master("local[2]")
-             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
-index 3051e27d7..22899c233 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
-@@ -125,6 +125,16 @@ public class TestSparkDataFile {
-         SparkSession.builder()
-             .master("local[2]")
-             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-     TestSparkDataFile.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
-   }
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
-index 4ccbf86f1..2089bac57 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
-@@ -100,6 +100,16 @@ public class TestSparkDataWrite {
-         SparkSession.builder()
-             .master("local[2]")
-             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-   }
- 
-@@ -144,7 +154,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
-     for (ManifestFile manifest :
-         SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io())) {
-@@ -213,7 +223,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
-   }
- 
-@@ -258,7 +268,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
-   }
- 
-@@ -310,7 +320,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
-   }
- 
-@@ -352,7 +362,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
-   }
- 
-@@ -391,7 +401,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
- 
-     List<DataFile> files = Lists.newArrayList();
-@@ -459,7 +469,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
-   }
- 
-@@ -706,7 +716,7 @@ public class TestSparkDataWrite {
-     // Since write and commit succeeded, the rows should be readable
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual)
-         .hasSize(records.size() + records2.size())
-         .containsExactlyInAnyOrder(
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
-index 596d05d30..e681d8170 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
-@@ -88,6 +88,16 @@ public class TestSparkReadProjection extends TestReadProjection {
-         SparkSession.builder()
-             .master("local[2]")
-             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-     ImmutableMap<String, String> config =
-         ImmutableMap.of(
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
-index 42699f466..c5e077d7a 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
-@@ -138,6 +138,16 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
-             .config("spark.ui.liveUpdate.period", 0)
-             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
-             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .enableHiveSupport()
-             .getOrCreate();
- 
-@@ -205,9 +215,10 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
-     catalog.dropTable(TableIdentifier.of("default", name));
-   }
- 
--  protected boolean countDeletes() {
--    return true;
--  }
-+protected boolean countDeletes() {
-+    // TODO: Enable once iceberg-rust exposes delete count metrics to Comet
-+             return false;
-+}
- 
-   @Override
-   protected long deleteCount() {
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
-index baf7fa8f8..150cc8969 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
-@@ -182,6 +182,16 @@ public class TestSparkReaderWithBloomFilter {
-         SparkSession.builder()
-             .master("local[2]")
-             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .enableHiveSupport()
-             .getOrCreate();
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
-index 54048bbf2..c87216824 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
-@@ -69,6 +69,16 @@ public class TestStructuredStreaming {
-             .master("local[2]")
-             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
-             .config("spark.sql.shuffle.partitions", 4)
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
-index 8b1e3fbfc..b4385c395 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
-@@ -75,7 +75,20 @@ public class TestTimestampWithoutZone extends TestBase {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestTimestampWithoutZone.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestTimestampWithoutZone.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterAll
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
-index c3fac70dd..b6c66f3f8 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
-@@ -84,6 +84,16 @@ public class TestWriteMetricsConfig {
-         SparkSession.builder()
-             .master("local[2]")
-             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-     TestWriteMetricsConfig.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
-   }
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
-index 5ce56b4fe..df1f914da 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
-@@ -63,6 +63,16 @@ public class TestAggregatePushDown extends CatalogTestBase {
-         SparkSession.builder()
-             .master("local[2]")
-             .config("spark.sql.iceberg.aggregate_pushdown", "true")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .enableHiveSupport()
-             .getOrCreate();
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
-index 9d2ce2b38..5e2336884 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
-@@ -598,9 +598,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
-     String planAsString = sparkPlan.toString().replaceAll("#(\\d+L?)", "");
- 
-     if (sparkFilter != null) {
--      assertThat(planAsString)
--          .as("Post scan filter should match")
--          .contains("Filter (" + sparkFilter + ")");
-+      assertThat(planAsString).as("Post scan filter should match").contains("CometFilter");
-     } else {
-       assertThat(planAsString).as("Should be no post scan filter").doesNotContain("Filter (");
-     }
-diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java
-deleted file mode 100644
-index 81b7d83a70..0000000000
---- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java
-+++ /dev/null
-@@ -1,140 +0,0 @@
--/*
-- * Licensed to the Apache Software Foundation (ASF) under one
-- * or more contributor license agreements.  See the NOTICE file
-- * distributed with this work for additional information
-- * regarding copyright ownership.  The ASF licenses this file
-- * to you under the Apache License, Version 2.0 (the
-- * "License"); you may not use this file except in compliance
-- * with the License.  You may obtain a copy of the License at
-- *
-- *   http://www.apache.org/licenses/LICENSE-2.0
-- *
-- * Unless required by applicable law or agreed to in writing,
-- * software distributed under the License is distributed on an
-- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-- * KIND, either express or implied.  See the License for the
-- * specific language governing permissions and limitations
-- * under the License.
-- */
--package org.apache.iceberg.spark.data.vectorized;
--
--import java.io.IOException;
--import org.apache.comet.CometSchemaImporter;
--import org.apache.comet.parquet.AbstractColumnReader;
--import org.apache.comet.parquet.ColumnReader;
--import org.apache.comet.parquet.TypeUtil;
--import org.apache.comet.parquet.Utils;
--import org.apache.comet.shaded.arrow.memory.RootAllocator;
--import org.apache.iceberg.parquet.VectorizedReader;
--import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
--import org.apache.iceberg.spark.SparkSchemaUtil;
--import org.apache.iceberg.types.Types;
--import org.apache.parquet.column.ColumnDescriptor;
--import org.apache.parquet.column.page.PageReader;
--import org.apache.spark.sql.types.DataType;
--import org.apache.spark.sql.types.Metadata;
--import org.apache.spark.sql.types.StructField;
--import org.apache.spark.sql.vectorized.ColumnVector;
--
--class CometColumnReader implements VectorizedReader<ColumnVector> {
--  // use the Comet default batch size
--  public static final int DEFAULT_BATCH_SIZE = 8192;
--
--  private final ColumnDescriptor descriptor;
--  private final DataType sparkType;
--
--  // The delegated ColumnReader from Comet side
--  private AbstractColumnReader delegate;
--  private boolean initialized = false;
--  private int batchSize = DEFAULT_BATCH_SIZE;
--  private CometSchemaImporter importer;
--
--  CometColumnReader(DataType sparkType, ColumnDescriptor descriptor) {
--    this.sparkType = sparkType;
--    this.descriptor = descriptor;
--  }
--
--  CometColumnReader(Types.NestedField field) {
--    DataType dataType = SparkSchemaUtil.convert(field.type());
--    StructField structField = new StructField(field.name(), dataType, false, Metadata.empty());
--    this.sparkType = dataType;
--    this.descriptor = TypeUtil.convertToParquet(structField);
--  }
--
--  public AbstractColumnReader delegate() {
--    return delegate;
--  }
--
--  void setDelegate(AbstractColumnReader delegate) {
--    this.delegate = delegate;
--  }
--
--  void setInitialized(boolean initialized) {
--    this.initialized = initialized;
--  }
--
--  public int batchSize() {
--    return batchSize;
--  }
--
--  /**
--   * This method is to initialized/reset the CometColumnReader. This needs to be called for each row
--   * group after readNextRowGroup, so a new dictionary encoding can be set for each of the new row
--   * groups.
--   */
--  public void reset() {
--    if (importer != null) {
--      importer.close();
--    }
--
--    if (delegate != null) {
--      delegate.close();
--    }
--
--    this.importer = new CometSchemaImporter(new RootAllocator());
--    this.delegate = Utils.getColumnReader(sparkType, descriptor, importer, batchSize, false, false);
--    this.initialized = true;
--  }
--
--  public ColumnDescriptor descriptor() {
--    return descriptor;
--  }
--
--  /** Returns the Spark data type for this column. */
--  public DataType sparkType() {
--    return sparkType;
--  }
--
--  /**
--   * Set the page reader to be 'pageReader'.
--   *
--   * <p>NOTE: this should be called before reading a new Parquet column chunk, and after {@link
--   * CometColumnReader#reset} is called.
--   */
--  public void setPageReader(PageReader pageReader) throws IOException {
--    Preconditions.checkState(initialized, "Invalid state: 'reset' should be called first");
--    ((ColumnReader) delegate).setPageReader(pageReader);
--  }
--
--  @Override
--  public void close() {
--    // close resources on native side
--    if (importer != null) {
--      importer.close();
--    }
--
--    if (delegate != null) {
--      delegate.close();
--    }
--  }
--
--  @Override
--  public void setBatchSize(int size) {
--    this.batchSize = size;
--  }
--
--  @Override
--  public ColumnVector read(ColumnVector reuse, int numRowsToRead) {
--    throw new UnsupportedOperationException("Not supported");
--  }
--}
-diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnarBatchReader.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnarBatchReader.java
-deleted file mode 100644
-index 04ac69476a..0000000000
---- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnarBatchReader.java
-+++ /dev/null
-@@ -1,197 +0,0 @@
--/*
-- * Licensed to the Apache Software Foundation (ASF) under one
-- * or more contributor license agreements.  See the NOTICE file
-- * distributed with this work for additional information
-- * regarding copyright ownership.  The ASF licenses this file
-- * to you under the Apache License, Version 2.0 (the
-- * "License"); you may not use this file except in compliance
-- * with the License.  You may obtain a copy of the License at
-- *
-- *   http://www.apache.org/licenses/LICENSE-2.0
-- *
-- * Unless required by applicable law or agreed to in writing,
-- * software distributed under the License is distributed on an
-- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-- * KIND, either express or implied.  See the License for the
-- * specific language governing permissions and limitations
-- * under the License.
-- */
--package org.apache.iceberg.spark.data.vectorized;
--
--import java.io.IOException;
--import java.io.UncheckedIOException;
--import java.util.List;
--import java.util.Map;
--import org.apache.comet.parquet.AbstractColumnReader;
--import org.apache.comet.parquet.BatchReader;
--import org.apache.iceberg.Schema;
--import org.apache.iceberg.data.DeleteFilter;
--import org.apache.iceberg.parquet.VectorizedReader;
--import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
--import org.apache.iceberg.spark.SparkSchemaUtil;
--import org.apache.iceberg.util.Pair;
--import org.apache.parquet.column.page.PageReadStore;
--import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
--import org.apache.parquet.hadoop.metadata.ColumnPath;
--import org.apache.spark.sql.catalyst.InternalRow;
--import org.apache.spark.sql.vectorized.ColumnVector;
--import org.apache.spark.sql.vectorized.ColumnarBatch;
--
--/**
-- * {@link VectorizedReader} that returns Spark's {@link ColumnarBatch} to support Spark's vectorized
-- * read path. The {@link ColumnarBatch} returned is created by passing in the Arrow vectors
-- * populated via delegated read calls to {@link CometColumnReader VectorReader(s)}.
-- */
--@SuppressWarnings("checkstyle:VisibilityModifier")
--class CometColumnarBatchReader implements VectorizedReader<ColumnarBatch> {
--
--  private final CometColumnReader[] readers;
--  private final boolean hasIsDeletedColumn;
--
--  // The delegated BatchReader on the Comet side does the real work of loading a batch of rows.
--  // The Comet BatchReader contains an array of ColumnReader. There is no need to explicitly call
--  // ColumnReader.readBatch; instead, BatchReader.nextBatch will be called, which underneath calls
--  // ColumnReader.readBatch. The only exception is DeleteColumnReader, because at the time of
--  // calling BatchReader.nextBatch, the isDeleted value is not yet available, so
--  // DeleteColumnReader.readBatch must be called explicitly later, after the isDeleted value is
--  // available.
--  private final BatchReader delegate;
--  private DeleteFilter<InternalRow> deletes = null;
--  private long rowStartPosInBatch = 0;
--
--  CometColumnarBatchReader(List<VectorizedReader<?>> readers, Schema schema) {
--    this.readers =
--        readers.stream().map(CometColumnReader.class::cast).toArray(CometColumnReader[]::new);
--    this.hasIsDeletedColumn =
--        readers.stream().anyMatch(reader -> reader instanceof CometDeleteColumnReader);
--
--    AbstractColumnReader[] abstractColumnReaders = new AbstractColumnReader[readers.size()];
--    this.delegate = new BatchReader(abstractColumnReaders);
--    delegate.setSparkSchema(SparkSchemaUtil.convert(schema));
--  }
--
--  @Override
--  public void setRowGroupInfo(
--      PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metaData) {
--    for (int i = 0; i < readers.length; i++) {
--      try {
--        if (!(readers[i] instanceof CometConstantColumnReader)
--            && !(readers[i] instanceof CometPositionColumnReader)
--            && !(readers[i] instanceof CometDeleteColumnReader)) {
--          readers[i].reset();
--          readers[i].setPageReader(pageStore.getPageReader(readers[i].descriptor()));
--        }
--      } catch (IOException e) {
--        throw new UncheckedIOException("Failed to setRowGroupInfo for Comet vectorization", e);
--      }
--    }
--
--    for (int i = 0; i < readers.length; i++) {
--      delegate.getColumnReaders()[i] = this.readers[i].delegate();
--    }
--
--    this.rowStartPosInBatch =
--        pageStore
--            .getRowIndexOffset()
--            .orElseThrow(
--                () ->
--                    new IllegalArgumentException(
--                        "PageReadStore does not contain row index offset"));
--  }
--
--  public void setDeleteFilter(DeleteFilter<InternalRow> deleteFilter) {
--    this.deletes = deleteFilter;
--  }
--
--  @Override
--  public final ColumnarBatch read(ColumnarBatch reuse, int numRowsToRead) {
--    ColumnarBatch columnarBatch = new ColumnBatchLoader(numRowsToRead).loadDataToColumnBatch();
--    rowStartPosInBatch += numRowsToRead;
--    return columnarBatch;
--  }
--
--  @Override
--  public void setBatchSize(int batchSize) {
--    for (CometColumnReader reader : readers) {
--      if (reader != null) {
--        reader.setBatchSize(batchSize);
--      }
--    }
--  }
--
--  @Override
--  public void close() {
--    for (CometColumnReader reader : readers) {
--      if (reader != null) {
--        reader.close();
--      }
--    }
--  }
--
--  private class ColumnBatchLoader {
--    private final int batchSize;
--
--    ColumnBatchLoader(int numRowsToRead) {
--      Preconditions.checkArgument(
--          numRowsToRead > 0, "Invalid number of rows to read: %s", numRowsToRead);
--      this.batchSize = numRowsToRead;
--    }
--
--    ColumnarBatch loadDataToColumnBatch() {
--      ColumnVector[] vectors = readDataToColumnVectors();
--      int numLiveRows = batchSize;
--
--      if (hasIsDeletedColumn) {
--        boolean[] isDeleted = buildIsDeleted(vectors);
--        readDeletedColumn(vectors, isDeleted);
--      } else {
--        Pair<int[], Integer> pair = buildRowIdMapping(vectors);
--        if (pair != null) {
--          int[] rowIdMapping = pair.first();
--          numLiveRows = pair.second();
--          for (int i = 0; i < vectors.length; i++) {
--            vectors[i] = new ColumnVectorWithFilter(vectors[i], rowIdMapping);
--          }
--        }
--      }
--
--      if (deletes != null && deletes.hasEqDeletes()) {
--        vectors = ColumnarBatchUtil.removeExtraColumns(deletes, vectors);
--      }
--
--      ColumnarBatch batch = new ColumnarBatch(vectors);
--      batch.setNumRows(numLiveRows);
--      return batch;
--    }
--
--    private boolean[] buildIsDeleted(ColumnVector[] vectors) {
--      return ColumnarBatchUtil.buildIsDeleted(vectors, deletes, rowStartPosInBatch, batchSize);
--    }
--
--    private Pair<int[], Integer> buildRowIdMapping(ColumnVector[] vectors) {
--      return ColumnarBatchUtil.buildRowIdMapping(vectors, deletes, rowStartPosInBatch, batchSize);
--    }
--
--    ColumnVector[] readDataToColumnVectors() {
--      ColumnVector[] columnVectors = new ColumnVector[readers.length];
--      // Fetch rows for all readers in the delegate
--      delegate.nextBatch(batchSize);
--      for (int i = 0; i < readers.length; i++) {
--        columnVectors[i] = readers[i].delegate().currentBatch();
--      }
--
--      return columnVectors;
--    }
--
--    void readDeletedColumn(ColumnVector[] columnVectors, boolean[] isDeleted) {
--      for (int i = 0; i < readers.length; i++) {
--        if (readers[i] instanceof CometDeleteColumnReader) {
--          CometDeleteColumnReader deleteColumnReader = new CometDeleteColumnReader<>(isDeleted);
--          deleteColumnReader.setBatchSize(batchSize);
--          deleteColumnReader.delegate().readBatch(batchSize);
--          columnVectors[i] = deleteColumnReader.delegate().currentBatch();
--        }
--      }
--    }
--  }
--}
-diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometConstantColumnReader.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometConstantColumnReader.java
-deleted file mode 100644
-index 047c96314b..0000000000
---- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometConstantColumnReader.java
-+++ /dev/null
-@@ -1,65 +0,0 @@
--/*
-- * Licensed to the Apache Software Foundation (ASF) under one
-- * or more contributor license agreements.  See the NOTICE file
-- * distributed with this work for additional information
-- * regarding copyright ownership.  The ASF licenses this file
-- * to you under the Apache License, Version 2.0 (the
-- * "License"); you may not use this file except in compliance
-- * with the License.  You may obtain a copy of the License at
-- *
-- *   http://www.apache.org/licenses/LICENSE-2.0
-- *
-- * Unless required by applicable law or agreed to in writing,
-- * software distributed under the License is distributed on an
-- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-- * KIND, either express or implied.  See the License for the
-- * specific language governing permissions and limitations
-- * under the License.
-- */
--package org.apache.iceberg.spark.data.vectorized;
--
--import java.math.BigDecimal;
--import java.nio.ByteBuffer;
--import org.apache.comet.parquet.ConstantColumnReader;
--import org.apache.iceberg.types.Types;
--import org.apache.spark.sql.types.DataType;
--import org.apache.spark.sql.types.DataTypes;
--import org.apache.spark.sql.types.Decimal;
--import org.apache.spark.sql.types.DecimalType;
--import org.apache.spark.unsafe.types.UTF8String;
--
--class CometConstantColumnReader<T> extends CometColumnReader {
--
--  CometConstantColumnReader(T value, Types.NestedField field) {
--    super(field);
--    // use delegate to set constant value on the native side to be consumed by native execution.
--    setDelegate(
--        new ConstantColumnReader(sparkType(), descriptor(), convertToSparkValue(value), false));
--  }
--
--  @Override
--  public void setBatchSize(int batchSize) {
--    super.setBatchSize(batchSize);
--    delegate().setBatchSize(batchSize);
--    setInitialized(true);
--  }
--
--  private Object convertToSparkValue(T value) {
--    DataType dataType = sparkType();
--    // Match the value to Spark internal type if necessary
--    if (dataType == DataTypes.StringType && value instanceof String) {
--      // the internal type for StringType is UTF8String
--      return UTF8String.fromString((String) value);
--    } else if (dataType instanceof DecimalType && value instanceof BigDecimal) {
--      // the internal type for DecimalType is Decimal
--      return Decimal.apply((BigDecimal) value);
--    } else if (dataType == DataTypes.BinaryType && value instanceof ByteBuffer) {
--      // the internal type for DecimalType is byte[]
--      // Iceberg default value should always use HeapBufferBuffer, so calling ByteBuffer.array()
--      // should be safe.
--      return ((ByteBuffer) value).array();
--    } else {
--      return value;
--    }
--  }
--}
-diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometDeleteColumnReader.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometDeleteColumnReader.java
-deleted file mode 100644
-index 6235bfe486..0000000000
---- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometDeleteColumnReader.java
-+++ /dev/null
-@@ -1,75 +0,0 @@
--/*
-- * Licensed to the Apache Software Foundation (ASF) under one
-- * or more contributor license agreements.  See the NOTICE file
-- * distributed with this work for additional information
-- * regarding copyright ownership.  The ASF licenses this file
-- * to you under the Apache License, Version 2.0 (the
-- * "License"); you may not use this file except in compliance
-- * with the License.  You may obtain a copy of the License at
-- *
-- *   http://www.apache.org/licenses/LICENSE-2.0
-- *
-- * Unless required by applicable law or agreed to in writing,
-- * software distributed under the License is distributed on an
-- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-- * KIND, either express or implied.  See the License for the
-- * specific language governing permissions and limitations
-- * under the License.
-- */
--package org.apache.iceberg.spark.data.vectorized;
--
--import org.apache.comet.parquet.MetadataColumnReader;
--import org.apache.comet.parquet.Native;
--import org.apache.comet.parquet.TypeUtil;
--import org.apache.iceberg.MetadataColumns;
--import org.apache.iceberg.types.Types;
--import org.apache.spark.sql.types.DataTypes;
--import org.apache.spark.sql.types.Metadata;
--import org.apache.spark.sql.types.StructField;
--
--class CometDeleteColumnReader<T> extends CometColumnReader {
--  CometDeleteColumnReader(Types.NestedField field) {
--    super(field);
--    setDelegate(new DeleteColumnReader());
--  }
--
--  CometDeleteColumnReader(boolean[] isDeleted) {
--    super(MetadataColumns.IS_DELETED);
--    setDelegate(new DeleteColumnReader(isDeleted));
--  }
--
--  @Override
--  public void setBatchSize(int batchSize) {
--    super.setBatchSize(batchSize);
--    delegate().setBatchSize(batchSize);
--    setInitialized(true);
--  }
--
--  private static class DeleteColumnReader extends MetadataColumnReader {
--    private boolean[] isDeleted;
--
--    DeleteColumnReader() {
--      super(
--          DataTypes.BooleanType,
--          TypeUtil.convertToParquet(
--              new StructField("_deleted", DataTypes.BooleanType, false, Metadata.empty())),
--          false /* useDecimal128 = false */,
--          false /* isConstant = false */);
--      this.isDeleted = new boolean[0];
--    }
--
--    DeleteColumnReader(boolean[] isDeleted) {
--      this();
--      this.isDeleted = isDeleted;
--    }
--
--    @Override
--    public void readBatch(int total) {
--      Native.resetBatch(nativeHandle);
--      // set isDeleted on the native side to be consumed by native execution
--      Native.setIsDeleted(nativeHandle, isDeleted);
--
--      super.readBatch(total);
--    }
--  }
--}
-diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometPositionColumnReader.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometPositionColumnReader.java
-deleted file mode 100644
-index bcc0e514c2..0000000000
---- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometPositionColumnReader.java
-+++ /dev/null
-@@ -1,62 +0,0 @@
--/*
-- * Licensed to the Apache Software Foundation (ASF) under one
-- * or more contributor license agreements.  See the NOTICE file
-- * distributed with this work for additional information
-- * regarding copyright ownership.  The ASF licenses this file
-- * to you under the Apache License, Version 2.0 (the
-- * "License"); you may not use this file except in compliance
-- * with the License.  You may obtain a copy of the License at
-- *
-- *   http://www.apache.org/licenses/LICENSE-2.0
-- *
-- * Unless required by applicable law or agreed to in writing,
-- * software distributed under the License is distributed on an
-- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-- * KIND, either express or implied.  See the License for the
-- * specific language governing permissions and limitations
-- * under the License.
-- */
--package org.apache.iceberg.spark.data.vectorized;
--
--import org.apache.comet.parquet.MetadataColumnReader;
--import org.apache.comet.parquet.Native;
--import org.apache.iceberg.types.Types;
--import org.apache.parquet.column.ColumnDescriptor;
--import org.apache.spark.sql.types.DataTypes;
--
--class CometPositionColumnReader extends CometColumnReader {
--  CometPositionColumnReader(Types.NestedField field) {
--    super(field);
--    setDelegate(new PositionColumnReader(descriptor()));
--  }
--
--  @Override
--  public void setBatchSize(int batchSize) {
--    super.setBatchSize(batchSize);
--    delegate().setBatchSize(batchSize);
--    setInitialized(true);
--  }
--
--  private static class PositionColumnReader extends MetadataColumnReader {
--    /** The current position value of the column that are used to initialize this column reader. */
--    private long position;
--
--    PositionColumnReader(ColumnDescriptor descriptor) {
--      super(
--          DataTypes.LongType,
--          descriptor,
--          false /* useDecimal128 = false */,
--          false /* isConstant = false */);
--    }
--
--    @Override
--    public void readBatch(int total) {
--      Native.resetBatch(nativeHandle);
--      // set position on the native side to be consumed by native execution
--      Native.setPosition(nativeHandle, position, total);
--      position += total;
--
--      super.readBatch(total);
--    }
--  }
--}
-diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometVectorizedReaderBuilder.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometVectorizedReaderBuilder.java
-deleted file mode 100644
-index d36f1a7274..0000000000
---- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometVectorizedReaderBuilder.java
-+++ /dev/null
-@@ -1,147 +0,0 @@
--/*
-- * Licensed to the Apache Software Foundation (ASF) under one
-- * or more contributor license agreements.  See the NOTICE file
-- * distributed with this work for additional information
-- * regarding copyright ownership.  The ASF licenses this file
-- * to you under the Apache License, Version 2.0 (the
-- * "License"); you may not use this file except in compliance
-- * with the License.  You may obtain a copy of the License at
-- *
-- *   http://www.apache.org/licenses/LICENSE-2.0
-- *
-- * Unless required by applicable law or agreed to in writing,
-- * software distributed under the License is distributed on an
-- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-- * KIND, either express or implied.  See the License for the
-- * specific language governing permissions and limitations
-- * under the License.
-- */
--package org.apache.iceberg.spark.data.vectorized;
--
--import java.util.List;
--import java.util.Map;
--import java.util.function.Function;
--import java.util.stream.IntStream;
--import org.apache.iceberg.MetadataColumns;
--import org.apache.iceberg.Schema;
--import org.apache.iceberg.data.DeleteFilter;
--import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
--import org.apache.iceberg.parquet.VectorizedReader;
--import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
--import org.apache.iceberg.relocated.com.google.common.collect.Lists;
--import org.apache.iceberg.relocated.com.google.common.collect.Maps;
--import org.apache.iceberg.spark.SparkSchemaUtil;
--import org.apache.iceberg.types.Types;
--import org.apache.parquet.column.ColumnDescriptor;
--import org.apache.parquet.schema.GroupType;
--import org.apache.parquet.schema.MessageType;
--import org.apache.parquet.schema.PrimitiveType;
--import org.apache.parquet.schema.Type;
--import org.apache.spark.sql.catalyst.InternalRow;
--
--class CometVectorizedReaderBuilder extends TypeWithSchemaVisitor<VectorizedReader<?>> {
--
--  private final MessageType parquetSchema;
--  private final Schema icebergSchema;
--  private final Map<Integer, ?> idToConstant;
--  private final Function<List<VectorizedReader<?>>, VectorizedReader<?>> readerFactory;
--  private final DeleteFilter<InternalRow> deleteFilter;
--
--  CometVectorizedReaderBuilder(
--      Schema expectedSchema,
--      MessageType parquetSchema,
--      Map<Integer, ?> idToConstant,
--      Function<List<VectorizedReader<?>>, VectorizedReader<?>> readerFactory,
--      DeleteFilter<InternalRow> deleteFilter) {
--    this.parquetSchema = parquetSchema;
--    this.icebergSchema = expectedSchema;
--    this.idToConstant = idToConstant;
--    this.readerFactory = readerFactory;
--    this.deleteFilter = deleteFilter;
--  }
--
--  @Override
--  public VectorizedReader<?> message(
--      Types.StructType expected, MessageType message, List<VectorizedReader<?>> fieldReaders) {
--    GroupType groupType = message.asGroupType();
--    Map<Integer, VectorizedReader<?>> readersById = Maps.newHashMap();
--    List<Type> fields = groupType.getFields();
--
--    IntStream.range(0, fields.size())
--        .filter(pos -> fields.get(pos).getId() != null)
--        .forEach(pos -> readersById.put(fields.get(pos).getId().intValue(), fieldReaders.get(pos)));
--
--    List<Types.NestedField> icebergFields =
--        expected != null ? expected.fields() : ImmutableList.of();
--
--    List<VectorizedReader<?>> reorderedFields =
--        Lists.newArrayListWithExpectedSize(icebergFields.size());
--
--    for (Types.NestedField field : icebergFields) {
--      int id = field.fieldId();
--      VectorizedReader<?> reader = readersById.get(id);
--      if (idToConstant.containsKey(id)) {
--        CometConstantColumnReader constantReader =
--            new CometConstantColumnReader<>(idToConstant.get(id), field);
--        reorderedFields.add(constantReader);
--      } else if (id == MetadataColumns.ROW_POSITION.fieldId()) {
--        reorderedFields.add(new CometPositionColumnReader(field));
--      } else if (id == MetadataColumns.IS_DELETED.fieldId()) {
--        CometColumnReader deleteReader = new CometDeleteColumnReader<>(field);
--        reorderedFields.add(deleteReader);
--      } else if (reader != null) {
--        reorderedFields.add(reader);
--      } else if (field.initialDefault() != null) {
--        CometColumnReader constantReader =
--            new CometConstantColumnReader<>(field.initialDefault(), field);
--        reorderedFields.add(constantReader);
--      } else if (field.isOptional()) {
--        CometColumnReader constantReader = new CometConstantColumnReader<>(null, field);
--        reorderedFields.add(constantReader);
--      } else {
--        throw new IllegalArgumentException(
--            String.format("Missing required field: %s", field.name()));
--      }
--    }
--    return vectorizedReader(reorderedFields);
--  }
--
--  protected VectorizedReader<?> vectorizedReader(List<VectorizedReader<?>> reorderedFields) {
--    VectorizedReader<?> reader = readerFactory.apply(reorderedFields);
--    if (deleteFilter != null) {
--      ((CometColumnarBatchReader) reader).setDeleteFilter(deleteFilter);
--    }
--    return reader;
--  }
--
--  @Override
--  public VectorizedReader<?> struct(
--      Types.StructType expected, GroupType groupType, List<VectorizedReader<?>> fieldReaders) {
--    if (expected != null) {
--      throw new UnsupportedOperationException(
--          "Vectorized reads are not supported yet for struct fields");
--    }
--    return null;
--  }
--
--  @Override
--  public VectorizedReader<?> primitive(
--      org.apache.iceberg.types.Type.PrimitiveType expected, PrimitiveType primitive) {
--
--    if (primitive.getId() == null) {
--      return null;
--    }
--    int parquetFieldId = primitive.getId().intValue();
--    ColumnDescriptor desc = parquetSchema.getColumnDescription(currentPath());
--    // Nested types not yet supported for vectorized reads
--    if (desc.getMaxRepetitionLevel() > 0) {
--      return null;
--    }
--    Types.NestedField icebergField = icebergSchema.findField(parquetFieldId);
--    if (icebergField == null) {
--      return null;
--    }
--
--    return new CometColumnReader(SparkSchemaUtil.convert(icebergField.type()), desc);
--  }
--}
-diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
-index d95baa724b..eecfa6b358 100644
---- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
-+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
-@@ -83,22 +83,6 @@ public class VectorizedSparkParquetReaders {
-         expectedSchema, fileSchema, idToConstant, deleteFilter, ArrowAllocation.rootAllocator());
-   }
- 
--  public static CometColumnarBatchReader buildCometReader(
--      Schema expectedSchema,
--      MessageType fileSchema,
--      Map<Integer, ?> idToConstant,
--      DeleteFilter<InternalRow> deleteFilter) {
--    return (CometColumnarBatchReader)
--        TypeWithSchemaVisitor.visit(
--            expectedSchema.asStruct(),
--            fileSchema,
--            new CometVectorizedReaderBuilder(
--                expectedSchema,
--                fileSchema,
--                idToConstant,
--                readers -> new CometColumnarBatchReader(readers, expectedSchema),
--                deleteFilter));
--  }
- 
-   // enables unsafe memory access to avoid costly checks to see if index is within bounds
-   // as long as it is not configured explicitly (see BoundsChecking in Arrow)
-diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
-index a0f45e7610..78e7845911 100644
---- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
-+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
-@@ -34,7 +34,6 @@ import org.apache.iceberg.parquet.Parquet;
- import org.apache.iceberg.relocated.com.google.common.collect.Sets;
- import org.apache.iceberg.spark.OrcBatchReadConf;
- import org.apache.iceberg.spark.ParquetBatchReadConf;
--import org.apache.iceberg.spark.ParquetReaderType;
- import org.apache.iceberg.spark.data.vectorized.VectorizedSparkOrcReaders;
- import org.apache.iceberg.spark.data.vectorized.VectorizedSparkParquetReaders;
- import org.apache.iceberg.types.TypeUtil;
-@@ -94,15 +93,9 @@ abstract class BaseBatchReader<T extends ScanTask> extends BaseReader<ColumnarBa
-         .project(requiredSchema)
-         .split(start, length)
-         .createBatchedReaderFunc(
--            fileSchema -> {
--              if (parquetConf.readerType() == ParquetReaderType.COMET) {
--                return VectorizedSparkParquetReaders.buildCometReader(
--                    requiredSchema, fileSchema, idToConstant, deleteFilter);
--              } else {
--                return VectorizedSparkParquetReaders.buildReader(
--                    requiredSchema, fileSchema, idToConstant, deleteFilter);
--              }
--            })
-+            fileSchema ->
-+                VectorizedSparkParquetReaders.buildReader(
-+                    requiredSchema, fileSchema, idToConstant, deleteFilter))
-         .recordsPerBatch(parquetConf.batchSize())
-         .filter(residual)
-         .caseSensitive(caseSensitive())
 diff --git a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java
 deleted file mode 100644
 index 81b7d83a70..0000000000
@@ -2298,10 +866,10 @@ index d36f1a7274..0000000000
 -  }
 -}
 diff --git a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
-index d95baa724b..eecfa6b358 100644
+index d95baa724b..865cf5085f 100644
 --- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
 +++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
-@@ -83,22 +83,6 @@ public class VectorizedSparkParquetReaders {
+@@ -83,23 +83,6 @@ public class VectorizedSparkParquetReaders {
          expectedSchema, fileSchema, idToConstant, deleteFilter, ArrowAllocation.rootAllocator());
    }
  
@@ -2321,9 +889,10 @@ index d95baa724b..eecfa6b358 100644
 -                readers -> new CometColumnarBatchReader(readers, expectedSchema),
 -                deleteFilter));
 -  }
- 
+-
    // enables unsafe memory access to avoid costly checks to see if index is within bounds
    // as long as it is not configured explicitly (see BoundsChecking in Arrow)
+   private static void enableUnsafeMemoryAccess() {
 diff --git a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
 index a0f45e7610..78e7845911 100644
 --- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
@@ -2355,3 +924,2089 @@ index a0f45e7610..78e7845911 100644
          .recordsPerBatch(parquetConf.batchSize())
          .filter(residual)
          .caseSensitive(caseSensitive())
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
+index 404ba72846..00e97e96f9 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
+@@ -90,6 +90,16 @@ public abstract class SparkDistributedDataScanTestBase
+         .master("local[2]")
+         .config("spark.serializer", serializer)
+         .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++        .config("spark.plugins", "org.apache.spark.CometPlugin")
++        .config(
++            "spark.shuffle.manager",
++            "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++        .config("spark.comet.explainFallback.enabled", "true")
++        .config("spark.comet.scan.icebergNative.enabled", "true")
++        .config("spark.memory.offHeap.enabled", "true")
++        .config("spark.memory.offHeap.size", "10g")
++        .config("spark.comet.use.lazyMaterialization", "false")
++        .config("spark.comet.schemaEvolution.enabled", "true")
+         .getOrCreate();
+   }
+ }
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
+index 9361c63176..9a78bbf3b6 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
+@@ -69,6 +69,16 @@ public class TestSparkDistributedDataScanDeletes
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
+index a218f965ea..eca0125ace 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
+@@ -62,6 +62,16 @@ public class TestSparkDistributedDataScanFilterFiles
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
+index acd4688440..9be94eab2f 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
+@@ -59,6 +59,16 @@ public class TestSparkDistributedDataScanReporting
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
+index 6647a1b483..b8b428229b 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
+@@ -62,6 +62,16 @@ public abstract class ScanTestBase extends AvroDataTestBase {
+         SparkSession.builder()
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
+             .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+     ScanTestBase.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+index 24a14bb64d..be45d95ae8 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+@@ -144,7 +144,20 @@ public class TestCompressionSettings extends CatalogTestBase {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestCompressionSettings.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestCompressionSettings.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @BeforeEach
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+index 99d3f38ee7..c94f21e391 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+@@ -74,7 +74,20 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestDataSourceOptions.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestDataSourceOptions.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+index a70aeb1ba6..f75ce46a35 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+@@ -123,6 +123,16 @@ public class TestFilteredScan {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+ 
+     // define UDFs used by partition tests
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+index c03f7b94ec..a3e803359a 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+@@ -99,6 +99,16 @@ public class TestForwardCompatibility {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+index f4f57157e4..7dd2ed811d 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+@@ -51,6 +51,16 @@ public class TestIcebergSpark {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+index e1402396fa..8b60b8bc48 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+@@ -118,6 +118,16 @@ public class TestPartitionPruning {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+     TestPartitionPruning.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+index b0ad930487..8b76a364bd 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+@@ -112,6 +112,16 @@ public class TestPartitionValues {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+index 11865db7fc..bdb9ae32a6 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+@@ -91,6 +91,16 @@ public class TestSnapshotSelection {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+index 833a0b6b5e..95007024d1 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+@@ -125,6 +125,16 @@ public class TestSparkDataFile {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+     TestSparkDataFile.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+index 8884654fe0..e666553d91 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+@@ -100,6 +100,16 @@ public class TestSparkDataWrite {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
+index 596d05d30b..e681d81704 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
+@@ -88,6 +88,16 @@ public class TestSparkReadProjection extends TestReadProjection {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+     ImmutableMap<String, String> config =
+         ImmutableMap.of(
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+index 16fa726032..64e367cf47 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+@@ -132,7 +132,27 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
+             .config("spark.ui.liveUpdate.period", 0)
+             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+ 
+     catalog =
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+index baf7fa8f88..665946ad82 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+@@ -182,7 +182,27 @@ public class TestSparkReaderWithBloomFilter {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+ 
+     catalog =
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+index dc4fc7e187..c18a701ecf 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+@@ -69,6 +69,16 @@ public class TestStructuredStreaming {
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
+             .config("spark.sql.shuffle.partitions", 4)
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
+index 8b1e3fbfc7..b4385c3950 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
+@@ -75,7 +75,20 @@ public class TestTimestampWithoutZone extends TestBase {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestTimestampWithoutZone.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestTimestampWithoutZone.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+index c3fac70dd3..b6c66f3f88 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+@@ -84,6 +84,16 @@ public class TestWriteMetricsConfig {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+     TestWriteMetricsConfig.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+index 5ce56b4fec..40e4fb0a74 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+@@ -63,7 +63,27 @@ public class TestAggregatePushDown extends CatalogTestBase {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.sql.iceberg.aggregate_pushdown", "true")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+ 
+     TestBase.catalog =
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+index 9d2ce2b388..5e23368848 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+@@ -598,9 +598,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
+     String planAsString = sparkPlan.toString().replaceAll("#(\\d+L?)", "");
+ 
+     if (sparkFilter != null) {
+-      assertThat(planAsString)
+-          .as("Post scan filter should match")
+-          .contains("Filter (" + sparkFilter + ")");
++      assertThat(planAsString).as("Post scan filter should match").contains("CometFilter");
+     } else {
+       assertThat(planAsString).as("Should be no post scan filter").doesNotContain("Filter (");
+     }
+diff --git a/spark/v3.5/build.gradle b/spark/v3.5/build.gradle
+index 69700d8436..49ea338a45 100644
+--- a/spark/v3.5/build.gradle
++++ b/spark/v3.5/build.gradle
+@@ -264,6 +264,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
+     integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+     integrationImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
+     integrationImplementation project(path: ":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
++    integrationImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:${libs.versions.comet.get()}"
+ 
+     // runtime dependencies for running Hive Catalog based integration test
+     integrationRuntimeOnly project(':iceberg-hive-metastore')
+diff --git a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
+index 4c1a509591..44b401644e 100644
+--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
++++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
+@@ -59,6 +59,16 @@ public abstract class ExtensionsTestBase extends CatalogTestBase {
+             .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
+             .config(
+                 SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), String.valueOf(RANDOM.nextBoolean()))
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
+diff --git a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+index ecf9e6f8a5..3475260ca5 100644
+--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
++++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+@@ -56,6 +56,16 @@ public class TestCallStatementParser {
+             .master("local[2]")
+             .config("spark.sql.extensions", IcebergSparkSessionExtensions.class.getName())
+             .config("spark.extra.prop", "value")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+     TestCallStatementParser.parser = spark.sessionState().sqlParser();
+   }
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
+index 64edb1002e..0fc10120ff 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
+@@ -179,6 +179,16 @@ public class DeleteOrphanFilesBenchmark {
+             .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
+             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+             .config("spark.sql.catalog.spark_catalog.warehouse", catalogWarehouse())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .master("local");
+     spark = builder.getOrCreate();
+   }
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
+index 77b79384a6..01a4c82dc9 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
+@@ -392,6 +392,16 @@ public class IcebergSortCompactionBenchmark {
+                 "spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog")
+             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+             .config("spark.sql.catalog.spark_catalog.warehouse", getCatalogWarehouse())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .master("local[*]");
+     spark = builder.getOrCreate();
+     Configuration sparkHadoopConf = spark.sessionState().newHadoopConf();
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
+index c6794e43c6..457d2823ee 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
+@@ -239,6 +239,16 @@ public class DVReaderBenchmark {
+             .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
+             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+             .config("spark.sql.catalog.spark_catalog.warehouse", newWarehouseDir())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .master("local[*]")
+             .getOrCreate();
+   }
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
+index ac74fb5a10..eab09293de 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
+@@ -223,6 +223,16 @@ public class DVWriterBenchmark {
+             .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
+             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+             .config("spark.sql.catalog.spark_catalog.warehouse", newWarehouseDir())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .master("local[*]")
+             .getOrCreate();
+   }
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
+index 68c537e34a..1e9e90d539 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
+@@ -94,7 +94,19 @@ public abstract class IcebergSourceBenchmark {
+   }
+ 
+   protected void setupSpark(boolean enableDictionaryEncoding) {
+-    SparkSession.Builder builder = SparkSession.builder().config("spark.ui.enabled", false);
++    SparkSession.Builder builder =
++        SparkSession.builder()
++            .config("spark.ui.enabled", false)
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true");
+     if (!enableDictionaryEncoding) {
+       builder
+           .config("parquet.dictionary.page.size", "1")
+diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java
+deleted file mode 100644
+index 81b7d83a70..0000000000
+--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java
++++ /dev/null
+@@ -1,140 +0,0 @@
+-/*
+- * Licensed to the Apache Software Foundation (ASF) under one
+- * or more contributor license agreements.  See the NOTICE file
+- * distributed with this work for additional information
+- * regarding copyright ownership.  The ASF licenses this file
+- * to you under the Apache License, Version 2.0 (the
+- * "License"); you may not use this file except in compliance
+- * with the License.  You may obtain a copy of the License at
+- *
+- *   http://www.apache.org/licenses/LICENSE-2.0
+- *
+- * Unless required by applicable law or agreed to in writing,
+- * software distributed under the License is distributed on an
+- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+- * KIND, either express or implied.  See the License for the
+- * specific language governing permissions and limitations
+- * under the License.
+- */
+-package org.apache.iceberg.spark.data.vectorized;
+-
+-import java.io.IOException;
+-import org.apache.comet.CometSchemaImporter;
+-import org.apache.comet.parquet.AbstractColumnReader;
+-import org.apache.comet.parquet.ColumnReader;
+-import org.apache.comet.parquet.TypeUtil;
+-import org.apache.comet.parquet.Utils;
+-import org.apache.comet.shaded.arrow.memory.RootAllocator;
+-import org.apache.iceberg.parquet.VectorizedReader;
+-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+-import org.apache.iceberg.spark.SparkSchemaUtil;
+-import org.apache.iceberg.types.Types;
+-import org.apache.parquet.column.ColumnDescriptor;
+-import org.apache.parquet.column.page.PageReader;
+-import org.apache.spark.sql.types.DataType;
+-import org.apache.spark.sql.types.Metadata;
+-import org.apache.spark.sql.types.StructField;
+-import org.apache.spark.sql.vectorized.ColumnVector;
+-
+-class CometColumnReader implements VectorizedReader<ColumnVector> {
+-  // use the Comet default batch size
+-  public static final int DEFAULT_BATCH_SIZE = 8192;
+-
+-  private final ColumnDescriptor descriptor;
+-  private final DataType sparkType;
+-
+-  // The delegated ColumnReader from Comet side
+-  private AbstractColumnReader delegate;
+-  private boolean initialized = false;
+-  private int batchSize = DEFAULT_BATCH_SIZE;
+-  private CometSchemaImporter importer;
+-
+-  CometColumnReader(DataType sparkType, ColumnDescriptor descriptor) {
+-    this.sparkType = sparkType;
+-    this.descriptor = descriptor;
+-  }
+-
+-  CometColumnReader(Types.NestedField field) {
+-    DataType dataType = SparkSchemaUtil.convert(field.type());
+-    StructField structField = new StructField(field.name(), dataType, false, Metadata.empty());
+-    this.sparkType = dataType;
+-    this.descriptor = TypeUtil.convertToParquet(structField);
+-  }
+-
+-  public AbstractColumnReader delegate() {
+-    return delegate;
+-  }
+-
+-  void setDelegate(AbstractColumnReader delegate) {
+-    this.delegate = delegate;
+-  }
+-
+-  void setInitialized(boolean initialized) {
+-    this.initialized = initialized;
+-  }
+-
+-  public int batchSize() {
+-    return batchSize;
+-  }
+-
+-  /**
+-   * This method is to initialized/reset the CometColumnReader. This needs to be called for each row
+-   * group after readNextRowGroup, so a new dictionary encoding can be set for each of the new row
+-   * groups.
+-   */
+-  public void reset() {
+-    if (importer != null) {
+-      importer.close();
+-    }
+-
+-    if (delegate != null) {
+-      delegate.close();
+-    }
+-
+-    this.importer = new CometSchemaImporter(new RootAllocator());
+-    this.delegate = Utils.getColumnReader(sparkType, descriptor, importer, batchSize, false, false);
+-    this.initialized = true;
+-  }
+-
+-  public ColumnDescriptor descriptor() {
+-    return descriptor;
+-  }
+-
+-  /** Returns the Spark data type for this column. */
+-  public DataType sparkType() {
+-    return sparkType;
+-  }
+-
+-  /**
+-   * Set the page reader to be 'pageReader'.
+-   *
+-   * <p>NOTE: this should be called before reading a new Parquet column chunk, and after {@link
+-   * CometColumnReader#reset} is called.
+-   */
+-  public void setPageReader(PageReader pageReader) throws IOException {
+-    Preconditions.checkState(initialized, "Invalid state: 'reset' should be called first");
+-    ((ColumnReader) delegate).setPageReader(pageReader);
+-  }
+-
+-  @Override
+-  public void close() {
+-    // close resources on native side
+-    if (importer != null) {
+-      importer.close();
+-    }
+-
+-    if (delegate != null) {
+-      delegate.close();
+-    }
+-  }
+-
+-  @Override
+-  public void setBatchSize(int size) {
+-    this.batchSize = size;
+-  }
+-
+-  @Override
+-  public ColumnVector read(ColumnVector reuse, int numRowsToRead) {
+-    throw new UnsupportedOperationException("Not supported");
+-  }
+-}
+diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnarBatchReader.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnarBatchReader.java
+deleted file mode 100644
+index 04ac69476a..0000000000
+--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnarBatchReader.java
++++ /dev/null
+@@ -1,197 +0,0 @@
+-/*
+- * Licensed to the Apache Software Foundation (ASF) under one
+- * or more contributor license agreements.  See the NOTICE file
+- * distributed with this work for additional information
+- * regarding copyright ownership.  The ASF licenses this file
+- * to you under the Apache License, Version 2.0 (the
+- * "License"); you may not use this file except in compliance
+- * with the License.  You may obtain a copy of the License at
+- *
+- *   http://www.apache.org/licenses/LICENSE-2.0
+- *
+- * Unless required by applicable law or agreed to in writing,
+- * software distributed under the License is distributed on an
+- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+- * KIND, either express or implied.  See the License for the
+- * specific language governing permissions and limitations
+- * under the License.
+- */
+-package org.apache.iceberg.spark.data.vectorized;
+-
+-import java.io.IOException;
+-import java.io.UncheckedIOException;
+-import java.util.List;
+-import java.util.Map;
+-import org.apache.comet.parquet.AbstractColumnReader;
+-import org.apache.comet.parquet.BatchReader;
+-import org.apache.iceberg.Schema;
+-import org.apache.iceberg.data.DeleteFilter;
+-import org.apache.iceberg.parquet.VectorizedReader;
+-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+-import org.apache.iceberg.spark.SparkSchemaUtil;
+-import org.apache.iceberg.util.Pair;
+-import org.apache.parquet.column.page.PageReadStore;
+-import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+-import org.apache.parquet.hadoop.metadata.ColumnPath;
+-import org.apache.spark.sql.catalyst.InternalRow;
+-import org.apache.spark.sql.vectorized.ColumnVector;
+-import org.apache.spark.sql.vectorized.ColumnarBatch;
+-
+-/**
+- * {@link VectorizedReader} that returns Spark's {@link ColumnarBatch} to support Spark's vectorized
+- * read path. The {@link ColumnarBatch} returned is created by passing in the Arrow vectors
+- * populated via delegated read calls to {@link CometColumnReader VectorReader(s)}.
+- */
+-@SuppressWarnings("checkstyle:VisibilityModifier")
+-class CometColumnarBatchReader implements VectorizedReader<ColumnarBatch> {
+-
+-  private final CometColumnReader[] readers;
+-  private final boolean hasIsDeletedColumn;
+-
+-  // The delegated BatchReader on the Comet side does the real work of loading a batch of rows.
+-  // The Comet BatchReader contains an array of ColumnReader. There is no need to explicitly call
+-  // ColumnReader.readBatch; instead, BatchReader.nextBatch will be called, which underneath calls
+-  // ColumnReader.readBatch. The only exception is DeleteColumnReader, because at the time of
+-  // calling BatchReader.nextBatch, the isDeleted value is not yet available, so
+-  // DeleteColumnReader.readBatch must be called explicitly later, after the isDeleted value is
+-  // available.
+-  private final BatchReader delegate;
+-  private DeleteFilter<InternalRow> deletes = null;
+-  private long rowStartPosInBatch = 0;
+-
+-  CometColumnarBatchReader(List<VectorizedReader<?>> readers, Schema schema) {
+-    this.readers =
+-        readers.stream().map(CometColumnReader.class::cast).toArray(CometColumnReader[]::new);
+-    this.hasIsDeletedColumn =
+-        readers.stream().anyMatch(reader -> reader instanceof CometDeleteColumnReader);
+-
+-    AbstractColumnReader[] abstractColumnReaders = new AbstractColumnReader[readers.size()];
+-    this.delegate = new BatchReader(abstractColumnReaders);
+-    delegate.setSparkSchema(SparkSchemaUtil.convert(schema));
+-  }
+-
+-  @Override
+-  public void setRowGroupInfo(
+-      PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metaData) {
+-    for (int i = 0; i < readers.length; i++) {
+-      try {
+-        if (!(readers[i] instanceof CometConstantColumnReader)
+-            && !(readers[i] instanceof CometPositionColumnReader)
+-            && !(readers[i] instanceof CometDeleteColumnReader)) {
+-          readers[i].reset();
+-          readers[i].setPageReader(pageStore.getPageReader(readers[i].descriptor()));
+-        }
+-      } catch (IOException e) {
+-        throw new UncheckedIOException("Failed to setRowGroupInfo for Comet vectorization", e);
+-      }
+-    }
+-
+-    for (int i = 0; i < readers.length; i++) {
+-      delegate.getColumnReaders()[i] = this.readers[i].delegate();
+-    }
+-
+-    this.rowStartPosInBatch =
+-        pageStore
+-            .getRowIndexOffset()
+-            .orElseThrow(
+-                () ->
+-                    new IllegalArgumentException(
+-                        "PageReadStore does not contain row index offset"));
+-  }
+-
+-  public void setDeleteFilter(DeleteFilter<InternalRow> deleteFilter) {
+-    this.deletes = deleteFilter;
+-  }
+-
+-  @Override
+-  public final ColumnarBatch read(ColumnarBatch reuse, int numRowsToRead) {
+-    ColumnarBatch columnarBatch = new ColumnBatchLoader(numRowsToRead).loadDataToColumnBatch();
+-    rowStartPosInBatch += numRowsToRead;
+-    return columnarBatch;
+-  }
+-
+-  @Override
+-  public void setBatchSize(int batchSize) {
+-    for (CometColumnReader reader : readers) {
+-      if (reader != null) {
+-        reader.setBatchSize(batchSize);
+-      }
+-    }
+-  }
+-
+-  @Override
+-  public void close() {
+-    for (CometColumnReader reader : readers) {
+-      if (reader != null) {
+-        reader.close();
+-      }
+-    }
+-  }
+-
+-  private class ColumnBatchLoader {
+-    private final int batchSize;
+-
+-    ColumnBatchLoader(int numRowsToRead) {
+-      Preconditions.checkArgument(
+-          numRowsToRead > 0, "Invalid number of rows to read: %s", numRowsToRead);
+-      this.batchSize = numRowsToRead;
+-    }
+-
+-    ColumnarBatch loadDataToColumnBatch() {
+-      ColumnVector[] vectors = readDataToColumnVectors();
+-      int numLiveRows = batchSize;
+-
+-      if (hasIsDeletedColumn) {
+-        boolean[] isDeleted = buildIsDeleted(vectors);
+-        readDeletedColumn(vectors, isDeleted);
+-      } else {
+-        Pair<int[], Integer> pair = buildRowIdMapping(vectors);
+-        if (pair != null) {
+-          int[] rowIdMapping = pair.first();
+-          numLiveRows = pair.second();
+-          for (int i = 0; i < vectors.length; i++) {
+-            vectors[i] = new ColumnVectorWithFilter(vectors[i], rowIdMapping);
+-          }
+-        }
+-      }
+-
+-      if (deletes != null && deletes.hasEqDeletes()) {
+-        vectors = ColumnarBatchUtil.removeExtraColumns(deletes, vectors);
+-      }
+-
+-      ColumnarBatch batch = new ColumnarBatch(vectors);
+-      batch.setNumRows(numLiveRows);
+-      return batch;
+-    }
+-
+-    private boolean[] buildIsDeleted(ColumnVector[] vectors) {
+-      return ColumnarBatchUtil.buildIsDeleted(vectors, deletes, rowStartPosInBatch, batchSize);
+-    }
+-
+-    private Pair<int[], Integer> buildRowIdMapping(ColumnVector[] vectors) {
+-      return ColumnarBatchUtil.buildRowIdMapping(vectors, deletes, rowStartPosInBatch, batchSize);
+-    }
+-
+-    ColumnVector[] readDataToColumnVectors() {
+-      ColumnVector[] columnVectors = new ColumnVector[readers.length];
+-      // Fetch rows for all readers in the delegate
+-      delegate.nextBatch(batchSize);
+-      for (int i = 0; i < readers.length; i++) {
+-        columnVectors[i] = readers[i].delegate().currentBatch();
+-      }
+-
+-      return columnVectors;
+-    }
+-
+-    void readDeletedColumn(ColumnVector[] columnVectors, boolean[] isDeleted) {
+-      for (int i = 0; i < readers.length; i++) {
+-        if (readers[i] instanceof CometDeleteColumnReader) {
+-          CometDeleteColumnReader deleteColumnReader = new CometDeleteColumnReader<>(isDeleted);
+-          deleteColumnReader.setBatchSize(batchSize);
+-          deleteColumnReader.delegate().readBatch(batchSize);
+-          columnVectors[i] = deleteColumnReader.delegate().currentBatch();
+-        }
+-      }
+-    }
+-  }
+-}
+diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometConstantColumnReader.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometConstantColumnReader.java
+deleted file mode 100644
+index 047c96314b..0000000000
+--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometConstantColumnReader.java
++++ /dev/null
+@@ -1,65 +0,0 @@
+-/*
+- * Licensed to the Apache Software Foundation (ASF) under one
+- * or more contributor license agreements.  See the NOTICE file
+- * distributed with this work for additional information
+- * regarding copyright ownership.  The ASF licenses this file
+- * to you under the Apache License, Version 2.0 (the
+- * "License"); you may not use this file except in compliance
+- * with the License.  You may obtain a copy of the License at
+- *
+- *   http://www.apache.org/licenses/LICENSE-2.0
+- *
+- * Unless required by applicable law or agreed to in writing,
+- * software distributed under the License is distributed on an
+- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+- * KIND, either express or implied.  See the License for the
+- * specific language governing permissions and limitations
+- * under the License.
+- */
+-package org.apache.iceberg.spark.data.vectorized;
+-
+-import java.math.BigDecimal;
+-import java.nio.ByteBuffer;
+-import org.apache.comet.parquet.ConstantColumnReader;
+-import org.apache.iceberg.types.Types;
+-import org.apache.spark.sql.types.DataType;
+-import org.apache.spark.sql.types.DataTypes;
+-import org.apache.spark.sql.types.Decimal;
+-import org.apache.spark.sql.types.DecimalType;
+-import org.apache.spark.unsafe.types.UTF8String;
+-
+-class CometConstantColumnReader<T> extends CometColumnReader {
+-
+-  CometConstantColumnReader(T value, Types.NestedField field) {
+-    super(field);
+-    // use delegate to set constant value on the native side to be consumed by native execution.
+-    setDelegate(
+-        new ConstantColumnReader(sparkType(), descriptor(), convertToSparkValue(value), false));
+-  }
+-
+-  @Override
+-  public void setBatchSize(int batchSize) {
+-    super.setBatchSize(batchSize);
+-    delegate().setBatchSize(batchSize);
+-    setInitialized(true);
+-  }
+-
+-  private Object convertToSparkValue(T value) {
+-    DataType dataType = sparkType();
+-    // Match the value to Spark internal type if necessary
+-    if (dataType == DataTypes.StringType && value instanceof String) {
+-      // the internal type for StringType is UTF8String
+-      return UTF8String.fromString((String) value);
+-    } else if (dataType instanceof DecimalType && value instanceof BigDecimal) {
+-      // the internal type for DecimalType is Decimal
+-      return Decimal.apply((BigDecimal) value);
+-    } else if (dataType == DataTypes.BinaryType && value instanceof ByteBuffer) {
+-      // the internal type for DecimalType is byte[]
+-      // Iceberg default value should always use HeapBufferBuffer, so calling ByteBuffer.array()
+-      // should be safe.
+-      return ((ByteBuffer) value).array();
+-    } else {
+-      return value;
+-    }
+-  }
+-}
+diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometDeleteColumnReader.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometDeleteColumnReader.java
+deleted file mode 100644
+index 6235bfe486..0000000000
+--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometDeleteColumnReader.java
++++ /dev/null
+@@ -1,75 +0,0 @@
+-/*
+- * Licensed to the Apache Software Foundation (ASF) under one
+- * or more contributor license agreements.  See the NOTICE file
+- * distributed with this work for additional information
+- * regarding copyright ownership.  The ASF licenses this file
+- * to you under the Apache License, Version 2.0 (the
+- * "License"); you may not use this file except in compliance
+- * with the License.  You may obtain a copy of the License at
+- *
+- *   http://www.apache.org/licenses/LICENSE-2.0
+- *
+- * Unless required by applicable law or agreed to in writing,
+- * software distributed under the License is distributed on an
+- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+- * KIND, either express or implied.  See the License for the
+- * specific language governing permissions and limitations
+- * under the License.
+- */
+-package org.apache.iceberg.spark.data.vectorized;
+-
+-import org.apache.comet.parquet.MetadataColumnReader;
+-import org.apache.comet.parquet.Native;
+-import org.apache.comet.parquet.TypeUtil;
+-import org.apache.iceberg.MetadataColumns;
+-import org.apache.iceberg.types.Types;
+-import org.apache.spark.sql.types.DataTypes;
+-import org.apache.spark.sql.types.Metadata;
+-import org.apache.spark.sql.types.StructField;
+-
+-class CometDeleteColumnReader<T> extends CometColumnReader {
+-  CometDeleteColumnReader(Types.NestedField field) {
+-    super(field);
+-    setDelegate(new DeleteColumnReader());
+-  }
+-
+-  CometDeleteColumnReader(boolean[] isDeleted) {
+-    super(MetadataColumns.IS_DELETED);
+-    setDelegate(new DeleteColumnReader(isDeleted));
+-  }
+-
+-  @Override
+-  public void setBatchSize(int batchSize) {
+-    super.setBatchSize(batchSize);
+-    delegate().setBatchSize(batchSize);
+-    setInitialized(true);
+-  }
+-
+-  private static class DeleteColumnReader extends MetadataColumnReader {
+-    private boolean[] isDeleted;
+-
+-    DeleteColumnReader() {
+-      super(
+-          DataTypes.BooleanType,
+-          TypeUtil.convertToParquet(
+-              new StructField("_deleted", DataTypes.BooleanType, false, Metadata.empty())),
+-          false /* useDecimal128 = false */,
+-          false /* isConstant = false */);
+-      this.isDeleted = new boolean[0];
+-    }
+-
+-    DeleteColumnReader(boolean[] isDeleted) {
+-      this();
+-      this.isDeleted = isDeleted;
+-    }
+-
+-    @Override
+-    public void readBatch(int total) {
+-      Native.resetBatch(nativeHandle);
+-      // set isDeleted on the native side to be consumed by native execution
+-      Native.setIsDeleted(nativeHandle, isDeleted);
+-
+-      super.readBatch(total);
+-    }
+-  }
+-}
+diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometPositionColumnReader.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometPositionColumnReader.java
+deleted file mode 100644
+index bcc0e514c2..0000000000
+--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometPositionColumnReader.java
++++ /dev/null
+@@ -1,62 +0,0 @@
+-/*
+- * Licensed to the Apache Software Foundation (ASF) under one
+- * or more contributor license agreements.  See the NOTICE file
+- * distributed with this work for additional information
+- * regarding copyright ownership.  The ASF licenses this file
+- * to you under the Apache License, Version 2.0 (the
+- * "License"); you may not use this file except in compliance
+- * with the License.  You may obtain a copy of the License at
+- *
+- *   http://www.apache.org/licenses/LICENSE-2.0
+- *
+- * Unless required by applicable law or agreed to in writing,
+- * software distributed under the License is distributed on an
+- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+- * KIND, either express or implied.  See the License for the
+- * specific language governing permissions and limitations
+- * under the License.
+- */
+-package org.apache.iceberg.spark.data.vectorized;
+-
+-import org.apache.comet.parquet.MetadataColumnReader;
+-import org.apache.comet.parquet.Native;
+-import org.apache.iceberg.types.Types;
+-import org.apache.parquet.column.ColumnDescriptor;
+-import org.apache.spark.sql.types.DataTypes;
+-
+-class CometPositionColumnReader extends CometColumnReader {
+-  CometPositionColumnReader(Types.NestedField field) {
+-    super(field);
+-    setDelegate(new PositionColumnReader(descriptor()));
+-  }
+-
+-  @Override
+-  public void setBatchSize(int batchSize) {
+-    super.setBatchSize(batchSize);
+-    delegate().setBatchSize(batchSize);
+-    setInitialized(true);
+-  }
+-
+-  private static class PositionColumnReader extends MetadataColumnReader {
+-    /** The current position value of the column that are used to initialize this column reader. */
+-    private long position;
+-
+-    PositionColumnReader(ColumnDescriptor descriptor) {
+-      super(
+-          DataTypes.LongType,
+-          descriptor,
+-          false /* useDecimal128 = false */,
+-          false /* isConstant = false */);
+-    }
+-
+-    @Override
+-    public void readBatch(int total) {
+-      Native.resetBatch(nativeHandle);
+-      // set position on the native side to be consumed by native execution
+-      Native.setPosition(nativeHandle, position, total);
+-      position += total;
+-
+-      super.readBatch(total);
+-    }
+-  }
+-}
+diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometVectorizedReaderBuilder.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometVectorizedReaderBuilder.java
+deleted file mode 100644
+index d36f1a7274..0000000000
+--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometVectorizedReaderBuilder.java
++++ /dev/null
+@@ -1,147 +0,0 @@
+-/*
+- * Licensed to the Apache Software Foundation (ASF) under one
+- * or more contributor license agreements.  See the NOTICE file
+- * distributed with this work for additional information
+- * regarding copyright ownership.  The ASF licenses this file
+- * to you under the Apache License, Version 2.0 (the
+- * "License"); you may not use this file except in compliance
+- * with the License.  You may obtain a copy of the License at
+- *
+- *   http://www.apache.org/licenses/LICENSE-2.0
+- *
+- * Unless required by applicable law or agreed to in writing,
+- * software distributed under the License is distributed on an
+- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+- * KIND, either express or implied.  See the License for the
+- * specific language governing permissions and limitations
+- * under the License.
+- */
+-package org.apache.iceberg.spark.data.vectorized;
+-
+-import java.util.List;
+-import java.util.Map;
+-import java.util.function.Function;
+-import java.util.stream.IntStream;
+-import org.apache.iceberg.MetadataColumns;
+-import org.apache.iceberg.Schema;
+-import org.apache.iceberg.data.DeleteFilter;
+-import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
+-import org.apache.iceberg.parquet.VectorizedReader;
+-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+-import org.apache.iceberg.spark.SparkSchemaUtil;
+-import org.apache.iceberg.types.Types;
+-import org.apache.parquet.column.ColumnDescriptor;
+-import org.apache.parquet.schema.GroupType;
+-import org.apache.parquet.schema.MessageType;
+-import org.apache.parquet.schema.PrimitiveType;
+-import org.apache.parquet.schema.Type;
+-import org.apache.spark.sql.catalyst.InternalRow;
+-
+-class CometVectorizedReaderBuilder extends TypeWithSchemaVisitor<VectorizedReader<?>> {
+-
+-  private final MessageType parquetSchema;
+-  private final Schema icebergSchema;
+-  private final Map<Integer, ?> idToConstant;
+-  private final Function<List<VectorizedReader<?>>, VectorizedReader<?>> readerFactory;
+-  private final DeleteFilter<InternalRow> deleteFilter;
+-
+-  CometVectorizedReaderBuilder(
+-      Schema expectedSchema,
+-      MessageType parquetSchema,
+-      Map<Integer, ?> idToConstant,
+-      Function<List<VectorizedReader<?>>, VectorizedReader<?>> readerFactory,
+-      DeleteFilter<InternalRow> deleteFilter) {
+-    this.parquetSchema = parquetSchema;
+-    this.icebergSchema = expectedSchema;
+-    this.idToConstant = idToConstant;
+-    this.readerFactory = readerFactory;
+-    this.deleteFilter = deleteFilter;
+-  }
+-
+-  @Override
+-  public VectorizedReader<?> message(
+-      Types.StructType expected, MessageType message, List<VectorizedReader<?>> fieldReaders) {
+-    GroupType groupType = message.asGroupType();
+-    Map<Integer, VectorizedReader<?>> readersById = Maps.newHashMap();
+-    List<Type> fields = groupType.getFields();
+-
+-    IntStream.range(0, fields.size())
+-        .filter(pos -> fields.get(pos).getId() != null)
+-        .forEach(pos -> readersById.put(fields.get(pos).getId().intValue(), fieldReaders.get(pos)));
+-
+-    List<Types.NestedField> icebergFields =
+-        expected != null ? expected.fields() : ImmutableList.of();
+-
+-    List<VectorizedReader<?>> reorderedFields =
+-        Lists.newArrayListWithExpectedSize(icebergFields.size());
+-
+-    for (Types.NestedField field : icebergFields) {
+-      int id = field.fieldId();
+-      VectorizedReader<?> reader = readersById.get(id);
+-      if (idToConstant.containsKey(id)) {
+-        CometConstantColumnReader constantReader =
+-            new CometConstantColumnReader<>(idToConstant.get(id), field);
+-        reorderedFields.add(constantReader);
+-      } else if (id == MetadataColumns.ROW_POSITION.fieldId()) {
+-        reorderedFields.add(new CometPositionColumnReader(field));
+-      } else if (id == MetadataColumns.IS_DELETED.fieldId()) {
+-        CometColumnReader deleteReader = new CometDeleteColumnReader<>(field);
+-        reorderedFields.add(deleteReader);
+-      } else if (reader != null) {
+-        reorderedFields.add(reader);
+-      } else if (field.initialDefault() != null) {
+-        CometColumnReader constantReader =
+-            new CometConstantColumnReader<>(field.initialDefault(), field);
+-        reorderedFields.add(constantReader);
+-      } else if (field.isOptional()) {
+-        CometColumnReader constantReader = new CometConstantColumnReader<>(null, field);
+-        reorderedFields.add(constantReader);
+-      } else {
+-        throw new IllegalArgumentException(
+-            String.format("Missing required field: %s", field.name()));
+-      }
+-    }
+-    return vectorizedReader(reorderedFields);
+-  }
+-
+-  protected VectorizedReader<?> vectorizedReader(List<VectorizedReader<?>> reorderedFields) {
+-    VectorizedReader<?> reader = readerFactory.apply(reorderedFields);
+-    if (deleteFilter != null) {
+-      ((CometColumnarBatchReader) reader).setDeleteFilter(deleteFilter);
+-    }
+-    return reader;
+-  }
+-
+-  @Override
+-  public VectorizedReader<?> struct(
+-      Types.StructType expected, GroupType groupType, List<VectorizedReader<?>> fieldReaders) {
+-    if (expected != null) {
+-      throw new UnsupportedOperationException(
+-          "Vectorized reads are not supported yet for struct fields");
+-    }
+-    return null;
+-  }
+-
+-  @Override
+-  public VectorizedReader<?> primitive(
+-      org.apache.iceberg.types.Type.PrimitiveType expected, PrimitiveType primitive) {
+-
+-    if (primitive.getId() == null) {
+-      return null;
+-    }
+-    int parquetFieldId = primitive.getId().intValue();
+-    ColumnDescriptor desc = parquetSchema.getColumnDescription(currentPath());
+-    // Nested types not yet supported for vectorized reads
+-    if (desc.getMaxRepetitionLevel() > 0) {
+-      return null;
+-    }
+-    Types.NestedField icebergField = icebergSchema.findField(parquetFieldId);
+-    if (icebergField == null) {
+-      return null;
+-    }
+-
+-    return new CometColumnReader(SparkSchemaUtil.convert(icebergField.type()), desc);
+-  }
+-}
+diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
+index d95baa724b..865cf5085f 100644
+--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
++++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
+@@ -83,23 +83,6 @@ public class VectorizedSparkParquetReaders {
+         expectedSchema, fileSchema, idToConstant, deleteFilter, ArrowAllocation.rootAllocator());
+   }
+ 
+-  public static CometColumnarBatchReader buildCometReader(
+-      Schema expectedSchema,
+-      MessageType fileSchema,
+-      Map<Integer, ?> idToConstant,
+-      DeleteFilter<InternalRow> deleteFilter) {
+-    return (CometColumnarBatchReader)
+-        TypeWithSchemaVisitor.visit(
+-            expectedSchema.asStruct(),
+-            fileSchema,
+-            new CometVectorizedReaderBuilder(
+-                expectedSchema,
+-                fileSchema,
+-                idToConstant,
+-                readers -> new CometColumnarBatchReader(readers, expectedSchema),
+-                deleteFilter));
+-  }
+-
+   // enables unsafe memory access to avoid costly checks to see if index is within bounds
+   // as long as it is not configured explicitly (see BoundsChecking in Arrow)
+   private static void enableUnsafeMemoryAccess() {
+diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
+index a0f45e7610..78e7845911 100644
+--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
++++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
+@@ -34,7 +34,6 @@ import org.apache.iceberg.parquet.Parquet;
+ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+ import org.apache.iceberg.spark.OrcBatchReadConf;
+ import org.apache.iceberg.spark.ParquetBatchReadConf;
+-import org.apache.iceberg.spark.ParquetReaderType;
+ import org.apache.iceberg.spark.data.vectorized.VectorizedSparkOrcReaders;
+ import org.apache.iceberg.spark.data.vectorized.VectorizedSparkParquetReaders;
+ import org.apache.iceberg.types.TypeUtil;
+@@ -94,15 +93,9 @@ abstract class BaseBatchReader<T extends ScanTask> extends BaseReader<ColumnarBa
+         .project(requiredSchema)
+         .split(start, length)
+         .createBatchedReaderFunc(
+-            fileSchema -> {
+-              if (parquetConf.readerType() == ParquetReaderType.COMET) {
+-                return VectorizedSparkParquetReaders.buildCometReader(
+-                    requiredSchema, fileSchema, idToConstant, deleteFilter);
+-              } else {
+-                return VectorizedSparkParquetReaders.buildReader(
+-                    requiredSchema, fileSchema, idToConstant, deleteFilter);
+-              }
+-            })
++            fileSchema ->
++                VectorizedSparkParquetReaders.buildReader(
++                    requiredSchema, fileSchema, idToConstant, deleteFilter))
+         .recordsPerBatch(parquetConf.batchSize())
+         .filter(residual)
+         .caseSensitive(caseSensitive())
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
+index 404ba72846..00e97e96f9 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
+@@ -90,6 +90,16 @@ public abstract class SparkDistributedDataScanTestBase
+         .master("local[2]")
+         .config("spark.serializer", serializer)
+         .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++        .config("spark.plugins", "org.apache.spark.CometPlugin")
++        .config(
++            "spark.shuffle.manager",
++            "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++        .config("spark.comet.explainFallback.enabled", "true")
++        .config("spark.comet.scan.icebergNative.enabled", "true")
++        .config("spark.memory.offHeap.enabled", "true")
++        .config("spark.memory.offHeap.size", "10g")
++        .config("spark.comet.use.lazyMaterialization", "false")
++        .config("spark.comet.schemaEvolution.enabled", "true")
+         .getOrCreate();
+   }
+ }
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
+index 659507e4c5..9076ec24d1 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
+@@ -73,6 +73,16 @@ public class TestSparkDistributedDataScanDeletes
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
+index a218f965ea..eca0125ace 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
+@@ -62,6 +62,16 @@ public class TestSparkDistributedDataScanFilterFiles
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
+index 2665d7ba8d..2381d0aa14 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
+@@ -63,6 +63,16 @@ public class TestSparkDistributedDataScanReporting
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
+index daf4e29ac0..cffe2944e0 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
+@@ -79,6 +79,17 @@ public abstract class TestBase extends SparkTestHelperBase {
+             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
+             .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .config("spark.comet.exec.broadcastExchange.enabled", "false")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetDictionaryEncodedVectorizedReads.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetDictionaryEncodedVectorizedReads.java
+index 973a17c9a3..4490c219d5 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetDictionaryEncodedVectorizedReads.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetDictionaryEncodedVectorizedReads.java
+@@ -65,6 +65,16 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
+index 1c5905744a..543edf3b2d 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
+@@ -61,6 +61,16 @@ public abstract class ScanTestBase extends AvroDataTestBase {
+     ScanTestBase.spark =
+         SparkSession.builder()
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .master("local[2]")
+             .getOrCreate();
+     ScanTestBase.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+index 19ec6d13dd..e2d0a84d01 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+@@ -144,7 +144,20 @@ public class TestCompressionSettings extends CatalogTestBase {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestCompressionSettings.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestCompressionSettings.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @BeforeEach
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+index a7702b169a..e1fdafae87 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+@@ -74,7 +74,20 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestDataSourceOptions.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestDataSourceOptions.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+index fd7d52178f..c8aab2996e 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+@@ -114,6 +114,16 @@ public class TestFilteredScan {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+index 153564f7d1..264179459d 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+@@ -98,6 +98,16 @@ public class TestForwardCompatibility {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+index f4f57157e4..7dd2ed811d 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+@@ -51,6 +51,16 @@ public class TestIcebergSpark {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+index e1402396fa..8b60b8bc48 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+@@ -118,6 +118,16 @@ public class TestPartitionPruning {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+     TestPartitionPruning.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+index 0b6ab2052b..dec4026f3b 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+@@ -112,6 +112,16 @@ public class TestPartitionValues {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+index 11865db7fc..bdb9ae32a6 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+@@ -91,6 +91,16 @@ public class TestSnapshotSelection {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+index 3051e27d72..22899c233b 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+@@ -125,6 +125,16 @@ public class TestSparkDataFile {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+     TestSparkDataFile.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+index 4ccbf86f12..2089bac577 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+@@ -100,6 +100,16 @@ public class TestSparkDataWrite {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+@@ -144,7 +154,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
+     for (ManifestFile manifest :
+         SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io())) {
+@@ -213,7 +223,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
+   }
+ 
+@@ -258,7 +268,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
+   }
+ 
+@@ -310,7 +320,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
+   }
+ 
+@@ -352,7 +362,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
+   }
+ 
+@@ -391,7 +401,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
+ 
+     List<DataFile> files = Lists.newArrayList();
+@@ -459,7 +469,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
+   }
+ 
+@@ -706,7 +716,7 @@ public class TestSparkDataWrite {
+     // Since write and commit succeeded, the rows should be readable
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual)
+         .hasSize(records.size() + records2.size())
+         .containsExactlyInAnyOrder(
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
+index 596d05d30b..e681d81704 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
+@@ -88,6 +88,16 @@ public class TestSparkReadProjection extends TestReadProjection {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+     ImmutableMap<String, String> config =
+         ImmutableMap.of(
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+index 42699f4662..74927dbd8d 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+@@ -138,6 +138,16 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
+             .config("spark.ui.liveUpdate.period", 0)
+             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
+@@ -206,7 +216,8 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
+   }
+ 
+   protected boolean countDeletes() {
+-    return true;
++    // TODO: Enable once iceberg-rust exposes delete count metrics to Comet
++    return false;
+   }
+ 
+   @Override
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+index baf7fa8f88..150cc89696 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+@@ -182,6 +182,16 @@ public class TestSparkReaderWithBloomFilter {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+index 54048bbf21..c87216824c 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+@@ -69,6 +69,16 @@ public class TestStructuredStreaming {
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
+             .config("spark.sql.shuffle.partitions", 4)
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
+index 8b1e3fbfc7..b4385c3950 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
+@@ -75,7 +75,20 @@ public class TestTimestampWithoutZone extends TestBase {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestTimestampWithoutZone.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestTimestampWithoutZone.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+index c3fac70dd3..b6c66f3f88 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+@@ -84,6 +84,16 @@ public class TestWriteMetricsConfig {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.driver.host", InetAddress.getLoopbackAddress().getHostAddress())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+     TestWriteMetricsConfig.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+index 5ce56b4fec..df1f914da3 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+@@ -63,6 +63,16 @@ public class TestAggregatePushDown extends CatalogTestBase {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.sql.iceberg.aggregate_pushdown", "true")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+index 9d2ce2b388..5e23368848 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+@@ -598,9 +598,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
+     String planAsString = sparkPlan.toString().replaceAll("#(\\d+L?)", "");
+ 
+     if (sparkFilter != null) {
+-      assertThat(planAsString)
+-          .as("Post scan filter should match")
+-          .contains("Filter (" + sparkFilter + ")");
++      assertThat(planAsString).as("Post scan filter should match").contains("CometFilter");
+     } else {
+       assertThat(planAsString).as("Should be no post scan filter").doesNotContain("Filter (");
+     }

--- a/dev/diffs/iceberg-rust/1.8.1.diff
+++ b/dev/diffs/iceberg-rust/1.8.1.diff
@@ -1,5 +1,5 @@
 diff --git a/gradle/libs.versions.toml b/gradle/libs.versions.toml
-index 04ffa8f4e..3a57af315 100644
+index 04ffa8f4ed..2d2c0d6e76 100644
 --- a/gradle/libs.versions.toml
 +++ b/gradle/libs.versions.toml
 @@ -34,6 +34,7 @@ azuresdk-bom = "1.2.31"
@@ -19,41 +19,42 @@ index 04ffa8f4e..3a57af315 100644
  sqlite-jdbc = "3.48.0.0"
  testcontainers = "1.20.4"
  tez010 = "0.10.4"
-diff --git a/spark/v3.5/build.gradle b/spark/v3.5/build.gradle
-index e2d2c7a7a..f64232dc5 100644
---- a/spark/v3.5/build.gradle
-+++ b/spark/v3.5/build.gradle
+diff --git a/spark/v3.4/build.gradle b/spark/v3.4/build.gradle
+index 6eb26e8b73..38d9cf3ca3 100644
+--- a/spark/v3.4/build.gradle
++++ b/spark/v3.4/build.gradle
 @@ -75,7 +75,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
        exclude group: 'org.roaringbitmap'
      }
-
+ 
 -    compileOnly "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:0.5.0"
 +    compileOnly "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:${libs.versions.comet.get()}"
-
+ 
      implementation libs.parquet.column
      implementation libs.parquet.hadoop
-@@ -183,7 +183,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
+@@ -185,7 +185,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
      testImplementation libs.avro.avro
      testImplementation libs.parquet.hadoop
-     testImplementation libs.awaitility
+     testImplementation libs.junit.vintage.engine
 -    testImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:0.5.0"
 +    testImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:${libs.versions.comet.get()}"
  
      // Required because we remove antlr plugin dependencies from the compile configuration, see note above
      runtimeOnly libs.antlr.runtime
-@@ -263,6 +263,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
+@@ -260,6 +260,8 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
      integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
      integrationImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
      integrationImplementation project(path: ":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
 +    integrationImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:${libs.versions.comet.get()}"
++    integrationImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:${libs.versions.comet.get()}"
  
      // runtime dependencies for running Hive Catalog based integration test
      integrationRuntimeOnly project(':iceberg-hive-metastore')
-diff --git a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
-index 578845e3d..4f44a73db 100644
---- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
-+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
-@@ -57,6 +57,16 @@ public abstract class ExtensionsTestBase extends CatalogTestBase {
+diff --git a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
+index 4f137f5b8d..4f06c036e1 100644
+--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
++++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
+@@ -60,7 +60,27 @@ public abstract class SparkExtensionsTestBase extends SparkCatalogTestBase {
              .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
              .config(
                  SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), String.valueOf(RANDOM.nextBoolean()))
@@ -68,13 +69,24 @@ index 578845e3d..4f44a73db 100644
 +            .config("spark.comet.use.lazyMaterialization", "false")
 +            .config("spark.comet.schemaEvolution.enabled", "true")
              .enableHiveSupport()
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
              .getOrCreate();
  
-diff --git a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
-index ade19de36..9111397e9 100644
---- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
-+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
-@@ -56,6 +56,16 @@ public class TestCallStatementParser {
+     SparkTestBase.catalog =
+diff --git a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+index 55a413063e..e34bfa57ed 100644
+--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
++++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+@@ -61,6 +61,16 @@ public class TestCallStatementParser {
              .master("local[2]")
              .config("spark.sql.extensions", IcebergSparkSessionExtensions.class.getName())
              .config("spark.extra.prop", "value")
@@ -91,11 +103,11 @@ index ade19de36..9111397e9 100644
              .getOrCreate();
      TestCallStatementParser.parser = spark.sessionState().sqlParser();
    }
-diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
-index 64edb1002..0fc10120f 100644
---- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
-+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
-@@ -179,6 +179,16 @@ public class DeleteOrphanFilesBenchmark {
+diff --git a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
+index b6ade2bff3..c12127d618 100644
+--- a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
++++ b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
+@@ -170,6 +170,16 @@ public class DeleteOrphanFilesBenchmark {
              .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
              .config("spark.sql.catalog.spark_catalog.type", "hadoop")
              .config("spark.sql.catalog.spark_catalog.warehouse", catalogWarehouse())
@@ -112,11 +124,11 @@ index 64edb1002..0fc10120f 100644
              .master("local");
      spark = builder.getOrCreate();
    }
-diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
-index a5d0456b0..f0759f837 100644
---- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
-+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
-@@ -392,6 +392,16 @@ public class IcebergSortCompactionBenchmark {
+diff --git a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
+index b08c352819..4ffee26156 100644
+--- a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
++++ b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
+@@ -386,6 +386,16 @@ public class IcebergSortCompactionBenchmark {
                  "spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog")
              .config("spark.sql.catalog.spark_catalog.type", "hadoop")
              .config("spark.sql.catalog.spark_catalog.warehouse", getCatalogWarehouse())
@@ -133,52 +145,10 @@ index a5d0456b0..f0759f837 100644
              .master("local[*]");
      spark = builder.getOrCreate();
      Configuration sparkHadoopConf = spark.sessionState().newHadoopConf();
-diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
-index c6794e43c..457d2823e 100644
---- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
-+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
-@@ -239,6 +239,16 @@ public class DVReaderBenchmark {
-             .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
-             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
-             .config("spark.sql.catalog.spark_catalog.warehouse", newWarehouseDir())
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .master("local[*]")
-             .getOrCreate();
-   }
-diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
-index ac74fb5a1..eab09293d 100644
---- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
-+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
-@@ -223,6 +223,16 @@ public class DVWriterBenchmark {
-             .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
-             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
-             .config("spark.sql.catalog.spark_catalog.warehouse", newWarehouseDir())
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .master("local[*]")
-             .getOrCreate();
-   }
-diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
-index 68c537e34..1e9e90d53 100644
---- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
-+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
+diff --git a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
+index 68c537e34a..1e9e90d539 100644
+--- a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
++++ b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
 @@ -94,7 +94,19 @@ public abstract class IcebergSourceBenchmark {
    }
  
@@ -200,705 +170,6 @@ index 68c537e34..1e9e90d53 100644
      if (!enableDictionaryEncoding) {
        builder
            .config("parquet.dictionary.page.size", "1")
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
-index 404ba7284..00e97e96f 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
-@@ -90,6 +90,16 @@ public abstract class SparkDistributedDataScanTestBase
-         .master("local[2]")
-         .config("spark.serializer", serializer)
-         .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
-+        .config("spark.plugins", "org.apache.spark.CometPlugin")
-+        .config(
-+            "spark.shuffle.manager",
-+            "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+        .config("spark.comet.explainFallback.enabled", "true")
-+        .config("spark.comet.scan.icebergNative.enabled", "true")
-+        .config("spark.memory.offHeap.enabled", "true")
-+        .config("spark.memory.offHeap.size", "10g")
-+        .config("spark.comet.use.lazyMaterialization", "false")
-+        .config("spark.comet.schemaEvolution.enabled", "true")
-         .getOrCreate();
-   }
- }
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
-index 659507e4c..9076ec24d 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
-@@ -73,6 +73,16 @@ public class TestSparkDistributedDataScanDeletes
-             .master("local[2]")
-             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
-index a218f965e..eca0125ac 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
-@@ -62,6 +62,16 @@ public class TestSparkDistributedDataScanFilterFiles
-             .master("local[2]")
-             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
-index 2665d7ba8..2381d0aa1 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
-@@ -63,6 +63,16 @@ public class TestSparkDistributedDataScanReporting
-             .master("local[2]")
-             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
-index de68351f6..2b5325e26 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
-@@ -77,6 +77,17 @@ public abstract class TestBase extends SparkTestHelperBase {
-             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
-             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
-             .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .config("spark.comet.exec.broadcastExchange.enabled", "false")
-             .enableHiveSupport()
-             .getOrCreate();
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
-index bc4e722bc..3bbff053f 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
-@@ -59,7 +59,20 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
- 
-   @BeforeAll
-   public static void startSpark() {
--    spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterAll
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
-index 3a269740b..42ecd7ac7 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
-@@ -54,7 +54,20 @@ public abstract class ScanTestBase extends AvroDataTest {
- 
-   @BeforeAll
-   public static void startSpark() {
--    ScanTestBase.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    ScanTestBase.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-     ScanTestBase.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
-index f411920a5..afb7830aa 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
-@@ -144,7 +144,20 @@ public class TestCompressionSettings extends CatalogTestBase {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestCompressionSettings.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestCompressionSettings.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @BeforeEach
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
-index c4ba96e63..98398968b 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
-@@ -75,7 +75,20 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestDataSourceOptions.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestDataSourceOptions.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterAll
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
-index 348173596..9017b4a37 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
-@@ -110,7 +110,20 @@ public class TestFilteredScan {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestFilteredScan.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestFilteredScan.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterAll
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
-index 84c99a575..1d60b01df 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
-@@ -93,7 +93,20 @@ public class TestForwardCompatibility {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestForwardCompatibility.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestForwardCompatibility.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterAll
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
-index 7eff93d20..7aab7f968 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
-@@ -46,7 +46,20 @@ public class TestIcebergSpark {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestIcebergSpark.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestIcebergSpark.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterAll
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
-index 9464f687b..ca4e3e035 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
-@@ -112,7 +112,20 @@ public class TestPartitionPruning {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestPartitionPruning.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestPartitionPruning.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-     TestPartitionPruning.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
- 
-     String optionKey = String.format("fs.%s.impl", CountOpenLocalFileSystem.scheme);
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
-index 5c218f21c..1d2222821 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
-@@ -107,7 +107,20 @@ public class TestPartitionValues {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestPartitionValues.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestPartitionValues.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterAll
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
-index a7334a580..ecd25670f 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
-@@ -87,7 +87,20 @@ public class TestSnapshotSelection {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestSnapshotSelection.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestSnapshotSelection.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterAll
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
-index 182b1ef8f..205892e4a 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
-@@ -120,7 +120,20 @@ public class TestSparkDataFile {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestSparkDataFile.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestSparkDataFile.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-     TestSparkDataFile.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
-index fb2b312be..3fca3330d 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
-@@ -96,7 +96,20 @@ public class TestSparkDataWrite {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestSparkDataWrite.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestSparkDataWrite.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterEach
-@@ -140,7 +153,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-     assertThat(actual).as("Result rows should match").isEqualTo(expected);
-     for (ManifestFile manifest :
-@@ -210,7 +223,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-     assertThat(actual).as("Result rows should match").isEqualTo(expected);
-   }
-@@ -256,7 +269,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-     assertThat(actual).as("Result rows should match").isEqualTo(expected);
-   }
-@@ -309,7 +322,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-     assertThat(actual).as("Result rows should match").isEqualTo(expected);
-   }
-@@ -352,7 +365,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-     assertThat(actual).as("Result rows should match").isEqualTo(expected);
-   }
-@@ -392,7 +405,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-     assertThat(actual).as("Result rows should match").isEqualTo(expected);
- 
-@@ -458,7 +471,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-     assertThat(actual).as("Result rows should match").isEqualTo(expected);
-   }
-@@ -622,7 +635,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-     assertThat(actual).as("Result rows should match").isEqualTo(expected);
- 
-@@ -708,7 +721,7 @@ public class TestSparkDataWrite {
-     // Since write and commit succeeded, the rows should be readable
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).as("Number of rows should match").hasSize(records.size() + records2.size());
-     assertThat(actual)
-         .describedAs("Result rows should match")
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
-index becf6a064..21701450a 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
-@@ -83,7 +83,20 @@ public class TestSparkReadProjection extends TestReadProjection {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestSparkReadProjection.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestSparkReadProjection.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-     ImmutableMap<String, String> config =
-         ImmutableMap.of(
-             "type", "hive",
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
-index 4f1cef5d3..f0f427732 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
-@@ -136,6 +136,16 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
-             .config("spark.ui.liveUpdate.period", 0)
-             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
-             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .enableHiveSupport()
-             .getOrCreate();
- 
-@@ -204,7 +214,8 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
-   }
- 
-   protected boolean countDeletes() {
--    return true;
-+    // TODO: Enable once iceberg-rust exposes delete count metrics to Comet
-+    return false;
-   }
- 
-   @Override
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
-index baf7fa8f8..150cc8969 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
-@@ -182,6 +182,16 @@ public class TestSparkReaderWithBloomFilter {
-         SparkSession.builder()
-             .master("local[2]")
-             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .enableHiveSupport()
-             .getOrCreate();
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
-index 17db46b85..d7e91b4ee 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
-@@ -65,6 +65,16 @@ public class TestStructuredStreaming {
-         SparkSession.builder()
-             .master("local[2]")
-             .config("spark.sql.shuffle.partitions", 4)
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
-index 306444b9f..b661aa8ce 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
-@@ -75,7 +75,20 @@ public class TestTimestampWithoutZone extends TestBase {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestTimestampWithoutZone.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestTimestampWithoutZone.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterAll
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
-index 841268a6b..2fcc92bcb 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
-@@ -80,7 +80,20 @@ public class TestWriteMetricsConfig {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestWriteMetricsConfig.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestWriteMetricsConfig.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-     TestWriteMetricsConfig.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
-index 6e0925270..e0d743180 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
-@@ -60,6 +60,16 @@ public class TestAggregatePushDown extends CatalogTestBase {
-         SparkSession.builder()
-             .master("local[2]")
-             .config("spark.sql.iceberg.aggregate_pushdown", "true")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .enableHiveSupport()
-             .getOrCreate();
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
-index 9d2ce2b38..5e2336884 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
-@@ -598,9 +598,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
-     String planAsString = sparkPlan.toString().replaceAll("#(\\d+L?)", "");
- 
-     if (sparkFilter != null) {
--      assertThat(planAsString)
--          .as("Post scan filter should match")
--          .contains("Filter (" + sparkFilter + ")");
-+      assertThat(planAsString).as("Post scan filter should match").contains("CometFilter");
-     } else {
-       assertThat(planAsString).as("Should be no post scan filter").doesNotContain("Filter (");
-     }
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
-index 6719c45ca..251545440 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
-@@ -616,7 +616,7 @@ public class TestStoragePartitionedJoins extends TestBaseWithCatalog {
-             + "FROM %s t1 "
-             + "INNER JOIN %s t2 "
-             + "ON t1.id = t2.id AND t1.%s = t2.%s "
--            + "ORDER BY t1.id, t1.%s",
-+            + "ORDER BY t1.id, t1.%s, t1.salary",
-         sourceColumnName,
-         tableName,
-         tableName(OTHER_TABLE_NAME),
 diff --git a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java
 deleted file mode 100644
 index 4794863ab1..0000000000
@@ -1638,10 +909,10 @@ index d36f1a7274..0000000000
 -  }
 -}
 diff --git a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
-index b523bc5bff..4aa274a0c7 100644
+index b523bc5bff..636ad3be7d 100644
 --- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
 +++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
-@@ -70,22 +70,6 @@ public class VectorizedSparkParquetReaders {
+@@ -70,23 +70,6 @@ public class VectorizedSparkParquetReaders {
                  deleteFilter));
    }
  
@@ -1661,9 +932,10 @@ index b523bc5bff..4aa274a0c7 100644
 -                readers -> new CometColumnarBatchReader(readers, expectedSchema),
 -                deleteFilter));
 -  }
- 
+-
    // enables unsafe memory access to avoid costly checks to see if index is within bounds
    // as long as it is not configured explicitly (see BoundsChecking in Arrow)
+   private static void enableUnsafeMemoryAccess() {
 diff --git a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
 index 780e1750a5..25f253eede 100644
 --- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
@@ -1695,6 +967,780 @@ index 780e1750a5..25f253eede 100644
          .recordsPerBatch(parquetConf.batchSize())
          .filter(residual)
          .caseSensitive(caseSensitive())
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
+index 404ba72846..00e97e96f9 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
+@@ -90,6 +90,16 @@ public abstract class SparkDistributedDataScanTestBase
+         .master("local[2]")
+         .config("spark.serializer", serializer)
+         .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++        .config("spark.plugins", "org.apache.spark.CometPlugin")
++        .config(
++            "spark.shuffle.manager",
++            "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++        .config("spark.comet.explainFallback.enabled", "true")
++        .config("spark.comet.scan.icebergNative.enabled", "true")
++        .config("spark.memory.offHeap.enabled", "true")
++        .config("spark.memory.offHeap.size", "10g")
++        .config("spark.comet.use.lazyMaterialization", "false")
++        .config("spark.comet.schemaEvolution.enabled", "true")
+         .getOrCreate();
+   }
+ }
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
+index 9361c63176..9a78bbf3b6 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
+@@ -69,6 +69,16 @@ public class TestSparkDistributedDataScanDeletes
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
+index a218f965ea..eca0125ace 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
+@@ -62,6 +62,16 @@ public class TestSparkDistributedDataScanFilterFiles
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
+index acd4688440..9be94eab2f 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
+@@ -59,6 +59,16 @@ public class TestSparkDistributedDataScanReporting
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
+index 3a269740b7..42ecd7ac7b 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
+@@ -54,7 +54,20 @@ public abstract class ScanTestBase extends AvroDataTest {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    ScanTestBase.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    ScanTestBase.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     ScanTestBase.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+index 724c6edde2..40b17106b0 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+@@ -103,7 +103,20 @@ public class TestCompressionSettings extends SparkCatalogTestBase {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestCompressionSettings.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestCompressionSettings.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @Parameterized.AfterParam
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+index 013b8d4386..613f35417e 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+@@ -76,7 +76,20 @@ public class TestDataSourceOptions extends SparkTestBaseWithCatalog {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestDataSourceOptions.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestDataSourceOptions.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterClass
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+index ba13d005bd..73d76e2d3e 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+@@ -118,7 +118,20 @@ public class TestFilteredScan {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestFilteredScan.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestFilteredScan.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+ 
+     // define UDFs used by partition tests
+     Function<Object, Integer> bucket4 = Transforms.bucket(4).bind(Types.LongType.get());
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+index 9f97753094..a69cf4f33d 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+@@ -94,7 +94,20 @@ public class TestForwardCompatibility {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestForwardCompatibility.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestForwardCompatibility.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterClass
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+index 0154506f86..79138afc26 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+@@ -46,7 +46,20 @@ public class TestIcebergSpark {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestIcebergSpark.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestIcebergSpark.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterClass
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+index 639d37c793..c4570510a6 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+@@ -111,7 +111,20 @@ public class TestPartitionPruning {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestPartitionPruning.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestPartitionPruning.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     TestPartitionPruning.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+ 
+     String optionKey = String.format("fs.%s.impl", CountOpenLocalFileSystem.scheme);
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+index ad0984ef42..cb143ac2fc 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+@@ -104,7 +104,20 @@ public class TestPartitionValues {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestPartitionValues.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestPartitionValues.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterClass
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+index 9fc576dde5..2765862300 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+@@ -83,7 +83,20 @@ public class TestSnapshotSelection {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestSnapshotSelection.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSnapshotSelection.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterClass
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+index 16fde3c954..9c01167064 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+@@ -121,7 +121,20 @@ public class TestSparkDataFile {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestSparkDataFile.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSparkDataFile.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     TestSparkDataFile.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+index 63c18277aa..c8c5c49009 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+@@ -89,7 +89,20 @@ public class TestSparkDataWrite {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestSparkDataWrite.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSparkDataWrite.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @Parameterized.AfterParam
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
+index 3a4b235c46..2de0760813 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
+@@ -86,7 +86,20 @@ public class TestSparkReadProjection extends TestReadProjection {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestSparkReadProjection.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSparkReadProjection.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     ImmutableMap<String, String> config =
+         ImmutableMap.of(
+             "type", "hive",
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+index dda49b4946..529992de6b 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+@@ -131,7 +131,27 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
+             .config("spark.ui.liveUpdate.period", 0)
+             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+ 
+     catalog =
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+index e5831b76e4..5c45a111d9 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+@@ -176,7 +176,27 @@ public class TestSparkReaderWithBloomFilter {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+ 
+     catalog =
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+index f420f1b955..d64dbfa61a 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+@@ -66,6 +66,16 @@ public class TestStructuredStreaming {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.sql.shuffle.partitions", 4)
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
+index ac674e2e62..4460d597b3 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
+@@ -73,7 +73,20 @@ public class TestTimestampWithoutZone extends SparkTestBase {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestTimestampWithoutZone.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestTimestampWithoutZone.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterClass
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+index 73827b309b..aa5e28e34d 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+@@ -80,7 +80,20 @@ public class TestWriteMetricsConfig {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestWriteMetricsConfig.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestWriteMetricsConfig.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     TestWriteMetricsConfig.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+index 1a4e2f3e1c..641cb855e9 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+@@ -65,7 +65,27 @@ public class TestAggregatePushDown extends SparkCatalogTestBase {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.sql.iceberg.aggregate_pushdown", "true")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+ 
+     SparkTestBase.catalog =
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+index f92055ab7a..95fde91f19 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+@@ -585,9 +585,7 @@ public class TestFilterPushDown extends SparkTestBaseWithCatalog {
+     String planAsString = sparkPlan.toString().replaceAll("#(\\d+L?)", "");
+ 
+     if (sparkFilter != null) {
+-      assertThat(planAsString)
+-          .as("Post scan filter should match")
+-          .contains("Filter (" + sparkFilter + ")");
++      assertThat(planAsString).as("Post scan filter should match").contains("CometFilter");
+     } else {
+       assertThat(planAsString).as("Should be no post scan filter").doesNotContain("Filter (");
+     }
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
+index 8a1ec5060f..3611521cc4 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
+@@ -605,7 +605,7 @@ public class TestStoragePartitionedJoins extends SparkTestBaseWithCatalog {
+             + "FROM %s t1 "
+             + "INNER JOIN %s t2 "
+             + "ON t1.id = t2.id AND t1.%s = t2.%s "
+-            + "ORDER BY t1.id, t1.%s",
++            + "ORDER BY t1.id, t1.%s, t1.salary",
+         sourceColumnName,
+         tableName,
+         tableName(OTHER_TABLE_NAME),
+diff --git a/spark/v3.5/build.gradle b/spark/v3.5/build.gradle
+index e2d2c7a7ac..95cd3c08b5 100644
+--- a/spark/v3.5/build.gradle
++++ b/spark/v3.5/build.gradle
+@@ -75,7 +75,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
+       exclude group: 'org.roaringbitmap'
+     }
+ 
+-    compileOnly "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:0.5.0"
++    compileOnly "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:${libs.versions.comet.get()}"
+ 
+     implementation libs.parquet.column
+     implementation libs.parquet.hadoop
+@@ -183,7 +183,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
+     testImplementation libs.avro.avro
+     testImplementation libs.parquet.hadoop
+     testImplementation libs.awaitility
+-    testImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:0.5.0"
++    testImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:${libs.versions.comet.get()}"
+ 
+     // Required because we remove antlr plugin dependencies from the compile configuration, see note above
+     runtimeOnly libs.antlr.runtime
+@@ -263,6 +263,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
+     integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+     integrationImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
+     integrationImplementation project(path: ":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
++    integrationImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:${libs.versions.comet.get()}"
+ 
+     // runtime dependencies for running Hive Catalog based integration test
+     integrationRuntimeOnly project(':iceberg-hive-metastore')
+diff --git a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
+index 578845e3da..4f44a73db3 100644
+--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
++++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
+@@ -57,6 +57,16 @@ public abstract class ExtensionsTestBase extends CatalogTestBase {
+             .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
+             .config(
+                 SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), String.valueOf(RANDOM.nextBoolean()))
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
+diff --git a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+index ade19de36f..9111397e9c 100644
+--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
++++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+@@ -56,6 +56,16 @@ public class TestCallStatementParser {
+             .master("local[2]")
+             .config("spark.sql.extensions", IcebergSparkSessionExtensions.class.getName())
+             .config("spark.extra.prop", "value")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+     TestCallStatementParser.parser = spark.sessionState().sqlParser();
+   }
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
+index 64edb1002e..0fc10120ff 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
+@@ -179,6 +179,16 @@ public class DeleteOrphanFilesBenchmark {
+             .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
+             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+             .config("spark.sql.catalog.spark_catalog.warehouse", catalogWarehouse())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .master("local");
+     spark = builder.getOrCreate();
+   }
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
+index a5d0456b0b..f0759f8378 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
+@@ -392,6 +392,16 @@ public class IcebergSortCompactionBenchmark {
+                 "spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog")
+             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+             .config("spark.sql.catalog.spark_catalog.warehouse", getCatalogWarehouse())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .master("local[*]");
+     spark = builder.getOrCreate();
+     Configuration sparkHadoopConf = spark.sessionState().newHadoopConf();
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
+index c6794e43c6..457d2823ee 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
+@@ -239,6 +239,16 @@ public class DVReaderBenchmark {
+             .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
+             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+             .config("spark.sql.catalog.spark_catalog.warehouse", newWarehouseDir())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .master("local[*]")
+             .getOrCreate();
+   }
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
+index ac74fb5a10..eab09293de 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
+@@ -223,6 +223,16 @@ public class DVWriterBenchmark {
+             .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
+             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+             .config("spark.sql.catalog.spark_catalog.warehouse", newWarehouseDir())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .master("local[*]")
+             .getOrCreate();
+   }
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
+index 68c537e34a..1e9e90d539 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
+@@ -94,7 +94,19 @@ public abstract class IcebergSourceBenchmark {
+   }
+ 
+   protected void setupSpark(boolean enableDictionaryEncoding) {
+-    SparkSession.Builder builder = SparkSession.builder().config("spark.ui.enabled", false);
++    SparkSession.Builder builder =
++        SparkSession.builder()
++            .config("spark.ui.enabled", false)
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true");
+     if (!enableDictionaryEncoding) {
+       builder
+           .config("parquet.dictionary.page.size", "1")
 diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java
 deleted file mode 100644
 index 4794863ab1..0000000000
@@ -2434,9 +2480,10 @@ index d36f1a7274..0000000000
 -  }
 -}
 diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
+index b523bc5bff..636ad3be7d 100644
 --- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
 +++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
-@@ -70,22 +70,6 @@
+@@ -70,23 +70,6 @@ public class VectorizedSparkParquetReaders {
                  deleteFilter));
    }
  
@@ -2456,13 +2503,15 @@ diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vector
 -                readers -> new CometColumnarBatchReader(readers, expectedSchema),
 -                deleteFilter));
 -  }
- 
+-
    // enables unsafe memory access to avoid costly checks to see if index is within bounds
    // as long as it is not configured explicitly (see BoundsChecking in Arrow)
+   private static void enableUnsafeMemoryAccess() {
 diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
+index 780e1750a5..25f253eede 100644
 --- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
 +++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
-@@ -34,7 +34,6 @@
+@@ -34,7 +34,6 @@ import org.apache.iceberg.parquet.Parquet;
  import org.apache.iceberg.relocated.com.google.common.collect.Sets;
  import org.apache.iceberg.spark.OrcBatchReadConf;
  import org.apache.iceberg.spark.ParquetBatchReadConf;
@@ -2470,7 +2519,7 @@ diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/Base
  import org.apache.iceberg.spark.data.vectorized.VectorizedSparkOrcReaders;
  import org.apache.iceberg.spark.data.vectorized.VectorizedSparkParquetReaders;
  import org.apache.iceberg.types.TypeUtil;
-@@ -92,15 +91,9 @@
+@@ -92,15 +91,9 @@ abstract class BaseBatchReader<T extends ScanTask> extends BaseReader<ColumnarBa
          .project(requiredSchema)
          .split(start, length)
          .createBatchedReaderFunc(
@@ -2489,3 +2538,702 @@ diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/Base
          .recordsPerBatch(parquetConf.batchSize())
          .filter(residual)
          .caseSensitive(caseSensitive())
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
+index 404ba72846..00e97e96f9 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
+@@ -90,6 +90,16 @@ public abstract class SparkDistributedDataScanTestBase
+         .master("local[2]")
+         .config("spark.serializer", serializer)
+         .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++        .config("spark.plugins", "org.apache.spark.CometPlugin")
++        .config(
++            "spark.shuffle.manager",
++            "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++        .config("spark.comet.explainFallback.enabled", "true")
++        .config("spark.comet.scan.icebergNative.enabled", "true")
++        .config("spark.memory.offHeap.enabled", "true")
++        .config("spark.memory.offHeap.size", "10g")
++        .config("spark.comet.use.lazyMaterialization", "false")
++        .config("spark.comet.schemaEvolution.enabled", "true")
+         .getOrCreate();
+   }
+ }
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
+index 659507e4c5..9076ec24d1 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
+@@ -73,6 +73,16 @@ public class TestSparkDistributedDataScanDeletes
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
+index a218f965ea..eca0125ace 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
+@@ -62,6 +62,16 @@ public class TestSparkDistributedDataScanFilterFiles
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
+index 2665d7ba8d..2381d0aa14 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
+@@ -63,6 +63,16 @@ public class TestSparkDistributedDataScanReporting
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
+index de68351f6e..2b5325e266 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
+@@ -77,6 +77,17 @@ public abstract class TestBase extends SparkTestHelperBase {
+             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
+             .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .config("spark.comet.exec.broadcastExchange.enabled", "false")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+index bc4e722bc8..3bbff053fd 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+@@ -59,7 +59,20 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    spark = SparkSession.builder().master("local[2]").getOrCreate();
++    spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
+index 3a269740b7..42ecd7ac7b 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
+@@ -54,7 +54,20 @@ public abstract class ScanTestBase extends AvroDataTest {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    ScanTestBase.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    ScanTestBase.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     ScanTestBase.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+index f411920a5d..afb7830aaa 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+@@ -144,7 +144,20 @@ public class TestCompressionSettings extends CatalogTestBase {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestCompressionSettings.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestCompressionSettings.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @BeforeEach
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+index c4ba96e634..98398968b0 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+@@ -75,7 +75,20 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestDataSourceOptions.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestDataSourceOptions.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+index 348173596e..9017b4a37a 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+@@ -110,7 +110,20 @@ public class TestFilteredScan {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestFilteredScan.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestFilteredScan.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+index 84c99a575c..1d60b01df5 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+@@ -93,7 +93,20 @@ public class TestForwardCompatibility {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestForwardCompatibility.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestForwardCompatibility.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+index 7eff93d204..7aab7f9682 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+@@ -46,7 +46,20 @@ public class TestIcebergSpark {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestIcebergSpark.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestIcebergSpark.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+index 9464f687b0..ca4e3e0353 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+@@ -112,7 +112,20 @@ public class TestPartitionPruning {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestPartitionPruning.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestPartitionPruning.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     TestPartitionPruning.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+ 
+     String optionKey = String.format("fs.%s.impl", CountOpenLocalFileSystem.scheme);
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+index 5c218f21c4..1d22228217 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+@@ -107,7 +107,20 @@ public class TestPartitionValues {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestPartitionValues.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestPartitionValues.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+index a7334a580c..ecd25670fe 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+@@ -87,7 +87,20 @@ public class TestSnapshotSelection {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestSnapshotSelection.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSnapshotSelection.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+index 182b1ef8f5..205892e4a6 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+@@ -120,7 +120,20 @@ public class TestSparkDataFile {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestSparkDataFile.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSparkDataFile.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     TestSparkDataFile.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+index fb2b312bed..3fca3330d0 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+@@ -96,7 +96,20 @@ public class TestSparkDataWrite {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestSparkDataWrite.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSparkDataWrite.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterEach
+@@ -140,7 +153,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
+     assertThat(actual).as("Result rows should match").isEqualTo(expected);
+     for (ManifestFile manifest :
+@@ -210,7 +223,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
+     assertThat(actual).as("Result rows should match").isEqualTo(expected);
+   }
+@@ -256,7 +269,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
+     assertThat(actual).as("Result rows should match").isEqualTo(expected);
+   }
+@@ -309,7 +322,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
+     assertThat(actual).as("Result rows should match").isEqualTo(expected);
+   }
+@@ -352,7 +365,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
+     assertThat(actual).as("Result rows should match").isEqualTo(expected);
+   }
+@@ -392,7 +405,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
+     assertThat(actual).as("Result rows should match").isEqualTo(expected);
+ 
+@@ -458,7 +471,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
+     assertThat(actual).as("Result rows should match").isEqualTo(expected);
+   }
+@@ -622,7 +635,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
+     assertThat(actual).as("Result rows should match").isEqualTo(expected);
+ 
+@@ -708,7 +721,7 @@ public class TestSparkDataWrite {
+     // Since write and commit succeeded, the rows should be readable
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).as("Number of rows should match").hasSize(records.size() + records2.size());
+     assertThat(actual)
+         .describedAs("Result rows should match")
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
+index becf6a064d..21701450a8 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
+@@ -83,7 +83,20 @@ public class TestSparkReadProjection extends TestReadProjection {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestSparkReadProjection.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSparkReadProjection.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     ImmutableMap<String, String> config =
+         ImmutableMap.of(
+             "type", "hive",
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+index 4f1cef5d37..f0f4277324 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+@@ -136,6 +136,16 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
+             .config("spark.ui.liveUpdate.period", 0)
+             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
+@@ -204,7 +214,8 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
+   }
+ 
+   protected boolean countDeletes() {
+-    return true;
++    // TODO: Enable once iceberg-rust exposes delete count metrics to Comet
++    return false;
+   }
+ 
+   @Override
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+index baf7fa8f88..150cc89696 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+@@ -182,6 +182,16 @@ public class TestSparkReaderWithBloomFilter {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+index 17db46b85c..d7e91b4eef 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+@@ -65,6 +65,16 @@ public class TestStructuredStreaming {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.sql.shuffle.partitions", 4)
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
+index 306444b9f2..b661aa8ced 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
+@@ -75,7 +75,20 @@ public class TestTimestampWithoutZone extends TestBase {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestTimestampWithoutZone.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestTimestampWithoutZone.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+index 841268a6be..2fcc92bcb6 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+@@ -80,7 +80,20 @@ public class TestWriteMetricsConfig {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestWriteMetricsConfig.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestWriteMetricsConfig.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     TestWriteMetricsConfig.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+index 6e09252704..e0d7431808 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+@@ -60,6 +60,16 @@ public class TestAggregatePushDown extends CatalogTestBase {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.sql.iceberg.aggregate_pushdown", "true")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+index 9d2ce2b388..5e23368848 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+@@ -598,9 +598,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
+     String planAsString = sparkPlan.toString().replaceAll("#(\\d+L?)", "");
+ 
+     if (sparkFilter != null) {
+-      assertThat(planAsString)
+-          .as("Post scan filter should match")
+-          .contains("Filter (" + sparkFilter + ")");
++      assertThat(planAsString).as("Post scan filter should match").contains("CometFilter");
+     } else {
+       assertThat(planAsString).as("Should be no post scan filter").doesNotContain("Filter (");
+     }
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
+index 6719c45ca9..2515454401 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
+@@ -616,7 +616,7 @@ public class TestStoragePartitionedJoins extends TestBaseWithCatalog {
+             + "FROM %s t1 "
+             + "INNER JOIN %s t2 "
+             + "ON t1.id = t2.id AND t1.%s = t2.%s "
+-            + "ORDER BY t1.id, t1.%s",
++            + "ORDER BY t1.id, t1.%s, t1.salary",
+         sourceColumnName,
+         tableName,
+         tableName(OTHER_TABLE_NAME),

--- a/dev/diffs/iceberg-rust/1.8.1.diff
+++ b/dev/diffs/iceberg-rust/1.8.1.diff
@@ -1051,6 +1051,27 @@ index acd4688440..9be94eab2f 100644
              .getOrCreate();
    }
  
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+index 3e8953fb95..cac4f75e95 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+@@ -77,6 +77,16 @@ public abstract class SparkTestBase extends SparkTestHelperBase {
+             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
+             .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
 diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
 index 3a269740b7..42ecd7ac7b 100644
 --- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java

--- a/dev/diffs/iceberg-rust/1.8.1.diff
+++ b/dev/diffs/iceberg-rust/1.8.1.diff
@@ -1312,7 +1312,7 @@ index 16fde3c954..9c01167064 100644
    }
  
 diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
-index 63c18277aa..c8c5c49009 100644
+index 63c18277aa..d214d7c23c 100644
 --- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
 +++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
 @@ -89,7 +89,20 @@ public class TestSparkDataWrite {
@@ -1337,6 +1337,87 @@ index 63c18277aa..c8c5c49009 100644
    }
  
    @Parameterized.AfterParam
+@@ -138,7 +151,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+     Assert.assertEquals("Result rows should match", expected, actual);
+     for (ManifestFile manifest :
+@@ -208,7 +221,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+     Assert.assertEquals("Result rows should match", expected, actual);
+   }
+@@ -254,7 +267,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+     Assert.assertEquals("Result rows should match", expected, actual);
+   }
+@@ -307,7 +320,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+     Assert.assertEquals("Result rows should match", expected, actual);
+   }
+@@ -350,7 +363,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+     Assert.assertEquals("Result rows should match", expected, actual);
+   }
+@@ -390,7 +403,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+     Assert.assertEquals("Result rows should match", expected, actual);
+ 
+@@ -455,7 +468,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+     Assert.assertEquals("Result rows should match", expected, actual);
+   }
+@@ -619,7 +632,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+     Assert.assertEquals("Result rows should match", expected, actual);
+ 
+@@ -705,7 +718,7 @@ public class TestSparkDataWrite {
+     // Since write and commit succeeded, the rows should be readable
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     Assert.assertEquals(
+         "Number of rows should match", records.size() + records2.size(), actual.size());
+     assertThat(actual)
 diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
 index 3a4b235c46..2de0760813 100644
 --- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java

--- a/dev/diffs/iceberg-rust/1.9.1.diff
+++ b/dev/diffs/iceberg-rust/1.9.1.diff
@@ -1286,7 +1286,7 @@ index 16fde3c954..9c01167064 100644
    }
  
 diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
-index 63c18277aa..c8c5c49009 100644
+index 63c18277aa..d214d7c23c 100644
 --- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
 +++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
 @@ -89,7 +89,20 @@ public class TestSparkDataWrite {
@@ -1311,6 +1311,87 @@ index 63c18277aa..c8c5c49009 100644
    }
  
    @Parameterized.AfterParam
+@@ -138,7 +151,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+     Assert.assertEquals("Result rows should match", expected, actual);
+     for (ManifestFile manifest :
+@@ -208,7 +221,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+     Assert.assertEquals("Result rows should match", expected, actual);
+   }
+@@ -254,7 +267,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+     Assert.assertEquals("Result rows should match", expected, actual);
+   }
+@@ -307,7 +320,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+     Assert.assertEquals("Result rows should match", expected, actual);
+   }
+@@ -350,7 +363,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+     Assert.assertEquals("Result rows should match", expected, actual);
+   }
+@@ -390,7 +403,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+     Assert.assertEquals("Result rows should match", expected, actual);
+ 
+@@ -455,7 +468,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+     Assert.assertEquals("Result rows should match", expected, actual);
+   }
+@@ -619,7 +632,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+     Assert.assertEquals("Result rows should match", expected, actual);
+ 
+@@ -705,7 +718,7 @@ public class TestSparkDataWrite {
+     // Since write and commit succeeded, the rows should be readable
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     Assert.assertEquals(
+         "Number of rows should match", records.size() + records2.size(), actual.size());
+     assertThat(actual)
 diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
 index 584a6b1c70..6b38a1195a 100644
 --- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java

--- a/dev/diffs/iceberg-rust/1.9.1.diff
+++ b/dev/diffs/iceberg-rust/1.9.1.diff
@@ -1025,6 +1025,27 @@ index acd4688440..9be94eab2f 100644
              .getOrCreate();
    }
  
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+index 3e8953fb95..cac4f75e95 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+@@ -77,6 +77,16 @@ public abstract class SparkTestBase extends SparkTestHelperBase {
+             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
+             .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
 diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
 index 06d5e0c44f..b4f6d3907a 100644
 --- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java

--- a/dev/diffs/iceberg-rust/1.9.1.diff
+++ b/dev/diffs/iceberg-rust/1.9.1.diff
@@ -1,5 +1,5 @@
 diff --git a/gradle/libs.versions.toml b/gradle/libs.versions.toml
-index c50991c5f..3acb395a6 100644
+index c50991c5fc..c3bd841c95 100644
 --- a/gradle/libs.versions.toml
 +++ b/gradle/libs.versions.toml
 @@ -36,6 +36,7 @@ awssdk-s3accessgrants = "2.3.0"
@@ -10,29 +10,29 @@ index c50991c5f..3acb395a6 100644
  datasketches = "6.2.0"
  delta-standalone = "3.3.1"
  delta-spark = "3.3.1"
-diff --git a/spark/v3.5/build.gradle b/spark/v3.5/build.gradle
-index 572c32f92..d155f634a 100644
---- a/spark/v3.5/build.gradle
-+++ b/spark/v3.5/build.gradle
+diff --git a/spark/v3.4/build.gradle b/spark/v3.4/build.gradle
+index 2cd8666892..4077116abb 100644
+--- a/spark/v3.4/build.gradle
++++ b/spark/v3.4/build.gradle
 @@ -75,7 +75,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
        exclude group: 'org.roaringbitmap'
      }
-
+ 
 -    compileOnly "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:0.5.0"
 +    compileOnly "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:${libs.versions.comet.get()}"
-
+ 
      implementation libs.parquet.column
      implementation libs.parquet.hadoop
-@@ -184,7 +184,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
-     testImplementation libs.avro.avro
+@@ -186,7 +186,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
      testImplementation libs.parquet.hadoop
      testImplementation libs.awaitility
+     testImplementation libs.junit.vintage.engine
 -    testImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:0.5.0"
 +    testImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:${libs.versions.comet.get()}"
  
      // Required because we remove antlr plugin dependencies from the compile configuration, see note above
      runtimeOnly libs.antlr.runtime
-@@ -265,6 +265,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
+@@ -267,6 +267,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
      integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
      integrationImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
      integrationImplementation project(path: ":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
@@ -40,11 +40,11 @@ index 572c32f92..d155f634a 100644
  
      // runtime dependencies for running Hive Catalog based integration test
      integrationRuntimeOnly project(':iceberg-hive-metastore')
-diff --git a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
-index 578845e3d..4f44a73db 100644
---- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
-+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
-@@ -57,6 +57,16 @@ public abstract class ExtensionsTestBase extends CatalogTestBase {
+diff --git a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
+index 578845e3da..fd93d91bc3 100644
+--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
++++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
+@@ -57,7 +57,27 @@ public abstract class ExtensionsTestBase extends CatalogTestBase {
              .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
              .config(
                  SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), String.valueOf(RANDOM.nextBoolean()))
@@ -59,12 +59,23 @@ index 578845e3d..4f44a73db 100644
 +            .config("spark.comet.use.lazyMaterialization", "false")
 +            .config("spark.comet.schemaEvolution.enabled", "true")
              .enableHiveSupport()
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
              .getOrCreate();
  
-diff --git a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
-index ecf9e6f8a..3475260ca 100644
---- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
-+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+     TestBase.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+diff --git a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+index 58d054bd05..4ead587cc1 100644
+--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
++++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
 @@ -56,6 +56,16 @@ public class TestCallStatementParser {
              .master("local[2]")
              .config("spark.sql.extensions", IcebergSparkSessionExtensions.class.getName())
@@ -82,11 +93,11 @@ index ecf9e6f8a..3475260ca 100644
              .getOrCreate();
      TestCallStatementParser.parser = spark.sessionState().sqlParser();
    }
-diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
-index 64edb1002..0fc10120f 100644
---- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
-+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
-@@ -179,6 +179,16 @@ public class DeleteOrphanFilesBenchmark {
+diff --git a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
+index b6ade2bff3..c12127d618 100644
+--- a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
++++ b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
+@@ -170,6 +170,16 @@ public class DeleteOrphanFilesBenchmark {
              .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
              .config("spark.sql.catalog.spark_catalog.type", "hadoop")
              .config("spark.sql.catalog.spark_catalog.warehouse", catalogWarehouse())
@@ -103,11 +114,11 @@ index 64edb1002..0fc10120f 100644
              .master("local");
      spark = builder.getOrCreate();
    }
-diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
-index a5d0456b0..f0759f837 100644
---- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
-+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
-@@ -392,6 +392,16 @@ public class IcebergSortCompactionBenchmark {
+diff --git a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
+index b08c352819..4ffee26156 100644
+--- a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
++++ b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
+@@ -386,6 +386,16 @@ public class IcebergSortCompactionBenchmark {
                  "spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog")
              .config("spark.sql.catalog.spark_catalog.type", "hadoop")
              .config("spark.sql.catalog.spark_catalog.warehouse", getCatalogWarehouse())
@@ -124,52 +135,10 @@ index a5d0456b0..f0759f837 100644
              .master("local[*]");
      spark = builder.getOrCreate();
      Configuration sparkHadoopConf = spark.sessionState().newHadoopConf();
-diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
-index c6794e43c..457d2823e 100644
---- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
-+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
-@@ -239,6 +239,16 @@ public class DVReaderBenchmark {
-             .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
-             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
-             .config("spark.sql.catalog.spark_catalog.warehouse", newWarehouseDir())
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .master("local[*]")
-             .getOrCreate();
-   }
-diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
-index ac74fb5a1..eab09293d 100644
---- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
-+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
-@@ -223,6 +223,16 @@ public class DVWriterBenchmark {
-             .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
-             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
-             .config("spark.sql.catalog.spark_catalog.warehouse", newWarehouseDir())
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .master("local[*]")
-             .getOrCreate();
-   }
-diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
-index 68c537e34..1e9e90d53 100644
---- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
-+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
+diff --git a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
+index 68c537e34a..1e9e90d539 100644
+--- a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
++++ b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
 @@ -94,7 +94,19 @@ public abstract class IcebergSourceBenchmark {
    }
  
@@ -191,705 +160,6 @@ index 68c537e34..1e9e90d53 100644
      if (!enableDictionaryEncoding) {
        builder
            .config("parquet.dictionary.page.size", "1")
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
-index 404ba7284..00e97e96f 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
-@@ -90,6 +90,16 @@ public abstract class SparkDistributedDataScanTestBase
-         .master("local[2]")
-         .config("spark.serializer", serializer)
-         .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
-+        .config("spark.plugins", "org.apache.spark.CometPlugin")
-+        .config(
-+            "spark.shuffle.manager",
-+            "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+        .config("spark.comet.explainFallback.enabled", "true")
-+        .config("spark.comet.scan.icebergNative.enabled", "true")
-+        .config("spark.memory.offHeap.enabled", "true")
-+        .config("spark.memory.offHeap.size", "10g")
-+        .config("spark.comet.use.lazyMaterialization", "false")
-+        .config("spark.comet.schemaEvolution.enabled", "true")
-         .getOrCreate();
-   }
- }
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
-index 659507e4c..9076ec24d 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
-@@ -73,6 +73,16 @@ public class TestSparkDistributedDataScanDeletes
-             .master("local[2]")
-             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
-index a218f965e..eca0125ac 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
-@@ -62,6 +62,16 @@ public class TestSparkDistributedDataScanFilterFiles
-             .master("local[2]")
-             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
-index 2665d7ba8..2381d0aa1 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
-@@ -63,6 +63,16 @@ public class TestSparkDistributedDataScanReporting
-             .master("local[2]")
-             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
-index 3e9f3334e..4401e8d0c 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
-@@ -77,6 +77,17 @@ public abstract class TestBase extends SparkTestHelperBase {
-             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
-             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
-             .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .config("spark.comet.exec.broadcastExchange.enabled", "false")
-             .enableHiveSupport()
-             .getOrCreate();
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
-index bc4e722bc..3bbff053f 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
-@@ -59,7 +59,20 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
- 
-   @BeforeAll
-   public static void startSpark() {
--    spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterAll
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
-index 0886df957..b9d49d55c 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
-@@ -57,7 +57,20 @@ public abstract class ScanTestBase extends AvroDataTest {
- 
-   @BeforeAll
-   public static void startSpark() {
--    ScanTestBase.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    ScanTestBase.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-     ScanTestBase.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
-index 6b7d86136..c857dafce 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
-@@ -144,7 +144,20 @@ public class TestCompressionSettings extends CatalogTestBase {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestCompressionSettings.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestCompressionSettings.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @BeforeEach
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
-index c4ba96e63..98398968b 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
-@@ -75,7 +75,20 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestDataSourceOptions.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestDataSourceOptions.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterAll
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
-index 348173596..9017b4a37 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
-@@ -110,7 +110,20 @@ public class TestFilteredScan {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestFilteredScan.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestFilteredScan.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterAll
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
-index 84c99a575..1d60b01df 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
-@@ -93,7 +93,20 @@ public class TestForwardCompatibility {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestForwardCompatibility.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestForwardCompatibility.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterAll
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
-index 7eff93d20..7aab7f968 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
-@@ -46,7 +46,20 @@ public class TestIcebergSpark {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestIcebergSpark.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestIcebergSpark.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterAll
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
-index 9464f687b..ca4e3e035 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
-@@ -112,7 +112,20 @@ public class TestPartitionPruning {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestPartitionPruning.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestPartitionPruning.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-     TestPartitionPruning.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
- 
-     String optionKey = String.format("fs.%s.impl", CountOpenLocalFileSystem.scheme);
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
-index 5c218f21c..1d2222821 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
-@@ -107,7 +107,20 @@ public class TestPartitionValues {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestPartitionValues.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestPartitionValues.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterAll
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
-index a7334a580..ecd25670f 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
-@@ -87,7 +87,20 @@ public class TestSnapshotSelection {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestSnapshotSelection.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestSnapshotSelection.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterAll
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
-index 182b1ef8f..205892e4a 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
-@@ -120,7 +120,20 @@ public class TestSparkDataFile {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestSparkDataFile.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestSparkDataFile.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-     TestSparkDataFile.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
-index fb2b312be..3fca3330d 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
-@@ -96,7 +96,20 @@ public class TestSparkDataWrite {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestSparkDataWrite.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestSparkDataWrite.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterEach
-@@ -140,7 +153,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-     assertThat(actual).as("Result rows should match").isEqualTo(expected);
-     for (ManifestFile manifest :
-@@ -210,7 +223,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-     assertThat(actual).as("Result rows should match").isEqualTo(expected);
-   }
-@@ -256,7 +269,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-     assertThat(actual).as("Result rows should match").isEqualTo(expected);
-   }
-@@ -309,7 +322,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-     assertThat(actual).as("Result rows should match").isEqualTo(expected);
-   }
-@@ -352,7 +365,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-     assertThat(actual).as("Result rows should match").isEqualTo(expected);
-   }
-@@ -392,7 +405,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-     assertThat(actual).as("Result rows should match").isEqualTo(expected);
- 
-@@ -458,7 +471,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-     assertThat(actual).as("Result rows should match").isEqualTo(expected);
-   }
-@@ -622,7 +635,7 @@ public class TestSparkDataWrite {
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
- 
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-     assertThat(actual).as("Result rows should match").isEqualTo(expected);
- 
-@@ -708,7 +721,7 @@ public class TestSparkDataWrite {
-     // Since write and commit succeeded, the rows should be readable
-     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
-     List<SimpleRecord> actual =
--        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-     assertThat(actual).as("Number of rows should match").hasSize(records.size() + records2.size());
-     assertThat(actual)
-         .describedAs("Result rows should match")
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
-index becf6a064..21701450a 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
-@@ -83,7 +83,20 @@ public class TestSparkReadProjection extends TestReadProjection {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestSparkReadProjection.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestSparkReadProjection.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-     ImmutableMap<String, String> config =
-         ImmutableMap.of(
-             "type", "hive",
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
-index 4f1cef5d3..f0f427732 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
-@@ -136,6 +136,16 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
-             .config("spark.ui.liveUpdate.period", 0)
-             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
-             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .enableHiveSupport()
-             .getOrCreate();
- 
-@@ -204,7 +214,8 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
-   }
- 
-   protected boolean countDeletes() {
--    return true;
-+    // TODO: Enable once iceberg-rust exposes delete count metrics to Comet
-+    return false;
-   }
- 
-   @Override
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
-index baf7fa8f8..150cc8969 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
-@@ -182,6 +182,16 @@ public class TestSparkReaderWithBloomFilter {
-         SparkSession.builder()
-             .master("local[2]")
-             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .enableHiveSupport()
-             .getOrCreate();
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
-index c84a65cbe..6a6dd8a49 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
-@@ -67,6 +67,16 @@ public class TestStructuredStreaming {
-         SparkSession.builder()
-             .master("local[2]")
-             .config("spark.sql.shuffle.partitions", 4)
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .getOrCreate();
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
-index 306444b9f..b661aa8ce 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
-@@ -75,7 +75,20 @@ public class TestTimestampWithoutZone extends TestBase {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestTimestampWithoutZone.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestTimestampWithoutZone.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-   }
- 
-   @AfterAll
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
-index 841268a6b..2fcc92bcb 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
-@@ -80,7 +80,20 @@ public class TestWriteMetricsConfig {
- 
-   @BeforeAll
-   public static void startSpark() {
--    TestWriteMetricsConfig.spark = SparkSession.builder().master("local[2]").getOrCreate();
-+    TestWriteMetricsConfig.spark =
-+        SparkSession.builder()
-+            .master("local[2]")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-+            .getOrCreate();
-     TestWriteMetricsConfig.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
-   }
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
-index 6e0925270..e0d743180 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
-@@ -60,6 +60,16 @@ public class TestAggregatePushDown extends CatalogTestBase {
-         SparkSession.builder()
-             .master("local[2]")
-             .config("spark.sql.iceberg.aggregate_pushdown", "true")
-+            .config("spark.plugins", "org.apache.spark.CometPlugin")
-+            .config(
-+                "spark.shuffle.manager",
-+                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
-+            .config("spark.comet.explainFallback.enabled", "true")
-+            .config("spark.comet.scan.icebergNative.enabled", "true")
-+            .config("spark.memory.offHeap.enabled", "true")
-+            .config("spark.memory.offHeap.size", "10g")
-+            .config("spark.comet.use.lazyMaterialization", "false")
-+            .config("spark.comet.schemaEvolution.enabled", "true")
-             .enableHiveSupport()
-             .getOrCreate();
- 
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
-index 9d2ce2b38..5e2336884 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
-@@ -598,9 +598,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
-     String planAsString = sparkPlan.toString().replaceAll("#(\\d+L?)", "");
- 
-     if (sparkFilter != null) {
--      assertThat(planAsString)
--          .as("Post scan filter should match")
--          .contains("Filter (" + sparkFilter + ")");
-+      assertThat(planAsString).as("Post scan filter should match").contains("CometFilter");
-     } else {
-       assertThat(planAsString).as("Should be no post scan filter").doesNotContain("Filter (");
-     }
-diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
-index 6719c45ca..251545440 100644
---- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
-+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
-@@ -616,7 +616,7 @@ public class TestStoragePartitionedJoins extends TestBaseWithCatalog {
-             + "FROM %s t1 "
-             + "INNER JOIN %s t2 "
-             + "ON t1.id = t2.id AND t1.%s = t2.%s "
--            + "ORDER BY t1.id, t1.%s",
-+            + "ORDER BY t1.id, t1.%s, t1.salary",
-         sourceColumnName,
-         tableName,
-         tableName(OTHER_TABLE_NAME),
 diff --git a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java
 deleted file mode 100644
 index 16159dcbdf..0000000000
@@ -1613,10 +883,10 @@ index d36f1a7274..0000000000
 -  }
 -}
 diff --git a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
-index b523bc5bff..4aa274a0c7 100644
+index b523bc5bff..636ad3be7d 100644
 --- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
 +++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
-@@ -70,22 +70,6 @@ public class VectorizedSparkParquetReaders {
+@@ -70,23 +70,6 @@ public class VectorizedSparkParquetReaders {
                  deleteFilter));
    }
  
@@ -1636,9 +906,10 @@ index b523bc5bff..4aa274a0c7 100644
 -                readers -> new CometColumnarBatchReader(readers, expectedSchema),
 -                deleteFilter));
 -  }
- 
+-
    // enables unsafe memory access to avoid costly checks to see if index is within bounds
    // as long as it is not configured explicitly (see BoundsChecking in Arrow)
+   private static void enableUnsafeMemoryAccess() {
 diff --git a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
 index 780e1750a5..25f253eede 100644
 --- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
@@ -1670,6 +941,780 @@ index 780e1750a5..25f253eede 100644
          .recordsPerBatch(parquetConf.batchSize())
          .filter(residual)
          .caseSensitive(caseSensitive())
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
+index 404ba72846..00e97e96f9 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
+@@ -90,6 +90,16 @@ public abstract class SparkDistributedDataScanTestBase
+         .master("local[2]")
+         .config("spark.serializer", serializer)
+         .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++        .config("spark.plugins", "org.apache.spark.CometPlugin")
++        .config(
++            "spark.shuffle.manager",
++            "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++        .config("spark.comet.explainFallback.enabled", "true")
++        .config("spark.comet.scan.icebergNative.enabled", "true")
++        .config("spark.memory.offHeap.enabled", "true")
++        .config("spark.memory.offHeap.size", "10g")
++        .config("spark.comet.use.lazyMaterialization", "false")
++        .config("spark.comet.schemaEvolution.enabled", "true")
+         .getOrCreate();
+   }
+ }
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
+index 9361c63176..9a78bbf3b6 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
+@@ -69,6 +69,16 @@ public class TestSparkDistributedDataScanDeletes
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
+index a218f965ea..eca0125ace 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
+@@ -62,6 +62,16 @@ public class TestSparkDistributedDataScanFilterFiles
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
+index acd4688440..9be94eab2f 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
+@@ -59,6 +59,16 @@ public class TestSparkDistributedDataScanReporting
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
+index 06d5e0c44f..b4f6d3907a 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
+@@ -57,7 +57,20 @@ public abstract class ScanTestBase extends AvroDataTest {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    ScanTestBase.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    ScanTestBase.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     ScanTestBase.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+index 26cb4dcc95..1d5eaf18e9 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+@@ -104,7 +104,20 @@ public class TestCompressionSettings extends SparkCatalogTestBase {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestCompressionSettings.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestCompressionSettings.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @Before
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+index 013b8d4386..613f35417e 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+@@ -76,7 +76,20 @@ public class TestDataSourceOptions extends SparkTestBaseWithCatalog {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestDataSourceOptions.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestDataSourceOptions.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterClass
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+index ba13d005bd..73d76e2d3e 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+@@ -118,7 +118,20 @@ public class TestFilteredScan {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestFilteredScan.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestFilteredScan.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+ 
+     // define UDFs used by partition tests
+     Function<Object, Integer> bucket4 = Transforms.bucket(4).bind(Types.LongType.get());
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+index 9f97753094..a69cf4f33d 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+@@ -94,7 +94,20 @@ public class TestForwardCompatibility {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestForwardCompatibility.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestForwardCompatibility.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterClass
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+index 0154506f86..79138afc26 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+@@ -46,7 +46,20 @@ public class TestIcebergSpark {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestIcebergSpark.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestIcebergSpark.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterClass
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+index 639d37c793..c4570510a6 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+@@ -111,7 +111,20 @@ public class TestPartitionPruning {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestPartitionPruning.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestPartitionPruning.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     TestPartitionPruning.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+ 
+     String optionKey = String.format("fs.%s.impl", CountOpenLocalFileSystem.scheme);
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+index ad0984ef42..cb143ac2fc 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+@@ -104,7 +104,20 @@ public class TestPartitionValues {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestPartitionValues.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestPartitionValues.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterClass
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+index 9fc576dde5..2765862300 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+@@ -83,7 +83,20 @@ public class TestSnapshotSelection {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestSnapshotSelection.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSnapshotSelection.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterClass
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+index 16fde3c954..9c01167064 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+@@ -121,7 +121,20 @@ public class TestSparkDataFile {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestSparkDataFile.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSparkDataFile.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     TestSparkDataFile.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+index 63c18277aa..c8c5c49009 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+@@ -89,7 +89,20 @@ public class TestSparkDataWrite {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestSparkDataWrite.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSparkDataWrite.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @Parameterized.AfterParam
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
+index 584a6b1c70..6b38a1195a 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
+@@ -86,7 +86,20 @@ public class TestSparkReadProjection extends TestReadProjection {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestSparkReadProjection.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSparkReadProjection.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     ImmutableMap<String, String> config =
+         ImmutableMap.of(
+             "type", "hive",
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+index dda49b4946..529992de6b 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+@@ -131,7 +131,27 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
+             .config("spark.ui.liveUpdate.period", 0)
+             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+ 
+     catalog =
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+index e5831b76e4..5c45a111d9 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+@@ -176,7 +176,27 @@ public class TestSparkReaderWithBloomFilter {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+ 
+     catalog =
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+index 961d69b721..57ffe5462f 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+@@ -68,6 +68,16 @@ public class TestStructuredStreaming {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.sql.shuffle.partitions", 4)
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
+index ac674e2e62..4460d597b3 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
+@@ -73,7 +73,20 @@ public class TestTimestampWithoutZone extends SparkTestBase {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestTimestampWithoutZone.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestTimestampWithoutZone.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterClass
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+index 73827b309b..aa5e28e34d 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+@@ -80,7 +80,20 @@ public class TestWriteMetricsConfig {
+ 
+   @BeforeClass
+   public static void startSpark() {
+-    TestWriteMetricsConfig.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestWriteMetricsConfig.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     TestWriteMetricsConfig.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+ 
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+index 1a4e2f3e1c..641cb855e9 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+@@ -65,7 +65,27 @@ public class TestAggregatePushDown extends SparkCatalogTestBase {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.sql.iceberg.aggregate_pushdown", "true")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+ 
+     SparkTestBase.catalog =
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+index f92055ab7a..95fde91f19 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+@@ -585,9 +585,7 @@ public class TestFilterPushDown extends SparkTestBaseWithCatalog {
+     String planAsString = sparkPlan.toString().replaceAll("#(\\d+L?)", "");
+ 
+     if (sparkFilter != null) {
+-      assertThat(planAsString)
+-          .as("Post scan filter should match")
+-          .contains("Filter (" + sparkFilter + ")");
++      assertThat(planAsString).as("Post scan filter should match").contains("CometFilter");
+     } else {
+       assertThat(planAsString).as("Should be no post scan filter").doesNotContain("Filter (");
+     }
+diff --git a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
+index 8a1ec5060f..3611521cc4 100644
+--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
++++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
+@@ -605,7 +605,7 @@ public class TestStoragePartitionedJoins extends SparkTestBaseWithCatalog {
+             + "FROM %s t1 "
+             + "INNER JOIN %s t2 "
+             + "ON t1.id = t2.id AND t1.%s = t2.%s "
+-            + "ORDER BY t1.id, t1.%s",
++            + "ORDER BY t1.id, t1.%s, t1.salary",
+         sourceColumnName,
+         tableName,
+         tableName(OTHER_TABLE_NAME),
+diff --git a/spark/v3.5/build.gradle b/spark/v3.5/build.gradle
+index 572c32f929..29013d26c0 100644
+--- a/spark/v3.5/build.gradle
++++ b/spark/v3.5/build.gradle
+@@ -75,7 +75,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
+       exclude group: 'org.roaringbitmap'
+     }
+ 
+-    compileOnly "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:0.5.0"
++    compileOnly "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:${libs.versions.comet.get()}"
+ 
+     implementation libs.parquet.column
+     implementation libs.parquet.hadoop
+@@ -184,7 +184,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
+     testImplementation libs.avro.avro
+     testImplementation libs.parquet.hadoop
+     testImplementation libs.awaitility
+-    testImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:0.5.0"
++    testImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:${libs.versions.comet.get()}"
+ 
+     // Required because we remove antlr plugin dependencies from the compile configuration, see note above
+     runtimeOnly libs.antlr.runtime
+@@ -265,6 +265,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
+     integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+     integrationImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
+     integrationImplementation project(path: ":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
++    integrationImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:${libs.versions.comet.get()}"
+ 
+     // runtime dependencies for running Hive Catalog based integration test
+     integrationRuntimeOnly project(':iceberg-hive-metastore')
+diff --git a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
+index 578845e3da..4f44a73db3 100644
+--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
++++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
+@@ -57,6 +57,16 @@ public abstract class ExtensionsTestBase extends CatalogTestBase {
+             .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
+             .config(
+                 SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), String.valueOf(RANDOM.nextBoolean()))
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
+diff --git a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+index ecf9e6f8a5..3475260ca5 100644
+--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
++++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+@@ -56,6 +56,16 @@ public class TestCallStatementParser {
+             .master("local[2]")
+             .config("spark.sql.extensions", IcebergSparkSessionExtensions.class.getName())
+             .config("spark.extra.prop", "value")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+     TestCallStatementParser.parser = spark.sessionState().sqlParser();
+   }
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
+index 64edb1002e..0fc10120ff 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
+@@ -179,6 +179,16 @@ public class DeleteOrphanFilesBenchmark {
+             .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
+             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+             .config("spark.sql.catalog.spark_catalog.warehouse", catalogWarehouse())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .master("local");
+     spark = builder.getOrCreate();
+   }
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
+index a5d0456b0b..f0759f8378 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
+@@ -392,6 +392,16 @@ public class IcebergSortCompactionBenchmark {
+                 "spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog")
+             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+             .config("spark.sql.catalog.spark_catalog.warehouse", getCatalogWarehouse())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .master("local[*]");
+     spark = builder.getOrCreate();
+     Configuration sparkHadoopConf = spark.sessionState().newHadoopConf();
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
+index c6794e43c6..457d2823ee 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
+@@ -239,6 +239,16 @@ public class DVReaderBenchmark {
+             .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
+             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+             .config("spark.sql.catalog.spark_catalog.warehouse", newWarehouseDir())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .master("local[*]")
+             .getOrCreate();
+   }
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
+index ac74fb5a10..eab09293de 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
+@@ -223,6 +223,16 @@ public class DVWriterBenchmark {
+             .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
+             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+             .config("spark.sql.catalog.spark_catalog.warehouse", newWarehouseDir())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .master("local[*]")
+             .getOrCreate();
+   }
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
+index 68c537e34a..1e9e90d539 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
+@@ -94,7 +94,19 @@ public abstract class IcebergSourceBenchmark {
+   }
+ 
+   protected void setupSpark(boolean enableDictionaryEncoding) {
+-    SparkSession.Builder builder = SparkSession.builder().config("spark.ui.enabled", false);
++    SparkSession.Builder builder =
++        SparkSession.builder()
++            .config("spark.ui.enabled", false)
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true");
+     if (!enableDictionaryEncoding) {
+       builder
+           .config("parquet.dictionary.page.size", "1")
 diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java
 deleted file mode 100644
 index 16159dcbdf..0000000000
@@ -2393,9 +2438,10 @@ index d36f1a7274..0000000000
 -  }
 -}
 diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
+index b523bc5bff..636ad3be7d 100644
 --- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
 +++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
-@@ -70,22 +70,6 @@
+@@ -70,23 +70,6 @@ public class VectorizedSparkParquetReaders {
                  deleteFilter));
    }
  
@@ -2415,13 +2461,15 @@ diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vector
 -                readers -> new CometColumnarBatchReader(readers, expectedSchema),
 -                deleteFilter));
 -  }
- 
+-
    // enables unsafe memory access to avoid costly checks to see if index is within bounds
    // as long as it is not configured explicitly (see BoundsChecking in Arrow)
+   private static void enableUnsafeMemoryAccess() {
 diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
+index 780e1750a5..25f253eede 100644
 --- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
 +++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
-@@ -34,7 +34,6 @@
+@@ -34,7 +34,6 @@ import org.apache.iceberg.parquet.Parquet;
  import org.apache.iceberg.relocated.com.google.common.collect.Sets;
  import org.apache.iceberg.spark.OrcBatchReadConf;
  import org.apache.iceberg.spark.ParquetBatchReadConf;
@@ -2429,7 +2477,7 @@ diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/Base
  import org.apache.iceberg.spark.data.vectorized.VectorizedSparkOrcReaders;
  import org.apache.iceberg.spark.data.vectorized.VectorizedSparkParquetReaders;
  import org.apache.iceberg.types.TypeUtil;
-@@ -92,15 +91,9 @@
+@@ -92,15 +91,9 @@ abstract class BaseBatchReader<T extends ScanTask> extends BaseReader<ColumnarBa
          .project(requiredSchema)
          .split(start, length)
          .createBatchedReaderFunc(
@@ -2448,3 +2496,702 @@ diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/Base
          .recordsPerBatch(parquetConf.batchSize())
          .filter(residual)
          .caseSensitive(caseSensitive())
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
+index 404ba72846..00e97e96f9 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
+@@ -90,6 +90,16 @@ public abstract class SparkDistributedDataScanTestBase
+         .master("local[2]")
+         .config("spark.serializer", serializer)
+         .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++        .config("spark.plugins", "org.apache.spark.CometPlugin")
++        .config(
++            "spark.shuffle.manager",
++            "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++        .config("spark.comet.explainFallback.enabled", "true")
++        .config("spark.comet.scan.icebergNative.enabled", "true")
++        .config("spark.memory.offHeap.enabled", "true")
++        .config("spark.memory.offHeap.size", "10g")
++        .config("spark.comet.use.lazyMaterialization", "false")
++        .config("spark.comet.schemaEvolution.enabled", "true")
+         .getOrCreate();
+   }
+ }
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
+index 659507e4c5..9076ec24d1 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
+@@ -73,6 +73,16 @@ public class TestSparkDistributedDataScanDeletes
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
+index a218f965ea..eca0125ace 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
+@@ -62,6 +62,16 @@ public class TestSparkDistributedDataScanFilterFiles
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
+index 2665d7ba8d..2381d0aa14 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
+@@ -63,6 +63,16 @@ public class TestSparkDistributedDataScanReporting
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
+index 3e9f3334ef..4401e8d0cd 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
+@@ -77,6 +77,17 @@ public abstract class TestBase extends SparkTestHelperBase {
+             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
+             .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .config("spark.comet.exec.broadcastExchange.enabled", "false")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+index bc4e722bc8..3bbff053fd 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+@@ -59,7 +59,20 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    spark = SparkSession.builder().master("local[2]").getOrCreate();
++    spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
+index 0886df957d..b9d49d55ce 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
+@@ -57,7 +57,20 @@ public abstract class ScanTestBase extends AvroDataTest {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    ScanTestBase.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    ScanTestBase.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     ScanTestBase.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+index 6b7d861364..c857dafce3 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+@@ -144,7 +144,20 @@ public class TestCompressionSettings extends CatalogTestBase {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestCompressionSettings.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestCompressionSettings.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @BeforeEach
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+index c4ba96e634..98398968b0 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+@@ -75,7 +75,20 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestDataSourceOptions.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestDataSourceOptions.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+index 348173596e..9017b4a37a 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+@@ -110,7 +110,20 @@ public class TestFilteredScan {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestFilteredScan.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestFilteredScan.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+index 84c99a575c..1d60b01df5 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+@@ -93,7 +93,20 @@ public class TestForwardCompatibility {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestForwardCompatibility.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestForwardCompatibility.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+index 7eff93d204..7aab7f9682 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+@@ -46,7 +46,20 @@ public class TestIcebergSpark {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestIcebergSpark.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestIcebergSpark.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+index 9464f687b0..ca4e3e0353 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+@@ -112,7 +112,20 @@ public class TestPartitionPruning {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestPartitionPruning.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestPartitionPruning.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     TestPartitionPruning.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+ 
+     String optionKey = String.format("fs.%s.impl", CountOpenLocalFileSystem.scheme);
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+index 5c218f21c4..1d22228217 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+@@ -107,7 +107,20 @@ public class TestPartitionValues {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestPartitionValues.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestPartitionValues.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+index a7334a580c..ecd25670fe 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+@@ -87,7 +87,20 @@ public class TestSnapshotSelection {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestSnapshotSelection.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSnapshotSelection.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+index 182b1ef8f5..205892e4a6 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+@@ -120,7 +120,20 @@ public class TestSparkDataFile {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestSparkDataFile.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSparkDataFile.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     TestSparkDataFile.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+index fb2b312bed..3fca3330d0 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+@@ -96,7 +96,20 @@ public class TestSparkDataWrite {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestSparkDataWrite.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSparkDataWrite.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterEach
+@@ -140,7 +153,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
+     assertThat(actual).as("Result rows should match").isEqualTo(expected);
+     for (ManifestFile manifest :
+@@ -210,7 +223,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
+     assertThat(actual).as("Result rows should match").isEqualTo(expected);
+   }
+@@ -256,7 +269,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
+     assertThat(actual).as("Result rows should match").isEqualTo(expected);
+   }
+@@ -309,7 +322,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
+     assertThat(actual).as("Result rows should match").isEqualTo(expected);
+   }
+@@ -352,7 +365,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
+     assertThat(actual).as("Result rows should match").isEqualTo(expected);
+   }
+@@ -392,7 +405,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
+     assertThat(actual).as("Result rows should match").isEqualTo(expected);
+ 
+@@ -458,7 +471,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
+     assertThat(actual).as("Result rows should match").isEqualTo(expected);
+   }
+@@ -622,7 +635,7 @@ public class TestSparkDataWrite {
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+ 
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
+     assertThat(actual).as("Result rows should match").isEqualTo(expected);
+ 
+@@ -708,7 +721,7 @@ public class TestSparkDataWrite {
+     // Since write and commit succeeded, the rows should be readable
+     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
+     List<SimpleRecord> actual =
+-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
++        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+     assertThat(actual).as("Number of rows should match").hasSize(records.size() + records2.size());
+     assertThat(actual)
+         .describedAs("Result rows should match")
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
+index becf6a064d..21701450a8 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
+@@ -83,7 +83,20 @@ public class TestSparkReadProjection extends TestReadProjection {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestSparkReadProjection.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSparkReadProjection.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     ImmutableMap<String, String> config =
+         ImmutableMap.of(
+             "type", "hive",
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+index 4f1cef5d37..f0f4277324 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+@@ -136,6 +136,16 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
+             .config("spark.ui.liveUpdate.period", 0)
+             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
+@@ -204,7 +214,8 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
+   }
+ 
+   protected boolean countDeletes() {
+-    return true;
++    // TODO: Enable once iceberg-rust exposes delete count metrics to Comet
++    return false;
+   }
+ 
+   @Override
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+index baf7fa8f88..150cc89696 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+@@ -182,6 +182,16 @@ public class TestSparkReaderWithBloomFilter {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+index c84a65cbe9..6a6dd8a49b 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+@@ -67,6 +67,16 @@ public class TestStructuredStreaming {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.sql.shuffle.partitions", 4)
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
+index 306444b9f2..b661aa8ced 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
+@@ -75,7 +75,20 @@ public class TestTimestampWithoutZone extends TestBase {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestTimestampWithoutZone.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestTimestampWithoutZone.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+index 841268a6be..2fcc92bcb6 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+@@ -80,7 +80,20 @@ public class TestWriteMetricsConfig {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestWriteMetricsConfig.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestWriteMetricsConfig.spark =
++        SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
++            .getOrCreate();
+     TestWriteMetricsConfig.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+index 6e09252704..e0d7431808 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+@@ -60,6 +60,16 @@ public class TestAggregatePushDown extends CatalogTestBase {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.sql.iceberg.aggregate_pushdown", "true")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config(
++                "spark.shuffle.manager",
++                "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .config("spark.comet.explainFallback.enabled", "true")
++            .config("spark.comet.scan.icebergNative.enabled", "true")
++            .config("spark.memory.offHeap.enabled", "true")
++            .config("spark.memory.offHeap.size", "10g")
++            .config("spark.comet.use.lazyMaterialization", "false")
++            .config("spark.comet.schemaEvolution.enabled", "true")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+index 9d2ce2b388..5e23368848 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+@@ -598,9 +598,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
+     String planAsString = sparkPlan.toString().replaceAll("#(\\d+L?)", "");
+ 
+     if (sparkFilter != null) {
+-      assertThat(planAsString)
+-          .as("Post scan filter should match")
+-          .contains("Filter (" + sparkFilter + ")");
++      assertThat(planAsString).as("Post scan filter should match").contains("CometFilter");
+     } else {
+       assertThat(planAsString).as("Should be no post scan filter").doesNotContain("Filter (");
+     }
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
+index 6719c45ca9..2515454401 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
+@@ -616,7 +616,7 @@ public class TestStoragePartitionedJoins extends TestBaseWithCatalog {
+             + "FROM %s t1 "
+             + "INNER JOIN %s t2 "
+             + "ON t1.id = t2.id AND t1.%s = t2.%s "
+-            + "ORDER BY t1.id, t1.%s",
++            + "ORDER BY t1.id, t1.%s, t1.salary",
+         sourceColumnName,
+         tableName,
+         tableName(OTHER_TABLE_NAME),


### PR DESCRIPTION
## Which issue does this PR close?

Closes #3784.

## Rationale for this change

The Iceberg Spark SQL test CI matrix includes Spark 3.4, but the diffs applied to Iceberg only patched `spark/v3.5/` files. Spark 3.4 tests ran without Comet loaded, providing no coverage.

## What changes are included in this PR?

Add v3.4 equivalents of all v3.5 Comet patches to the Iceberg diffs (1.8.1, 1.9.1, 1.10.0):

- `spark/v3.4/build.gradle`: add Comet dependency to `compileOnly`, `testImplementation`, and `integrationImplementation` configurations
- Test base classes (`SparkTestBase`/`TestBase`, `ScanTestBase`, `SparkExtensionsTestBase`/`ExtensionsTestBase`, `SparkDistributedDataScanTestBase`): load Comet
plugin and shuffle manager in `SparkSession.builder()` calls
- Individual test files with their own `SparkSession` builders: same Comet plugin config
- JMH benchmarks (`IcebergSourceBenchmark`, `DeleteOrphanFilesBenchmark`, `IcebergSortCompactionBenchmark`): same
- `TestSparkDataWrite`: add `orderBy("id", "data")` for deterministic results (matching v3.5)
- `TestFilterPushDown`: update assertion to check for `CometFilter` (matching v3.5)
- `TestStoragePartitionedJoins`: add `t1.salary` to `ORDER BY` for deterministic results (matching v3.5)

## How are these changes tested?

Existing Iceberg Spark SQL CI workflow. I also brought these diffs over to #3779 to verify that the 3.4.3 workflows now fail in that PR. 