### PR TITLE
chore: gitignore generated docs directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ spark/benchmarks
 comet-event-trace.json
 __pycache__
 output
+docs/comet-*/
+docs/build/
+docs/temp/


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

`docs/build.sh` and `docs/generate-versions.py` produce three kinds of build artifacts under `docs/`: per-release clones (`docs/comet-0.XX/`), the Sphinx output (`docs/build/`), and the staging tree (`docs/temp/`). None of these are gitignored, so every local docs build leaves them as untracked files. That noise makes `git status` hard to read and invites accidental inclusion in commits.

## What changes are included in this PR?

Add `docs/comet-*/`, `docs/build/`, and `docs/temp/` to `.gitignore`.

## How are these changes tested?

Verified locally that `git check-ignore` matches the three paths and that they no longer appear in `git status`.