### PR TITLE
fix: exclude tpcds-plan-stability extended.txt files from rat license check

### DIFF
--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -24,6 +24,7 @@ spark/src/test/resources/tpcds-query-results/*.out
 spark/src/test/resources/tpcds-micro-benchmarks/*.sql
 spark/src/test/resources/tpcds-plan-stability/approved-plans*/**/explain.txt
 spark/src/test/resources/tpcds-plan-stability/approved-plans*/**/simplified.txt
+spark/src/test/resources/tpcds-plan-stability/approved-plans*/**/extended.txt
 spark/src/test/resources/tpch-query-results/*.out
 spark/src/test/resources/tpch-extended/q*.sql
 spark/src/test/resources/test-data/*.csv


### PR DESCRIPTION
## Which issue does this PR close?

Closes #2810.

## Rationale for this change

Fix an issue I run into on every release.

## What changes are included in this PR?

Add `spark/src/test/resources/tpcds-plan-stability/approved-plans*/**/extended.txt` to `dev/release/rat_exclude_files.txt`.

## How are these changes tested?

Manually