### PR TITLE
Add issue links to incompatible expression serde comments

### DIFF
--- a/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
+++ b/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
@@ -149,6 +149,7 @@ object CometCast extends CometExpressionSerde[Cast] with CometExprShim {
         isSupported(dt.elementType, dt1.elementType, timeZoneId, evalMode)
       case (dt: DataType, _) if dt.typeName == "timestamp_ntz" =>
         // https://github.com/apache/datafusion-comet/issues/378
+        // https://github.com/apache/datafusion-comet/issues/3179
         toType match {
           case DataTypes.TimestampType | DataTypes.DateType | DataTypes.StringType =>
             Incompatible()

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -244,7 +244,12 @@ object CometArrayMin extends CometExpressionSerde[ArrayMin] {
 
 object CometArraysOverlap extends CometExpressionSerde[ArraysOverlap] {
 
-  override def getSupportLevel(expr: ArraysOverlap): SupportLevel = Incompatible(None)
+  override def getSupportLevel(expr: ArraysOverlap): SupportLevel =
+    Incompatible(
+      Some(
+        "Inconsistent behavior with NULL values" +
+          " (https://github.com/apache/datafusion-comet/issues/3645)" +
+          " (https://github.com/apache/datafusion-comet/issues/2036)"))
 
   override def convert(
       expr: ArraysOverlap,
@@ -443,7 +448,11 @@ object CometArrayInsert extends CometExpressionSerde[ArrayInsert] {
 
 object CometArrayUnion extends CometExpressionSerde[ArrayUnion] {
 
-  override def getSupportLevel(expr: ArrayUnion): SupportLevel = Incompatible(None)
+  override def getSupportLevel(expr: ArrayUnion): SupportLevel =
+    Incompatible(
+      Some(
+        "Correctness issue" +
+          " (https://github.com/apache/datafusion-comet/issues/3644)"))
 
   override def convert(
       expr: ArrayUnion,


### PR DESCRIPTION
## Which issue does this PR close?

No specific issue. This is a documentation improvement for tracking purposes.

## Rationale for this change

Several expressions marked as `Incompatible` were missing links to their corresponding tracking issues. This makes it harder to understand why an expression is incompatible and what work is needed to make it compatible.

## What changes are included in this PR?

Added issue links to `Incompatible()` declarations that were previously missing them:

- `CometArraysOverlap` — links to #3645 and #2036
- `CometArrayUnion` — links to #3644
- `CometCast` (TimestampNTZ) — added #3179 alongside existing #378

Other incompatible expressions (`ArrayRemove`, `ArrayContains`, `Ceil`, `Floor`, `Tan`, `Hour`, `Minute`, `Second`, `TruncTimestamp`, `Corr`, `StructsToJson`) already had issue links.

## How are these changes tested?

Comment-only changes, no behavioral impact.