### PR TITLE
chore: Register task completion listener to ensure CometExecIterator is always closed

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -135,7 +135,8 @@ class CometExecIterator(
   private var currentBatch: ColumnarBatch = null
   private var closed: Boolean = false
 
-  // Register a task completion listener to ensure native resources are released when the task is done.
+  // Register a task completion listener to ensure native resources are released
+  // when the task is done.
   TaskContext.get().addTaskCompletionListener[Unit] { _ =>
     this.close()
   }

--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -135,6 +135,11 @@ class CometExecIterator(
   private var currentBatch: ColumnarBatch = null
   private var closed: Boolean = false
 
+  // Register a task completion listener to ensure native resources are released when the task is done.
+  TaskContext.get().addTaskCompletionListener[Unit] { _ =>
+    this.close()
+  }
+
   private def getNextBatch: Option[ColumnarBatch] = {
     assert(partitionIndex >= 0 && partitionIndex < numParts)
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometExecRDD.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometExecRDD.scala
@@ -137,7 +137,6 @@ private[spark] class CometExecRDD(
 
     Option(context).foreach { ctx =>
       ctx.addTaskCompletionListener[Unit] { _ =>
-        it.close()
         subqueries.foreach(sub => CometScalarSubquery.removeSubquery(it.id, sub))
       }
     }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometTakeOrderedAndProjectExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometTakeOrderedAndProjectExec.scala
@@ -174,7 +174,6 @@ case class CometTakeOrderedAndProjectExec(
 
         Option(TaskContext.get()).foreach { context =>
           context.addTaskCompletionListener[Unit] { _ =>
-            it.close()
             cleanSubqueries(it.id, this)
           }
         }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

`CometExecIterator.close` is not always registered to the task completion listener, which may lead to leaks when task fails. Like:

https://github.com/apache/datafusion-comet/blob/29557ca898764057d8f314cb2334154030ba161e/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeWriteExec.scala#L207

https://github.com/apache/datafusion-comet/blob/29557ca898764057d8f314cb2334154030ba161e/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala#L99

## What changes are included in this PR?

Always register a task completion listener for `CometExecIterator.close`.

## How are these changes tested?

