### PR TITLE
docs: Improve Spark version compatibility & ANSI mode documentation [WIP]

### DIFF
--- a/docs/source/user-guide/latest/compatibility/expressions/cast.md
+++ b/docs/source/user-guide/latest/compatibility/expressions/cast.md
@@ -34,8 +34,6 @@ Cast operations in Comet fall into three levels of support:
 
 Cast will fall back to Spark in some cases when ANSI mode is enabled. This can be enabled by setting `spark.comet.expression.Cast.allowIncompatible=true`. See the [Comet Supported Expressions Guide](../../expressions.md) for more information on this configuration setting.
 
-There is an [epic](https://github.com/apache/datafusion-comet/issues/313) where we are tracking the work to fully implement ANSI support.
-
 ## String to Decimal
 
 Comet's native `CAST(string AS DECIMAL)` implementation matches Apache Spark's behavior,

--- a/docs/source/user-guide/latest/compatibility/index.md
+++ b/docs/source/user-guide/latest/compatibility/index.md
@@ -28,6 +28,7 @@ This guide documents areas where Comet's behavior is known to differ from Spark.
 - **Regular expressions**: differences between the Rust regexp crate and Java's regex engine.
 - **Operators**: operator-level compatibility notes, including window functions and round-robin partitioning.
 - **Expressions**: per-expression compatibility notes, including cast.
+- **Spark versions**: differences between supported Spark versions, including Spark 4.0 specific gaps.
 
 ```{toctree}
 :maxdepth: 1
@@ -37,4 +38,5 @@ floating-point
 regex
 operators
 expressions/index
+spark-versions
 ```

--- a/docs/source/user-guide/latest/compatibility/scans.md
+++ b/docs/source/user-guide/latest/compatibility/scans.md
@@ -59,7 +59,7 @@ The following shared limitation may produce incorrect results without falling ba
 
 ## `native_datafusion` Limitations
 
-The `native_datafusion` scan has some additional limitations, mostly related to Parquet metadata. All of these
+The `native_datafusion` scan has some additional limitations, mostly related to Parquet metadata. The following
 cause Comet to fall back to Spark (including when using `auto` mode). Note that the `native_datafusion` scan
 requires `spark.comet.exec.enabled=true` because the scan node must be wrapped by `CometExecRule`.
 
@@ -71,6 +71,18 @@ requires `spark.comet.exec.enabled=true` because the scan node must be wrapped b
 - Duplicate field names in case-insensitive mode (e.g., a Parquet file with both `B` and `b` columns)
   are detected at read time and raise a `SparkRuntimeException` with error class `_LEGACY_ERROR_TEMP_2093`,
   matching Spark's behavior.
+
+The following limitation may produce different behavior or incorrect results without falling back to Spark:
+
+- Silent type coercion on Parquet schema mismatch. When the requested read schema does not match the
+  Parquet file's physical schema, Spark's vectorized reader normally throws a `SparkException`. The
+  `native_datafusion` scan inherits DataFusion's more permissive reader, which silently accepts or
+  coerces many of these reads. For value-preserving widenings (such as `INT32` read as `INT64`) the data
+  is read correctly but no exception is raised, which differs from Spark 3.x behavior. For incompatible
+  reads (such as binary read as timestamp, `TimestampLTZ` read as `TimestampNTZ`, or decimals with
+  incompatible precision/scale) the result may be incorrect. See
+  [issue #3720](https://github.com/apache/datafusion-comet/issues/3720) for the affected cases. This
+  applies on all supported Spark versions.
 
 ## `native_iceberg_compat` Limitations
 

--- a/docs/source/user-guide/latest/compatibility/spark-versions.md
+++ b/docs/source/user-guide/latest/compatibility/spark-versions.md
@@ -1,0 +1,59 @@
+<!---
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Spark Version Compatibility
+
+Comet supports Apache Spark 3.4, 3.5, and 4.0. This page documents differences
+between supported Spark versions. For per-feature compatibility notes that
+apply across versions, see the other pages in this guide.
+
+## Spark 4.0
+
+Comet works with Spark 4.0 and runs the full Comet test suite plus a subset of
+the Spark SQL test suite in CI. Most workloads that run on Spark 3.5 will run
+on Spark 4.0 with the same level of acceleration. The known gaps below are
+specific to Spark 4.0 features that Comet has not yet implemented; in each case
+Comet falls back to Spark rather than producing incorrect results.
+
+### ANSI mode
+
+Spark 4.0 enables ANSI mode by default. Comet has good coverage for ANSI
+behavior across arithmetic, cast, and other expressions, and falls back to
+Spark for the cases that are not yet supported. See the
+[Cast compatibility](expressions/cast.md) page for cast-specific notes and
+the [tracking epic](https://github.com/apache/datafusion-comet/issues/313)
+for ongoing ANSI work.
+
+### Variant type
+
+The `VariantType` introduced in Spark 4.0 is not yet supported. Queries that
+read or produce variant columns will fall back to Spark.
+
+### Parquet type widening
+
+Spark 4.0 added broader support for reading Parquet files with widened types
+(for example, reading an `INT32` column as `BIGINT`). Comet supports the
+common integer widenings but does not yet cover the full set that Spark
+supports. Unsupported widenings cause a fallback to Spark.
+
+## Spark 3.4 and 3.5
+
+Spark 3.4 and 3.5 are the most thoroughly exercised versions in CI and are
+suitable for production use. There are no version-specific gaps to call out
+beyond the per-feature compatibility notes in the rest of this guide.

--- a/docs/source/user-guide/latest/compatibility/spark-versions.md
+++ b/docs/source/user-guide/latest/compatibility/spark-versions.md
@@ -43,6 +43,24 @@ behavior across arithmetic, aggregates, and most cast expressions. A few
 `Cast` source/target combinations still fall back to Spark in ANSI mode;
 see the [Cast compatibility](expressions/cast.md) page for details.
 
+### Non-default collations
+
+Spark 4.0 adds collation support for `StringType` columns. Comet's native
+hashing, equality, and ordering compare raw UTF-8 bytes, which would put
+rows that compare equal under a non-default collation into different
+groups, partitions, or sort positions. Operations on columns with a
+non-default collation (group-by, distinct, sort, join keys, hash and
+range partitioning in shuffle) fall back to Spark. Columns using the
+session-default collation are unaffected.
+
+### V2 bucketing with partial cluster distribution
+
+Spark 4.0's DataSource V2 bucketing supports partially clustered
+distribution for storage-partitioned joins
+(`spark.sql.sources.v2.bucketing.partiallyClusteredDistribution.enabled`).
+Comet does not yet support this distribution and falls back to Spark for
+the affected exchange.
+
 ### Variant type
 
 The `VariantType` introduced in Spark 4.0 is not yet supported. Queries that

--- a/docs/source/user-guide/latest/compatibility/spark-versions.md
+++ b/docs/source/user-guide/latest/compatibility/spark-versions.md
@@ -39,10 +39,10 @@ specific to Spark 4.0 features that Comet has not yet implemented.
 ### ANSI mode
 
 Spark 4.0 enables ANSI mode by default. Comet has good coverage for ANSI
-behavior across arithmetic, cast, and other expressions. A few cases still
-fall back to Spark, including `Sum` and `Average` aggregates in ANSI mode
-and some `Cast` expressions; see the
-[Cast compatibility](expressions/cast.md) page for cast-specific notes.
+behavior across arithmetic, aggregates (including `Sum` and `Average`),
+and most cast expressions. A few `Cast` source/target combinations still
+fall back to Spark in ANSI mode; see the
+[Cast compatibility](expressions/cast.md) page for details.
 
 ### Variant type
 

--- a/docs/source/user-guide/latest/compatibility/spark-versions.md
+++ b/docs/source/user-guide/latest/compatibility/spark-versions.md
@@ -39,11 +39,10 @@ specific to Spark 4.0 features that Comet has not yet implemented.
 ### ANSI mode
 
 Spark 4.0 enables ANSI mode by default. Comet has good coverage for ANSI
-behavior across arithmetic, cast, and other expressions, and falls back to
-Spark for the cases that are not yet supported. See the
-[Cast compatibility](expressions/cast.md) page for cast-specific notes and
-the [tracking epic](https://github.com/apache/datafusion-comet/issues/313)
-for ongoing ANSI work.
+behavior across arithmetic, cast, and other expressions. A few cases still
+fall back to Spark, including `Sum` and `Average` aggregates in ANSI mode
+and some `Cast` expressions; see the
+[Cast compatibility](expressions/cast.md) page for cast-specific notes.
 
 ### Variant type
 

--- a/docs/source/user-guide/latest/compatibility/spark-versions.md
+++ b/docs/source/user-guide/latest/compatibility/spark-versions.md
@@ -69,8 +69,13 @@ read or produce variant columns fall back to Spark.
 ### Parquet type widening
 
 Spark 4.0 added broader support for reading Parquet files with widened types
-(for example, reading an `INT32` column as `BIGINT`). Comet supports the
-common integer widenings but does not yet cover the full set that Spark
-supports. Unsupported widenings are not detected as a fallback condition,
-so queries that rely on them may fail or return incorrect results rather
-than transparently falling back to Spark.
+(for example, reading an `INT32` column as `BIGINT`). Comet covers the common
+integer and floating-point widenings but does not yet implement the full set
+that Spark 4.0 supports, and unsupported widenings are not detected as a
+fallback condition.
+
+The underlying scan behavior, including silent acceptance of schema mismatches
+that Spark would reject, is documented under
+[`native_datafusion` Limitations](scans.md#native_datafusion-limitations) and
+applies on all supported Spark versions. Spark 4.0 exercises more of these
+paths because of its expanded widening rules.

--- a/docs/source/user-guide/latest/compatibility/spark-versions.md
+++ b/docs/source/user-guide/latest/compatibility/spark-versions.md
@@ -39,10 +39,9 @@ specific to Spark 4.0 features that Comet has not yet implemented.
 ### ANSI mode
 
 Spark 4.0 enables ANSI mode by default. Comet has good coverage for ANSI
-behavior across arithmetic, aggregates (including `Sum` and `Average`),
-and most cast expressions. A few `Cast` source/target combinations still
-fall back to Spark in ANSI mode; see the
-[Cast compatibility](expressions/cast.md) page for details.
+behavior across arithmetic, aggregates, and most cast expressions. A few
+`Cast` source/target combinations still fall back to Spark in ANSI mode;
+see the [Cast compatibility](expressions/cast.md) page for details.
 
 ### Variant type
 

--- a/docs/source/user-guide/latest/compatibility/spark-versions.md
+++ b/docs/source/user-guide/latest/compatibility/spark-versions.md
@@ -23,13 +23,18 @@ Comet supports Apache Spark 3.4, 3.5, and 4.0. This page documents differences
 between supported Spark versions. For per-feature compatibility notes that
 apply across versions, see the other pages in this guide.
 
+## Spark 3.4 and 3.5
+
+Spark 3.4 and 3.5 are the most thoroughly exercised versions in CI and are
+suitable for production use. There are no version-specific gaps to call out
+beyond the per-feature compatibility notes in the rest of this guide.
+
 ## Spark 4.0
 
 Comet works with Spark 4.0 and runs the full Comet test suite plus a subset of
 the Spark SQL test suite in CI. Most workloads that run on Spark 3.5 will run
 on Spark 4.0 with the same level of acceleration. The known gaps below are
-specific to Spark 4.0 features that Comet has not yet implemented; in each case
-Comet falls back to Spark rather than producing incorrect results.
+specific to Spark 4.0 features that Comet has not yet implemented.
 
 ### ANSI mode
 
@@ -43,17 +48,13 @@ for ongoing ANSI work.
 ### Variant type
 
 The `VariantType` introduced in Spark 4.0 is not yet supported. Queries that
-read or produce variant columns will fall back to Spark.
+read or produce variant columns fall back to Spark.
 
 ### Parquet type widening
 
 Spark 4.0 added broader support for reading Parquet files with widened types
 (for example, reading an `INT32` column as `BIGINT`). Comet supports the
 common integer widenings but does not yet cover the full set that Spark
-supports. Unsupported widenings cause a fallback to Spark.
-
-## Spark 3.4 and 3.5
-
-Spark 3.4 and 3.5 are the most thoroughly exercised versions in CI and are
-suitable for production use. There are no version-specific gaps to call out
-beyond the per-feature compatibility notes in the rest of this guide.
+supports. Unsupported widenings are not detected as a fallback condition,
+so queries that rely on them may fail or return incorrect results rather
+than transparently falling back to Spark.

--- a/docs/source/user-guide/latest/installation.md
+++ b/docs/source/user-guide/latest/installation.md
@@ -47,8 +47,7 @@ Other versions may work well enough for development and evaluation purposes.
 Note that we do not test the full matrix of supported Java and Scala versions in CI for every Spark version.
 
 Spark 4.0 support has good coverage and is exercised in CI, but a few Spark 4.0 features are not yet implemented.
-Comet falls back to Spark in those cases. See the [Spark Version Compatibility](compatibility/spark-versions.md)
-guide for details.
+See the [Spark Version Compatibility](compatibility/spark-versions.md) guide for details.
 
 Note that Comet may not fully work with proprietary forks of Apache Spark such as the Spark versions offered by
 Cloud Service Providers.

--- a/docs/source/user-guide/latest/installation.md
+++ b/docs/source/user-guide/latest/installation.md
@@ -42,15 +42,13 @@ Other versions may work well enough for development and evaluation purposes.
 | 3.5.6         | 11/17        | 2.12/2.13     | Yes               | No                    |
 | 3.5.7         | 11/17        | 2.12/2.13     | Yes               | Yes                   |
 | 3.5.8         | 11/17        | 2.12/2.13     | Yes               | Yes                   |
+| 4.0.1         | 17           | 2.13          | Yes               | Yes                   |
 
 Note that we do not test the full matrix of supported Java and Scala versions in CI for every Spark version.
 
-Experimental support is provided for the following versions of Apache Spark and is intended for development/testing
-use only and should not be used in production yet.
-
-| Spark Version | Java Version | Scala Version | Comet Tests in CI | Spark SQL Tests in CI |
-| ------------- | ------------ | ------------- | ----------------- | --------------------- |
-| 4.0.1         | 17           | 2.13          | Yes               | Yes                   |
+Spark 4.0 support has good coverage and is exercised in CI, but a few Spark 4.0 features are not yet implemented.
+Comet falls back to Spark in those cases. See the [Spark Version Compatibility](compatibility/spark-versions.md)
+guide for details.
 
 Note that Comet may not fully work with proprietary forks of Apache Spark such as the Spark versions offered by
 Cloud Service Providers.
@@ -74,7 +72,7 @@ through the release vote. Release candidate jars can be found [here](https://rep
 - [Comet plugin for Spark 3.4 / Scala 2.13](https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.4_2.13/$COMET_VERSION/comet-spark-spark3.4_2.13-$COMET_VERSION.jar)
 - [Comet plugin for Spark 3.5 / Scala 2.12](https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.12/$COMET_VERSION/comet-spark-spark3.5_2.12-$COMET_VERSION.jar)
 - [Comet plugin for Spark 3.5 / Scala 2.13](https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.13/$COMET_VERSION/comet-spark-spark3.5_2.13-$COMET_VERSION.jar)
-- [Comet plugin for Spark 4.0 / Scala 2.13 (Experimental)](https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark4.0_2.13/$COMET_VERSION/comet-spark-spark4.0_2.13-$COMET_VERSION.jar)
+- [Comet plugin for Spark 4.0 / Scala 2.13](https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark4.0_2.13/$COMET_VERSION/comet-spark-spark4.0_2.13-$COMET_VERSION.jar)
 
 ## Building from source
 


### PR DESCRIPTION
## Which issue does this PR close?

Part of #1637

## Rationale for this change

There has been a lot of progress recently with Spark 4 and ANSI support. The docs now need some updates.

## What changes are included in this PR?

- Add new Spark Versions page to compatibility guide
- Various minor updates

## How are these changes tested?

N/A