### PR TITLE
debug: config-gated assertion for columnar-to-row transition invariant [do not merge]

### DIFF
--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -626,7 +626,7 @@ object CometConf extends ShimCometConf {
           "post-rule plan has a columnar child. Intended for debugging intermittent " +
           "bad-plan shapes; off by default.")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val COMET_LOG_FALLBACK_REASONS: ConfigEntry[Boolean] =
     conf("spark.comet.logFallbackReasons.enabled")

--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -618,6 +618,16 @@ object CometConf extends ShimCometConf {
       .booleanConf
       .createWithDefault(false)
 
+  val COMET_ASSERT_VALID_PLAN_TRANSITIONS: ConfigEntry[Boolean] =
+    conf("spark.comet.assertValidPlanTransitions.enabled")
+      .category(CATEGORY_EXEC_EXPLAIN)
+      .doc(
+        "When enabled, Comet asserts that every columnar-to-row transition in the " +
+          "post-rule plan has a columnar child. Intended for debugging intermittent " +
+          "bad-plan shapes; off by default.")
+      .booleanConf
+      .createWithDefault(false)
+
   val COMET_LOG_FALLBACK_REASONS: ConfigEntry[Boolean] =
     conf("spark.comet.logFallbackReasons.enabled")
       .category(CATEGORY_EXEC_EXPLAIN)

--- a/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
@@ -57,6 +57,7 @@ case class EliminateRedundantTransitions(session: SparkSession) extends Rule[Spa
 
   override def apply(plan: SparkPlan): SparkPlan = {
     val newPlan = _apply(plan)
+    checkTransitionInvariant(newPlan)
     if (showTransformations && !newPlan.fastEquals(plan)) {
       logInfo(s"""
            |=== Applying Rule $ruleName ===
@@ -64,6 +65,29 @@ case class EliminateRedundantTransitions(session: SparkSession) extends Rule[Spa
            |""".stripMargin)
     }
     newPlan
+  }
+
+  // Diagnostic only: every columnar-to-row transition must have a columnar child.
+  // Intended to surface the bad-plan shape reported after #3879 as a loud
+  // driver-side failure instead of a runtime symptom. Remove once root cause
+  // is identified.
+  private def checkTransitionInvariant(plan: SparkPlan): Unit = {
+    plan.foreach {
+      case c: ColumnarToRowExec if !c.child.supportsColumnar =>
+        val cls = c.child.getClass.getName
+        throw new IllegalStateException(
+          s"ColumnarToRowExec wraps non-columnar child ($cls):\n" + plan.treeString)
+      case c: CometColumnarToRowExec if !c.child.supportsColumnar =>
+        val cls = c.child.getClass.getName
+        throw new IllegalStateException(
+          s"CometColumnarToRowExec wraps non-columnar child ($cls):\n" + plan.treeString)
+      case c: CometNativeColumnarToRowExec if !c.child.supportsColumnar =>
+        val cls = c.child.getClass.getName
+        throw new IllegalStateException(
+          s"CometNativeColumnarToRowExec wraps non-columnar child ($cls):\n" +
+            plan.treeString)
+      case _ =>
+    }
   }
 
   private def _apply(plan: SparkPlan): SparkPlan = {

--- a/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
@@ -54,10 +54,14 @@ import org.apache.comet.CometConf
 case class EliminateRedundantTransitions(session: SparkSession) extends Rule[SparkPlan] {
 
   private lazy val showTransformations = CometConf.COMET_EXPLAIN_TRANSFORMATIONS.get()
+  private lazy val assertValidPlanTransitions =
+    CometConf.COMET_ASSERT_VALID_PLAN_TRANSITIONS.get()
 
   override def apply(plan: SparkPlan): SparkPlan = {
     val newPlan = _apply(plan)
-    checkTransitionInvariant(newPlan)
+    if (assertValidPlanTransitions) {
+      checkTransitionInvariant(newPlan)
+    }
     if (showTransformations && !newPlan.fastEquals(plan)) {
       logInfo(s"""
            |=== Applying Rule $ruleName ===
@@ -67,10 +71,9 @@ case class EliminateRedundantTransitions(session: SparkSession) extends Rule[Spa
     newPlan
   }
 
-  // Diagnostic only: every columnar-to-row transition must have a columnar child.
-  // Intended to surface the bad-plan shape reported after #3879 as a loud
-  // driver-side failure instead of a runtime symptom. Remove once root cause
-  // is identified.
+  // Gated by spark.comet.assertValidPlanTransitions.enabled.
+  // Every columnar-to-row transition must have a columnar child; violations
+  // indicate a bad plan produced by an earlier rule.
   private def checkTransitionInvariant(plan: SparkPlan): Unit = {
     plan.foreach {
       case c: ColumnarToRowExec if !c.child.supportsColumnar =>


### PR DESCRIPTION
## Which issue does this PR close?

Diagnostic probe for a customer-reported issue following #3879. No issue filed yet.

## Rationale for this change

A user reports a plan in which Spark's \`ColumnarToRowExec\` ends up wrapping a child whose \`supportsColumnar == false\`. The initial plan (before AQE) is clean; the bad shape emerges after AQE re-planning. Not reproduced locally across several configuration sweeps.

This adds an off-by-default diagnostic that surfaces the bad plan as a loud driver-side failure with the full offending subtree, instead of a runtime symptom that is hard to trace back. Leaving it in as a gated config means it stays available for future transition regressions at zero production cost.

## What changes are included in this PR?

- New config \`spark.comet.assertValidPlanTransitions.enabled\` (default: \`false\`) under the \`exec_explain\` category.
- When enabled, \`EliminateRedundantTransitions.apply\` walks the post-rule plan and throws \`IllegalStateException\` if any of the following wraps a non-columnar child:
  - Spark's \`ColumnarToRowExec\`
  - \`CometColumnarToRowExec\`
  - \`CometNativeColumnarToRowExec\`

  The exception message includes the offending child's class name and the full \`treeString\`.

## How are these changes tested?

Built against \`main\` and exercised a local DPP + AQE sweep (V1/V2 sources, skew/coalesce, chained joins) with the config enabled. The assertion does not fire on clean plans. The intent is for the customer to set the flag and re-run their failing query so we can capture the offending plan shape.