### PR TITLE
docs: clarify Maven staging behavior across release candidates

### DIFF
--- a/docs/source/contributor-guide/release_process.md
+++ b/docs/source/contributor-guide/release_process.md
@@ -302,8 +302,13 @@ Creating Nexus staging repository
 In the Nexus repository UI (https://repository.apache.org/) locate and verify the artifacts in
 staging (https://central.sonatype.org/publish/release/#locate-and-examine-your-staging-repository).
 
-If the artifacts appear to be correct, then close and release the repository so it is made visible (this should
-actually happen automatically when running the script).
+The script closes the staging repository but does not release it. Releasing to Maven Central is a manual step
+performed only after the vote passes (see [Publishing Maven Artifacts](#publishing-maven-artifacts) below).
+
+Note that the Maven artifacts are always published under the final release version (e.g. `0.13.0`), not the RC
+version — the `-rc1` / `-rc2` suffix only appears in the git tag and the source tarball in SVN. Because the script
+creates a new staging repository on each run, re-staging the same version for a subsequent RC is supported as long
+as no staging repository for that version has been released to Maven Central.
 
 ### Create the Release Candidate Tarball
 
@@ -344,6 +349,13 @@ Voters can also use the `dev/release/verify-release-candidate.sh` script to assi
 If the vote does not pass, address the issues raised, increment the release candidate number, and repeat from
 the [Tag the Release Candidate](#tag-the-release-candidate) step. For example, the next attempt would be tagged
 `0.13.0-rc2`.
+
+Before staging the next RC, drop the previous RC's staging repository in the
+[Nexus UI](https://repository.apache.org/#stagingRepositories) by selecting it and clicking "Drop". This avoids
+leaving multiple closed staging repositories for the same version and prevents accidentally releasing the wrong
+one when the vote eventually passes. The Maven version (e.g. `0.13.0`) is shared across all RCs, so each run of
+`publish-to-maven.sh` creates a new staging repository for the same GAV — only one of them should ever be
+released to Maven Central.
 
 ## Publishing Binary Releases
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

The release process doc is ambiguous about how Maven staging works when a vote fails and a new RC is needed. Specifically:

- The doc says "close and release the repository so it is made visible (this should actually happen automatically when running the script)", but `publish-to-maven.sh` only calls the Nexus `finish` endpoint, which closes the staging repo — it does not release to Maven Central. Releasing is (correctly) a manual step performed later in `### Publishing Maven Artifacts`.
- The Maven version (`0.13.0`) is shared across all RCs — the `-rc1` / `-rc2` suffix only appears in the git tag and the SVN source tarball. Nothing in the doc explains this, which makes it unclear whether re-staging for rc2 is safe.
- "If the Vote Fails" doesn't mention dropping the previous RC's staging repo in Nexus, so multiple closed staging repos for the same version can accumulate and the release manager could accidentally release the wrong one.

## What changes are included in this PR?

- Correct the description of what `publish-to-maven.sh` does (closes only; does not release).
- Explain that Maven artifacts always use the final release version regardless of the RC number, and that re-staging the same version across RCs is supported as long as none has been released to Maven Central.
- Add a step to "If the Vote Fails" to drop the previous RC's staging repository in Nexus before staging the next RC.

## How are these changes tested?

Documentation-only change.