### PR TITLE
chore: update git plugin to allow worktrees

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@ under the License.
     <build-helper-maven-plugin.version>3.4.0</build-helper-maven-plugin.version>
     <flatten-maven-plugin.version>1.3.0</flatten-maven-plugin.version>
     <scalastyle-maven-plugin.version>1.0.0</scalastyle-maven-plugin.version>
-    <git-commit-id-maven-plugin.version>4.9.9</git-commit-id-maven-plugin.version>
+    <git-commit-id-maven-plugin.version>9.0.2</git-commit-id-maven-plugin.version>
     <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <scalafix-maven-plugin.version>0.1.7_0.10.4</scalafix-maven-plugin.version>


### PR DESCRIPTION
Updates the version of the git plugin for maven. Without this, Comet's maven build fails when working in a git worktree directory.