### PR TITLE
test: fix SparkToColumnar plan-shape assertions on Spark 4

### DIFF
--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -2388,8 +2388,6 @@ class CometExecSuite extends CometTestBase {
   }
 
   test("SparkToColumnar eliminate redundant in AQE") {
-    // TODO fix for Spark 4.0.0
-    assume(!isSpark40Plus)
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       CometConf.COMET_SHUFFLE_MODE.key -> "jvm") {
@@ -2404,7 +2402,10 @@ class CometExecSuite extends CometTestBase {
       val planAfter = df.queryExecution.executedPlan
       assert(planAfter.toString.startsWith("AdaptiveSparkPlan isFinalPlan=true"))
       val adaptivePlan = planAfter.asInstanceOf[AdaptiveSparkPlanExec].executedPlan
-      val numOperators = adaptivePlan.collect { case c: CometSparkToColumnarExec =>
+      // Use AdaptiveSparkPlanHelper.collect so traversal descends through QueryStageExec.plan;
+      // Spark 4 wraps the final plan in ResultQueryStageExec (a LeafExecNode) that
+      // SparkPlan.collect would otherwise stop at.
+      val numOperators = collect(adaptivePlan) { case c: CometSparkToColumnarExec =>
         c
       }
       assert(numOperators.length == 1)
@@ -2478,8 +2479,6 @@ class CometExecSuite extends CometTestBase {
   }
 
   test("SparkToColumnar override node name for row input") {
-    // TODO fix for Spark 4.0.0
-    assume(!isSpark40Plus)
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       CometConf.COMET_SHUFFLE_MODE.key -> "jvm") {
@@ -2494,7 +2493,8 @@ class CometExecSuite extends CometTestBase {
       val planAfter = df.queryExecution.executedPlan
       assert(planAfter.toString.startsWith("AdaptiveSparkPlan isFinalPlan=true"))
       val adaptivePlan = planAfter.asInstanceOf[AdaptiveSparkPlanExec].executedPlan
-      val nodeNames = adaptivePlan.collect { case c: CometSparkToColumnarExec =>
+      // See comment in the "eliminate redundant in AQE" test about AdaptiveSparkPlanHelper.collect.
+      val nodeNames = collect(adaptivePlan) { case c: CometSparkToColumnarExec =>
         c.nodeName
       }
       assert(nodeNames.length == 1)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4031.

## Rationale for this change

Two tests in `CometExecSuite` (`SparkToColumnar eliminate redundant in AQE` and `SparkToColumnar override node name for row input`) were skipped on Spark 4 via `assume(!isSpark40Plus)`. When the guards are removed they both fail with `List() had length 0 instead of expected length 1`: the tests look for exactly one `CometSparkToColumnarExec` in the final AQE plan and find zero.

The `CometSparkToColumnarExec` insertion is actually working correctly. Spark 4 introduced `ResultQueryStageExec`, which extends `LeafExecNode` and now wraps the final plan exposed by `AdaptiveSparkPlanExec.executedPlan`. The tests used `SparkPlan.collect`, which treats a `LeafExecNode` as opaque and does not descend into `QueryStageExec.plan`, so the node was invisible to the assertion.

## What changes are included in this PR?

- Switch the two affected assertions to use `collect` from `AdaptiveSparkPlanHelper` (already mixed into `CometTestBase`). The helper's `collect` descends through `AdaptiveSparkPlanExec` and `QueryStageExec.plan` via `allChildren`, so it works identically on Spark 3.4 / 3.5 (where the top-level plan is not wrapped in a `ResultQueryStageExec`) and Spark 4.
- Remove the `assume(!isSpark40Plus)` guards that were disabling the tests on Spark 4.

## How are these changes tested?

The two previously skipped tests now run and pass on Spark 4. Verified with:

```
./mvnw test -Pspark-4.0 -Dtest=none -Dsuites='org.apache.comet.exec.CometExecSuite SparkToColumnar'
```

All 9 `SparkToColumnar*` tests pass. Also verified on the default Spark 3.5 profile; all 9 still pass.