### PR TITLE
fix: Native_datafusion reports correct files and bytes scanned

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
@@ -85,7 +85,11 @@ case class CometScanExec(
 
   private lazy val driverMetrics: HashMap[String, Long] = HashMap.empty
 
-  @transient private lazy val setDriverMetrics: Unit = {
+  /**
+   * Send the driver-side metrics. Before calling this function, selectedPartitions has been
+   * initialized. See SPARK-26327 for more details.
+   */
+  private def sendDriverMetrics(): Unit = {
     driverMetrics.foreach(e => metrics(e._1).set(e._2))
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
     SQLMetrics.postDriverMetricUpdates(
@@ -93,12 +97,6 @@ case class CometScanExec(
       executionId,
       metrics.filter(e => driverMetrics.contains(e._1)).values.toSeq)
   }
-
-  /**
-   * Send the driver-side metrics. Before calling this function, selectedPartitions has been
-   * initialized. See SPARK-26327 for more details.
-   */
-  private def sendDriverMetrics(): Unit = setDriverMetrics
 
   private def isDynamicPruningFilter(e: Expression): Boolean =
     e.find(_.isInstanceOf[PlanExpression[_]]).isDefined

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -2180,7 +2180,8 @@ class CometExecSuite extends CometTestBase {
 
       withSQLConf(
         CometConf.COMET_ENABLED.key -> "true",
-        CometConf.COMET_EXEC_ENABLED.key -> "true") {
+        CometConf.COMET_EXEC_ENABLED.key -> "true",
+        CometConf.COMET_NATIVE_SCAN_IMPL.key -> "native_datafusion") {
         val df = spark.read.parquet(path)
 
         // Trigger two different actions to ensure metrics are not duplicated


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3791 

## Rationale for this change

In `CometScanExec`, calling `getFilePartitions()` unconditionally executes `sendDriverMetrics()`. Because `getFilePartitions()` can be evaluated multiple times during planning (e.g., converting to `CometNativeScanExec`) and execution (e.g., fetching partitions), the `SQLMetric` accumulators like `numFiles` and `filesSize` were being duplicated. This led to incorrect double-counted values rendering in the Spark UI.

## What changes are included in this PR?

* Replaced `metrics(...).add()` with `metrics(...).set()` in `CometScanExec` to ensure idempotency when reporting metrics. 
* Wrapped the driver metric updates and Spark listener event dispatching inside a `lazy val`. This prevents both double-counting during Catalyst transformations (`makeCopy`) and sending redundant UI events.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

* Added a dedicated end-to-end unit test in `CometExecSuite`.
* The test writes a dummy Parquet dataset, sequentially triggers multiple UI actions (`count` and `collect`) to force severe plan evaluations, and strictly asserts that `numFiles` is exactly `2` without any duplication.
