### PR TITLE
perf: remove BufReader wrapper when copying spill files to shuffle output

### DIFF
--- a/native/shuffle/src/partitioners/multi_partition.rs
+++ b/native/shuffle/src/partitioners/multi_partition.rs
@@ -35,7 +35,7 @@ use itertools::Itertools;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::fs::{File, OpenOptions};
-use std::io::{BufReader, BufWriter, Seek, Write};
+use std::io::{BufWriter, Seek, Write};
 use std::sync::Arc;
 use tokio::time::Instant;
 
@@ -582,7 +582,9 @@ impl ShufflePartitioner for MultiPartitionShuffleRepartitioner {
                 // if we wrote a spill file for this partition then copy the
                 // contents into the shuffle file
                 if let Some(spill_path) = self.partition_writers[i].path() {
-                    let mut spill_file = BufReader::new(File::open(spill_path)?);
+                    // Use raw File handle (not BufReader) so that std::io::copy
+                    // can use copy_file_range/sendfile for zero-copy on Linux.
+                    let mut spill_file = File::open(spill_path)?;
                     let mut write_timer = self.metrics.write_time.timer();
                     std::io::copy(&mut spill_file, &mut output_data)?;
                     write_timer.stop();


### PR DESCRIPTION
## Which issue does this PR close?

Closes #3834.

## Rationale for this change

In `MultiPartitionShuffleRepartitioner::shuffle_write()`, spill files are copied to the final shuffle output wrapped in `BufReader`. This is counterproductive because `std::io::copy` already uses an internal buffer, and wrapping in `BufReader` defeats the `copy_file_range`/`sendfile` zero-copy specialization on Linux since the source is no longer a raw `File`.

## What changes are included in this PR?

Remove the `BufReader` wrapper and pass the raw `File` handle directly to `std::io::copy`. Also removes the now-unused `BufReader` import.

## How are these changes tested?

Covered by existing shuffle tests. This is a minimal change that only affects the I/O path used for copying spill files.