### PR TITLE
ci: add concurrency blocks to more workflows to cancel on new commit

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,10 @@
 
 name: "CodeQL"
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -17,6 +17,10 @@
 
 name: Run Miri Safety Checks
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/pr_missing_suites.yml
+++ b/.github/workflows/pr_missing_suites.yml
@@ -17,6 +17,10 @@
 
 name: Check that all test suites are added to PR workflows
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/validate_workflows.yml
+++ b/.github/workflows/validate_workflows.yml
@@ -17,6 +17,10 @@
 
 name: Validate Github Workflows
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

Several workflows were missing the `concurrency` block, meaning in-progress CI runs were not cancelled when new commits were pushed. This is especially wasteful for the Miri workflow, which is long-running. The other three (`codeql`, `pr_missing_suites`, `validate_workflows`) are short but should be consistent with the rest of the repo.

## What changes are included in this PR?

Adds `concurrency` with `cancel-in-progress: true` to four workflows:

- `miri.yml`
- `codeql.yml`
- `pr_missing_suites.yml`
- `validate_workflows.yml`

## How are these changes tested?

Workflow syntax only. The `concurrency` block is already used by all other PR-triggered workflows in this repo.
