### PR TITLE
ci: add Spark 4.0 / JDK 21 profile

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -81,7 +81,7 @@ jobs:
     container:
       image: amd64/rust
       env:
-        JAVA_TOOL_OPTIONS: ${{ matrix.profile.java_version == '17' && '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED' || '' }}
+        JAVA_TOOL_OPTIONS: ${{ (matrix.profile.java_version == '17' || matrix.profile.java_version == '21') && '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED' || '' }}
     strategy:
       matrix:
         profile:
@@ -93,6 +93,9 @@ jobs:
             maven_opts: "-Pspark-3.5 -Pscala-2.12"
           - name: "Spark 4.0, JDK 17"
             java_version: "17"
+            maven_opts: "-Pspark-4.0"
+          - name: "Spark 4.0, JDK 21"
+            java_version: "21"
             maven_opts: "-Pspark-4.0"
           # Spark 4.1 is intentionally absent: the lint job invokes -Psemanticdb,
           # but semanticdb-scalac_2.13.17 is not yet published, so we cannot
@@ -293,6 +296,11 @@ jobs:
             maven_opts: "-Pspark-4.0"
             scan_impl: "auto"
 
+          - name: "Spark 4.0, JDK 21"
+            java_version: "21"
+            maven_opts: "-Pspark-4.0"
+            scan_impl: "auto"
+
           - name: "Spark 4.1, JDK 17"
             java_version: "17"
             maven_opts: "-Pspark-4.1"
@@ -388,7 +396,7 @@ jobs:
     container:
       image: amd64/rust
       env:
-        JAVA_TOOL_OPTIONS: ${{ matrix.profile.java_version == '17' && '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED' || '' }}
+        JAVA_TOOL_OPTIONS: ${{ (matrix.profile.java_version == '17' || matrix.profile.java_version == '21') && '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED' || '' }}
 
     steps:
       - uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0  # v2.1.0

--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -176,6 +176,14 @@ jobs:
           fi
         env:
           LC_ALL: "C.UTF-8"
+          # Mirror Spark's own JDK 21 / 25 CI workaround. apache/spark's
+          # build_java21.yml and build_java25.yml set this same env var to
+          # process-isolate the V1/V2 Parquet and Orc source suites because
+          # they exhibit cross-suite resource interactions (file-stream and
+          # thread leaks) under the newer JDKs. project/SparkBuild.scala
+          # reads DEDICATED_JVM_SBT_TESTS and forks a separate JVM per
+          # listed suite. Empty value is a safe no-op.
+          DEDICATED_JVM_SBT_TESTS: ${{ matrix.config.spark-short == '4.0' && 'org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormatV1Suite,org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormatV2Suite,org.apache.spark.sql.execution.datasources.orc.OrcSourceV1Suite,org.apache.spark.sql.execution.datasources.orc.OrcSourceV2Suite' || '' }}
       - name: Upload fallback log
         if: ${{ github.event.inputs.collect-fallback-logs == 'true' }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -141,6 +141,7 @@ jobs:
           - {spark-short: '3.4', spark-full: '3.4.3', java: 11, scan-impl: 'auto'}
           - {spark-short: '3.5', spark-full: '3.5.8', java: 11, scan-impl: 'auto'}
           - {spark-short: '4.0', spark-full: '4.0.2', java: 17, scan-impl: 'auto'}
+          - {spark-short: '4.0', spark-full: '4.0.2', java: 21, scan-impl: 'auto'}
       fail-fast: false
     name: spark-sql-${{ matrix.config.scan-impl }}-${{ matrix.module.name }}/spark-${{ matrix.config.spark-full }}
     runs-on: ${{ matrix.os }}

--- a/docs/source/user-guide/latest/installation.md
+++ b/docs/source/user-guide/latest/installation.md
@@ -43,7 +43,7 @@ Other versions may work well enough for development and evaluation purposes.
 | ------------- | ------------ | ------------- | ----------------- | --------------------- |
 | 3.4.3         | 11/17        | 2.12/2.13     | Yes               | Yes                   |
 | 3.5.8         | 11/17        | 2.12/2.13     | Yes               | Yes                   |
-| 4.0.2         | 17           | 2.13          | Yes               | Yes                   |
+| 4.0.2         | 17/21        | 2.13          | Yes               | Yes                   |
 
 Note that we do not test the full matrix of supported Java and Scala versions in CI for every Spark version.
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4059

## Rationale for this change

Spark 4 officially supports both Java 17 and 21 ([ref](https://spark.apache.org/docs/4.0.1/)). The current Comet CI and compatibility docs only cover Java 17 for Spark 4.0, which leaves Java 21 — an LTS release, widely adopted across the Spark / Arrow / Netty / Iceberg / Delta stack — without official validation.

This PR adds Java 21 as a supported runtime for the experimental Spark 4.0 tier so downstream consumers can adopt it with an upstream signal.

## What changes are included in this PR?

Two commits:

**1. `ci: add Spark 4.0 / JDK 21 profile`**
- `.github/workflows/pr_build_linux.yml`: add a `Spark 4.0, JDK 21` profile next to the existing `Spark 4.0, JDK 17` profile in both matrix sections. Extend the conditional `JAVA_TOOL_OPTIONS` so the existing `--add-opens` / `--add-exports` flags also apply under JDK 21 (they remain valid — same set Spark 4's own launcher scripts use for both JDK versions).
- `.github/workflows/spark_sql_test.yml`: add `{spark-short: '4.0', spark-full: '4.0.1', java: 21, scan-impl: 'auto'}` to the `config:` matrix.
- `docs/source/user-guide/latest/installation.md`: update the Spark 4.0.1 row of the experimental compatibility table from `17` to `17/21`.

**2. `ci: process-isolate V1/V2 Parquet and Orc suites for Spark 4`**
- `.github/workflows/spark_sql_test.yml`: set the `DEDICATED_JVM_SBT_TESTS` env var on the sbt invocation, conditional on Spark 4.0. Mirrors apache/spark's own JDK 21 CI (`build_java21.yml` and the `build_branch40_java21.yml` / `build_branch41_java21.yml` variants), which classify `ParquetFileFormatV1Suite`, `ParquetFileFormatV2Suite`, `OrcSourceV1Suite`, and `OrcSourceV2Suite` as needing dedicated JVM isolation due to cross-suite resource contamination (file-stream and thread leaks) under JDK 21. `project/SparkBuild.scala` reads the env var and forks a separate JVM per listed suite. Without this, the `sql_core-1` matrix row aborts under JDK 21 on `ParquetFileFormatV2Suite`'s `afterEach` file-stream leak detector — the same suite Spark itself isolates.

Skipped because they have no Spark 4 rows to mirror:
- `spark_sql_test_native_iceberg_compat.yml` (Spark 3.4/3.5 × Java 11 only)
- `iceberg_spark_test.yml` (Spark 3.4/3.5 × Java 11/17 only)

## How are these changes tested?

By the CI itself — this PR's purpose is to add the test profile. The new matrix rows exercise the existing full test suite under a JDK 21 runtime; any genuine incompatibility surfaces as a row-specific failure. If the JDK 21 rows go green, Comet can legitimately claim JDK 21 support for Spark 4 in the compatibility matrix.

The `--add-opens` / `--add-exports` flag set is the same one Spark 4 ships in its launcher scripts for both JDK 17 and 21, so no flag divergence is expected. The dedicated-JVM env var in the second commit is byte-for-byte the same value Spark's own JDK 21 CI uses, so it inherits Spark's well-tested mitigation rather than introducing a novel exclusion mechanism.

Additionally, I've run comet a bit in JDK 21 successfully, but not extensively.