### PR TITLE
test: add sql-file test confirming fallback on parquet variant reads

### DIFF
--- a/spark/src/test/resources/sql-tests/expressions/misc/variant.sql
+++ b/spark/src/test/resources/sql-tests/expressions/misc/variant.sql
@@ -1,0 +1,55 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Confirms Comet falls back to Spark when a parquet scan's schema contains a
+-- VariantType column. VariantType is a Spark 4.0+ data type that Comet does
+-- not currently support, so any scan exposing it must be executed by Spark.
+
+-- MinSparkVersion: 4.0
+
+statement
+CREATE TABLE test_variant(id INT, v VARIANT) USING parquet
+
+statement
+INSERT INTO test_variant VALUES
+  (1, parse_json('{"a": 1, "b": "hello"}')),
+  (2, parse_json('{"a": 2, "b": "world"}')),
+  (3, parse_json('null')),
+  (4, NULL)
+
+query expect_fallback(Unsupported v of type VariantType)
+SELECT id, v FROM test_variant ORDER BY id
+
+query expect_fallback(Unsupported v of type VariantType)
+SELECT variant_get(v, '$.a', 'int') AS a FROM test_variant ORDER BY id
+
+query expect_fallback(Unsupported v of type VariantType)
+SELECT id FROM test_variant WHERE variant_get(v, '$.a', 'int') = 1
+
+query expect_fallback(Unsupported v of type VariantType)
+SELECT COUNT(*) FROM test_variant WHERE v IS NOT NULL
+
+statement
+CREATE TABLE test_variant_struct(id INT, s STRUCT<v: VARIANT>) USING parquet
+
+statement
+INSERT INTO test_variant_struct VALUES
+  (1, named_struct('v', parse_json('{"x": 10}'))),
+  (2, named_struct('v', parse_json('{"x": 20}')))
+
+query expect_fallback(Unsupported v of type VariantType)
+SELECT id, s FROM test_variant_struct ORDER BY id


### PR DESCRIPTION
## Which issue does this PR close?

Part of #1637

## Rationale for this change

Comet does not support Spark 4.0's `VARIANT` data type, so scans exposing a VariantType column must fall back to Spark. There is no regression test pinning this behavior today. If a future change silently lets a VariantType column through the scan, we would only notice through runtime errors or wrong results. A targeted sql-file test locks in the fallback contract.

## What changes are included in this PR?

- New file `spark/src/test/resources/sql-tests/expressions/misc/variant.sql`
- Gated with `-- MinSparkVersion: 4.0` so it is skipped on Spark 3.4 / 3.5 via `CometSqlFileTestSuite`
- Creates parquet-backed tables with a `VARIANT` column (directly and nested inside `STRUCT<v: VARIANT>`), populated via `parse_json`
- Uses `query expect_fallback(Unsupported v of type VariantType)` on five queries covering projection, `variant_get` extraction, `variant_get` in a predicate, a `COUNT(*)` with a not-null filter, and a struct-containing-variant projection

## How are these changes tested?

Ran the new test under the Spark 4.0 profile:

```
./mvnw test -Pspark-4.0 -Dsuites="org.apache.comet.CometSqlFileTestSuite variant" -Dtest=none
```

All five queries in the file fall back with the expected reason and the suite reports `Tests: succeeded 1, failed 0`.