### PR TITLE
fix: parameterize file count in Native_datafusion metrics test

### DIFF
--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -2210,9 +2210,11 @@ class CometExecSuite extends CometTestBase {
   }
 
   test("Native_datafusion reports correct files and bytes scanned") {
+    val inputFiles = 2
+
     withTempDir { dir =>
       val path = new java.io.File(dir, "test_metrics").getAbsolutePath
-      spark.range(100).repartition(2).write.mode("overwrite").parquet(path)
+      spark.range(100).repartition(inputFiles).write.mode("overwrite").parquet(path)
 
       withSQLConf(
         CometConf.COMET_ENABLED.key -> "true",
@@ -2236,8 +2238,8 @@ class CometExecSuite extends CometTestBase {
 
         val numFiles = scanNode.metrics("numFiles").value
         assert(
-          numFiles == 2,
-          s"Expected exactly 2 files to be scanned, but got metrics reporting $numFiles")
+          numFiles == inputFiles,
+          s"Expected exactly $inputFiles files to be scanned, but got metrics reporting $numFiles")
       }
     }
   }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
Follow-up to PR #3798 (Fixes Issue #3791).

## Rationale for this change

This addresses the post-merge review comments from @comphead in PR #3798 regarding the removal of hardcoded literals in the newly added test for `CometNativeScanExec` metrics.

## What changes are included in this PR?

- Extracted the hardcoded `2` into a well-named `val inputFiles = 2` constant inside the test `"Native_datafusion reports correct files and bytes scanned"`.
- Updated the assertions and `repartition()` logic to strictly rely on `inputFiles` for better readability and maintainability.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Verified locally by running `CometExecSuite`.