### PR TITLE
fix: [branch-0.14] backport #3914 - use min instead of max when capping write buffer size to Int range

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
@@ -191,7 +191,7 @@ class CometNativeShuffleWriter[K, V](
       shuffleWriterBuilder.setCompressionLevel(
         CometConf.COMET_EXEC_SHUFFLE_COMPRESSION_ZSTD_LEVEL.get)
       shuffleWriterBuilder.setWriteBufferSize(
-        CometConf.COMET_SHUFFLE_WRITE_BUFFER_SIZE.get().max(Int.MaxValue).toInt)
+        CometConf.COMET_SHUFFLE_WRITE_BUFFER_SIZE.get().min(Int.MaxValue).toInt)
 
       outputPartitioning match {
         case p if isSinglePartitioning(p) =>


### PR DESCRIPTION
## Which issue does this PR close?

Backport of #3914 to branch-0.14.

## Rationale for this change

PR #3914 fixes a bug where `max` was used instead of `min` when capping the write buffer size to the Int range.

## What changes are included in this PR?

Cherry-pick of commit 967a81e0c from main. A one-line fix changing `max` to `min` when capping the write buffer size.

## How are these changes tested?

Covered by existing tests in the original PR.