### PR TITLE
fix: log Comet execution errors before Spark can obscure them

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometBatchScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometBatchScanExec.scala
@@ -54,7 +54,7 @@ case class CometBatchScanExec(
 
   override lazy val inputRDD: RDD[InternalRow] = wrappedScan.inputRDD
 
-  override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+  override def doExecuteCometColumnar(): RDD[ColumnarBatch] = {
     val rdd = inputRDD.asInstanceOf[RDD[ColumnarBatch]]
 
     // These metrics are important for streaming solutions.
@@ -82,7 +82,7 @@ case class CometBatchScanExec(
   }
 
   // `ReusedSubqueryExec` in Spark only call non-columnar execute.
-  override def doExecute(): RDD[InternalRow] = {
+  override def doExecuteComet(): RDD[InternalRow] = {
     ColumnarToRowExec(this).doExecute()
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometBroadcastExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometBroadcastExchangeExec.scala
@@ -216,7 +216,7 @@ case class CometBroadcastExchangeExec(
     relationFuture
   }
 
-  override protected def doExecute(): RDD[InternalRow] = {
+  override protected def doExecuteComet(): RDD[InternalRow] = {
     throw QueryExecutionErrors.executeCodePathUnsupportedError("CometBroadcastExchangeExec")
   }
 
@@ -227,7 +227,7 @@ case class CometBroadcastExchangeExec(
     ColumnarToRowExec(this).executeCollect()
 
   // This is basically for unit test only, called by `executeCollect` indirectly.
-  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
+  override protected def doExecuteCometColumnar(): RDD[ColumnarBatch] = {
     val broadcasted = executeBroadcast[Array[ChunkedByteBuffer]]()
 
     new CometBatchRDD(sparkContext, getNumPartitions(), broadcasted)
@@ -245,7 +245,7 @@ case class CometBroadcastExchangeExec(
     new CometBatchRDD(sparkContext, numPartitions, broadcasted)
   }
 
-  override protected[sql] def doExecuteBroadcast[T](): broadcast.Broadcast[T] = {
+  override protected[sql] def doExecuteCometBroadcast[T](): broadcast.Broadcast[T] = {
     try {
       relationFuture.get(timeout, TimeUnit.SECONDS).asInstanceOf[broadcast.Broadcast[T]]
     } catch {

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometCoalesceExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometCoalesceExec.scala
@@ -57,7 +57,7 @@ case class CometCoalesceExec(
     child: SparkPlan)
     extends CometExec
     with UnaryExecNode {
-  protected override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+  protected override def doExecuteCometColumnar(): RDD[ColumnarBatch] = {
     val rdd = child.executeColumnar()
     if (numPartitions == 1 && rdd.getNumPartitions < 1) {
       // Make sure we don't output an RDD with 0 partitions, when claiming that we have a

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometCollectLimitExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometCollectLimitExec.scala
@@ -92,7 +92,7 @@ case class CometCollectLimitExec(
     if (offset > 0) rows.drop(offset) else rows
   }
 
-  protected override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+  protected override def doExecuteCometColumnar(): RDD[ColumnarBatch] = {
     val childRDD = child.executeColumnar()
     if (childRDD.getNumPartitions == 0) {
       CometExecUtils.emptyRDDWithPartitions(sparkContext, 1)

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometColumnarToRowExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometColumnarToRowExec.scala
@@ -72,7 +72,7 @@ case class CometColumnarToRowExec(child: SparkPlan)
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
     "numInputBatches" -> SQLMetrics.createMetric(sparkContext, "number of input batches"))
 
-  override def doExecute(): RDD[InternalRow] = {
+  override def doExecuteComet(): RDD[InternalRow] = {
     val numOutputRows = longMetric("numOutputRows")
     val numInputBatches = longMetric("numInputBatches")
     // This avoids calling `output` in the RDD closure, so that we don't need to include the entire
@@ -150,7 +150,7 @@ case class CometColumnarToRowExec(child: SparkPlan)
     }
   }
 
-  override def doExecuteBroadcast[T](): broadcast.Broadcast[T] = {
+  override def doExecuteCometBroadcast[T](): broadcast.Broadcast[T] = {
     if (cometBroadcastExchange.isEmpty) {
       throw new SparkException(
         "ColumnarToRowExec only supports doExecuteBroadcast when child contains a " +

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometIcebergNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometIcebergNativeScanExec.scala
@@ -293,7 +293,7 @@ case class CometIcebergNativeScanExec(
   }
 
   /** Executes using CometExecRDD - planning data is computed lazily on first access. */
-  override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+  override def doExecuteCometColumnar(): RDD[ColumnarBatch] = {
     val nativeMetrics = CometMetricNode.fromCometPlan(this)
     val serializedPlan = CometExec.serializeNativePlan(nativeOp)
     CometExecRDD(

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometLocalTableScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometLocalTableScanExec.scala
@@ -63,7 +63,7 @@ case class CometLocalTableScanExec(
     }
   }
 
-  override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+  override def doExecuteCometColumnar(): RDD[ColumnarBatch] = {
     val numInputRows = longMetric("numOutputRows")
     val maxRecordsPerBatch = CometConf.COMET_BATCH_SIZE.get(conf)
     val timeZoneId = conf.sessionLocalTimeZone

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeColumnarToRowExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeColumnarToRowExec.scala
@@ -155,7 +155,7 @@ case class CometNativeColumnarToRowExec(child: SparkPlan)
     }
   }
 
-  override def doExecuteBroadcast[T](): broadcast.Broadcast[T] = {
+  override def doExecuteCometBroadcast[T](): broadcast.Broadcast[T] = {
     if (cometBroadcastExchange.isEmpty) {
       throw new SparkException(
         "CometNativeColumnarToRowExec only supports doExecuteBroadcast when child contains a " +
@@ -184,7 +184,7 @@ case class CometNativeColumnarToRowExec(child: SparkPlan)
     }
   }
 
-  override def doExecute(): RDD[InternalRow] = {
+  override def doExecuteComet(): RDD[InternalRow] = {
     val numOutputRows = longMetric("numOutputRows")
     val numInputBatches = longMetric("numInputBatches")
     val convertTime = longMetric("convertTime")

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
@@ -165,7 +165,7 @@ case class CometNativeScanExec(
   def commonData: Array[Byte] = serializedPartitionData._1
   def perPartitionData: Array[Array[Byte]] = serializedPartitionData._2
 
-  override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+  override def doExecuteCometColumnar(): RDD[ColumnarBatch] = {
     val nativeMetrics = CometMetricNode.fromCometPlan(this)
     val serializedPlan = CometExec.serializeNativePlan(nativeOp)
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeWriteExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeWriteExec.scala
@@ -93,7 +93,7 @@ case class CometNativeWriteExec(
     "bytes_written" -> SQLMetrics.createSizeMetric(sparkContext, "written data"),
     "rows_written" -> SQLMetrics.createMetric(sparkContext, "number of written rows"))
 
-  override def doExecute(): RDD[InternalRow] = {
+  override def doExecuteComet(): RDD[InternalRow] = {
     // Setup job if committer is present
     committer.foreach { c =>
       val jobContext = createJobContext()
@@ -139,7 +139,7 @@ case class CometNativeWriteExec(
     sparkContext.emptyRDD[InternalRow]
   }
 
-  override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+  override def doExecuteCometColumnar(): RDD[ColumnarBatch] = {
     // Get the input data from the child operator
     val childRDD = if (child.supportsColumnar) {
       child.executeColumnar()

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometPlan.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometPlan.scala
@@ -19,9 +19,43 @@
 
 package org.apache.spark.sql.comet
 
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
  * The base trait for physical Comet operators.
+ *
+ * Wraps execution methods with error logging so that exceptions are logged with Comet-specific
+ * context before Spark can obscure them with generic INTERNAL_ERROR messages.
  */
-trait CometPlan extends SparkPlan
+trait CometPlan extends SparkPlan {
+
+  private def withErrorLogging[T](methodName: String)(body: => T): T = {
+    try { body }
+    catch {
+      case e: Throwable =>
+        logError(s"Error in Comet ${getClass.getSimpleName}.$methodName", e)
+        throw e
+    }
+  }
+
+  override def doExecuteColumnar(): RDD[ColumnarBatch] =
+    withErrorLogging("doExecuteColumnar") { doExecuteCometColumnar() }
+
+  override def doExecute(): RDD[InternalRow] =
+    withErrorLogging("doExecute") { doExecuteComet() }
+
+  override def doExecuteBroadcast[T](): Broadcast[T] =
+    withErrorLogging("doExecuteBroadcast") { doExecuteCometBroadcast() }
+
+  protected def doExecuteCometColumnar(): RDD[ColumnarBatch] =
+    super.doExecuteColumnar()
+
+  protected def doExecuteComet(): RDD[InternalRow]
+
+  protected def doExecuteCometBroadcast[T](): Broadcast[T] =
+    super.doExecuteBroadcast()
+}

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
@@ -287,11 +287,11 @@ case class CometScanExec(
       case _ => Map.empty
     })
 
-  protected override def doExecute(): RDD[InternalRow] = {
+  protected override def doExecuteComet(): RDD[InternalRow] = {
     ColumnarToRowExec(this).doExecute()
   }
 
-  protected override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+  protected override def doExecuteCometColumnar(): RDD[ColumnarBatch] = {
     val rdd = inputRDD.asInstanceOf[RDD[ColumnarBatch]]
 
     // These metrics are important for streaming solutions.

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometSparkToColumnarExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometSparkToColumnarExec.scala
@@ -46,11 +46,11 @@ case class CometSparkToColumnarExec(child: SparkPlan)
 
   override def outputOrdering: Seq[SortOrder] = child.outputOrdering
 
-  override protected def doExecute(): RDD[InternalRow] = {
+  override protected def doExecuteComet(): RDD[InternalRow] = {
     child.execute()
   }
 
-  override def doExecuteBroadcast[T](): Broadcast[T] = {
+  override def doExecuteCometBroadcast[T](): Broadcast[T] = {
     child.executeBroadcast()
   }
 
@@ -92,7 +92,7 @@ case class CometSparkToColumnarExec(child: SparkPlan)
     }
   }
 
-  override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+  override def doExecuteCometColumnar(): RDD[ColumnarBatch] = {
     val numInputRows = longMetric("numInputRows")
     val numOutputBatches = longMetric("numOutputBatches")
     val conversionTime = longMetric("conversionTime")

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometTakeOrderedAndProjectExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometTakeOrderedAndProjectExec.scala
@@ -121,7 +121,7 @@ case class CometTakeOrderedAndProjectExec(
   lazy val orderingSatisfies: Boolean =
     SortOrder.orderingSatisfies(child.outputOrdering, sortOrder)
 
-  protected override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+  protected override def doExecuteCometColumnar(): RDD[ColumnarBatch] = {
     val childRDD = child.executeColumnar()
     if (childRDD.getNumPartitions == 0 || limit == 0) {
       new ParallelCollectionRDD(sparkContext, Seq.empty[ColumnarBatch], 1, Map.empty)

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
@@ -169,7 +169,7 @@ case class CometShuffleExchangeExec(
         s"Unsupported shuffle type: ${shuffleType.getClass.getName}")
     }
 
-  protected override def doExecute(): RDD[InternalRow] = {
+  protected override def doExecuteComet(): RDD[InternalRow] = {
     ColumnarToRowExec(this).doExecute()
   }
 
@@ -186,7 +186,7 @@ case class CometShuffleExchangeExec(
   /**
    * Comet returns RDD[ColumnarBatch] for columnar execution.
    */
-  protected override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+  protected override def doExecuteCometColumnar(): RDD[ColumnarBatch] = {
     // Returns the same CometShuffledBatchRDD if this plan is used by multiple plans.
     if (cachedShuffleRDD == null) {
       cachedShuffleRDD = new CometShuffledBatchRDD(shuffleDependency, readMetrics)

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -246,7 +246,7 @@ abstract class CometExec extends CometPlan {
 
   override def output: Seq[Attribute] = originalPlan.output
 
-  override def doExecute(): RDD[InternalRow] =
+  override def doExecuteComet(): RDD[InternalRow] =
     ColumnarToRowExec(this).doExecute()
 
   override def executeCollect(): Array[InternalRow] =
@@ -418,7 +418,7 @@ abstract class CometNativeExec extends CometExec {
     runningSubqueries.clear()
   }
 
-  override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+  override def doExecuteCometColumnar(): RDD[ColumnarBatch] = {
     serializedPlanOpt.plan match {
       case None =>
         // This is in the middle of a native execution, it should not be executed directly.
@@ -1317,7 +1317,7 @@ case class CometUnionExec(
     children: Seq[SparkPlan])
     extends CometExec {
 
-  override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+  override def doExecuteCometColumnar(): RDD[ColumnarBatch] = {
     sparkContext.union(children.map(_.executeColumnar()))
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

When a `NullPointerException` or `AssertionError` occurs in Comet execution code, Spark's `QueryExecution.toInternalError` catches it and wraps it in a generic `[INTERNAL_ERROR] The "collect" action failed. You hit a bug in Spark or the Spark plugins you use.` message. This hides the original Comet context (which operator failed, what the root cause was), making it very difficult for users to debug or report issues.

## What changes are included in this PR?

Adds error logging in the `CometPlan` trait using the template method pattern:

- `CometPlan` now overrides `doExecuteColumnar`, `doExecute`, and `doExecuteBroadcast` with a `withErrorLogging` wrapper that catches exceptions, logs them with Comet-specific context (operator class name and method), and re-throws the original exception.
- All Comet operators now override `doExecuteCometColumnar`, `doExecuteComet`, and `doExecuteCometBroadcast` instead of the Spark methods directly.
- The original exception is preserved and re-thrown unchanged, but the Comet-specific context is captured in the logs before Spark has a chance to obscure it.

## How are these changes tested?

Verified manually by injecting a `NullPointerException` in `CometNativeExec.doExecuteCometColumnar` and running `CometExecSuite`. Confirmed that the error is logged with the Comet operator name and original cause before Spark wraps it.