### PR TITLE
feat: add audit-comet-expression Claude Code skill

### DIFF
--- a/.claude/skills/audit-comet-expression/SKILL.md
+++ b/.claude/skills/audit-comet-expression/SKILL.md
@@ -201,23 +201,23 @@ Compare the Spark test coverage (Step 2) against the Comet test coverage (Step 4
 
 For each of the following dimensions, note whether it is covered in Comet tests or missing:
 
-| Dimension                                               | Spark tests it | Comet SQL test | Comet Scala test | Gap? |
-| ------------------------------------------------------- | -------------- | -------------- | ---------------- | ---- |
-| Column reference argument(s)                            |                |                |                  |      |
-| Literal argument(s)                                     |                |                |                  |      |
-| NULL input                                              |                |                |                  |      |
-| Empty string / empty array / empty map                  |                |                |                  |      |
-| Array/map with NULL elements                            |                |                |                  |      |
-| Zero, negative zero, negative values (numeric)          |                |                |                  |      |
-| Underflow, overflow                                     |                |                |                  |      |
-| Boundary values (INT_MIN, INT_MAX, Long.MinValue, minimum positive, etc.) | |           |                  |      |
-| NaN, Infinity, -Infinity, subnormal (float/double)      |                |                |                  |      |
-| Multibyte / special UTF-8 (composed vs decomposed, e.g. `é` U+00E9 vs `e` + U+0301, non-Latin scripts) | | | | |
-| ANSI mode (failOnError=true)                            |                |                |                  |      |
-| Non-ANSI mode (failOnError=false)                       |                |                |                  |      |
-| All supported input types                               |                |                |                  |      |
-| Parquet dictionary encoding (ConfigMatrix)              |                |                |                  |      |
-| Cross-version behavior differences                      |                |                |                  |      |
+| Dimension                                                                                              | Spark tests it | Comet SQL test | Comet Scala test | Gap? |
+| ------------------------------------------------------------------------------------------------------ | -------------- | -------------- | ---------------- | ---- |
+| Column reference argument(s)                                                                           |                |                |                  |      |
+| Literal argument(s)                                                                                    |                |                |                  |      |
+| NULL input                                                                                             |                |                |                  |      |
+| Empty string / empty array / empty map                                                                 |                |                |                  |      |
+| Array/map with NULL elements                                                                           |                |                |                  |      |
+| Zero, negative zero, negative values (numeric)                                                         |                |                |                  |      |
+| Underflow, overflow                                                                                    |                |                |                  |      |
+| Boundary values (INT_MIN, INT_MAX, Long.MinValue, minimum positive, etc.)                              |                |                |                  |      |
+| NaN, Infinity, -Infinity, subnormal (float/double)                                                     |                |                |                  |      |
+| Multibyte / special UTF-8 (composed vs decomposed, e.g. `é` U+00E9 vs `e` + U+0301, non-Latin scripts) |                |                |                  |      |
+| ANSI mode (failOnError=true)                                                                           |                |                |                  |      |
+| Non-ANSI mode (failOnError=false)                                                                      |                |                |                  |      |
+| All supported input types                                                                              |                |                |                  |      |
+| Parquet dictionary encoding (ConfigMatrix)                                                             |                |                |                  |      |
+| Cross-version behavior differences                                                                     |                |                |                  |      |
 
 ### Implementation gaps
 


### PR DESCRIPTION
## Summary

Adds a new Claude Code skill `.claude/skills/audit-comet-expression/SKILL.md` for auditing existing Comet expression implementations for correctness and test coverage.

The skill (`/audit-comet-expression <expression-name>`) performs a structured audit:

- Studies the Spark implementation across versions 3.4.3, 3.5.8, and 4.0.1, cloning each tag to `/tmp/` and diffing behavioral changes across versions
- Reviews the Comet Scala serde, shims, and Rust/DataFusion implementation for correctness (null handling, type dispatch, ANSI mode, `getSupportLevel` accuracy)
- Inventories existing Comet tests: SQL file tests and Scala tests
- Produces a coverage gap matrix against Spark's own test suite (nulls, boundary values, NaN, multibyte UTF-8, ANSI mode, all input types, Parquet dictionary encoding, cross-version differences)
- Flags implementation gaps such as missing shims or incorrect `Incompatible`/`Unsupported` markings
- Offers to implement the missing tests (preferring the SQL file test framework)

This complements the existing `review-comet-pr` skill, which focuses on reviewing incoming PRs. The audit skill is for proactively checking the quality of expressions already in the codebase.