### PR TITLE
feat: Add support for Spark NaNvl math expression

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -106,6 +106,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
     classOf[Log2] -> CometLog2,
     classOf[Log10] -> CometLog10,
     classOf[Multiply] -> CometMultiply,
+    classOf[NaNvl] -> CometScalarFunction("nanvl"),
     classOf[Pow] -> CometScalarFunction("pow"),
     classOf[Rand] -> CometRand,
     classOf[Randn] -> CometRandn,

--- a/spark/src/test/resources/sql-tests/expressions/math/nanvl.sql
+++ b/spark/src/test/resources/sql-tests/expressions/math/nanvl.sql
@@ -1,0 +1,31 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- ConfigMatrix: parquet.enable.dictionary=false,true
+
+statement
+CREATE TABLE test_nanvl(x double, y double) USING parquet
+
+statement
+INSERT INTO test_nanvl VALUES (1.0, 2.0), (cast('NaN' as double), 3.0), (cast('NaN' as double), cast('NaN' as double)), (NULL, 5.0), (4.0, NULL), (NULL, NULL)
+
+query tolerance=1e-6
+SELECT nanvl(x, y) FROM test_nanvl
+
+-- literal arguments
+query tolerance=1e-6
+SELECT nanvl(1.0, 2.0), nanvl(cast('NaN' as double), 3.0), nanvl(NULL, 5.0)


### PR DESCRIPTION
## Summary
- Add support for Spark's `NaNvl` expression (returns first arg if not NaN, otherwise second arg)
- Delegates to DataFusion's built-in `nanvl` function via `CometScalarFunction`
- No native Rust code needed — DataFusion's function registry handles execution
- SQL test added covering NaN, normal values, NULL, and mixed inputs

## Test plan
- [x] SQL test added: `nanvl.sql`
- [ ] Run `CometSqlFileTestSuite` to verify results match Spark

Related to #2084