### PR TITLE
fix: reject incompatible decimal precision/scale in native_datafusion scan

### DIFF
--- a/native/core/src/parquet/schema_adapter.rs
+++ b/native/core/src/parquet/schema_adapter.rs
@@ -385,6 +385,33 @@ impl SparkPhysicalExprAdapter {
             let physical_type = cast.input_field().data_type();
             let target_type = cast.target_field().data_type();
 
+            // Decimal-to-decimal scale-narrowing check.
+            // Reject reads where the read schema has a smaller scale than the
+            // file's, because Spark's Cast below would silently truncate
+            // fractional digits, producing wrong values. This matches the
+            // unconditionally-lossy case in issue #4089 (e.g. Decimal(10,2) read
+            // as Decimal(5,0)).
+            //
+            // Precision-only changes with the same scale (e.g. Decimal(5,2) read
+            // as Decimal(3,2)) are NOT rejected here: Spark 3.x's strict rule
+            // would reject them, but Spark 4.0's parquet-mr fallback path
+            // (PARQUET_VECTORIZED_READER_ENABLED=false) and the vectorized
+            // type-widening path produce null on per-value overflow, which
+            // DataFusion's cast already does in the adapting-schema path.
+            if let (DataType::Decimal128(_src_p, src_s), DataType::Decimal128(_dst_p, dst_s)) =
+                (physical_type, target_type)
+            {
+                if dst_s < src_s {
+                    return Err(DataFusionError::Plan(format!(
+                        "Parquet column cannot be converted. Column: [{}], \
+                         Expected: {}, Found: {}",
+                        cast.input_field().name(),
+                        target_type,
+                        physical_type,
+                    )));
+                }
+            }
+
             // For complex nested types (Struct, List, Map), Timestamp timezone
             // mismatches, and Timestamp→Int64 (nanosAsLong), use CometCastColumnExpr
             // with spark_parquet_convert which handles field-name-based selection,

--- a/native/core/src/parquet/schema_adapter.rs
+++ b/native/core/src/parquet/schema_adapter.rs
@@ -392,12 +392,21 @@ impl SparkPhysicalExprAdapter {
             // unconditionally-lossy case in issue #4089 (e.g. Decimal(10,2) read
             // as Decimal(5,0)).
             //
-            // Precision-only changes with the same scale (e.g. Decimal(5,2) read
-            // as Decimal(3,2)) are NOT rejected here: Spark 3.x's strict rule
-            // would reject them, but Spark 4.0's parquet-mr fallback path
-            // (PARQUET_VECTORIZED_READER_ENABLED=false) and the vectorized
-            // type-widening path produce null on per-value overflow, which
-            // DataFusion's cast already does in the adapting-schema path.
+            // Other decimal mismatches are intentionally NOT rejected here,
+            // even though Spark's vectorized reader would reject them via
+            // `ParquetVectorUpdaterFactory#isDecimalTypeMatched` (which requires
+            // exact precision and scale):
+            //
+            // - Precision-only changes with the same scale (e.g. Decimal(5,2)
+            //   read as Decimal(3,2)): Spark 4.0's parquet-mr fallback path
+            //   (PARQUET_VECTORIZED_READER_ENABLED=false) and the vectorized
+            //   type-widening path produce null on per-value overflow, which
+            //   DataFusion's cast already does in the adapting-schema path.
+            //
+            // - Scale widening (e.g. Decimal(10,2) read as Decimal(10,4)): the
+            //   cast is lossless (no truncation, no overflow), so allowing it
+            //   here is strictly more permissive than Spark's vectorized reader
+            //   without risking wrong values.
             if let (DataType::Decimal128(_src_p, src_s), DataType::Decimal128(_dst_p, dst_s)) =
                 (physical_type, target_type)
             {

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -998,6 +998,29 @@ abstract class ParquetReadSuite extends CometTestBase {
     }
   }
 
+  test("native_datafusion rejects incompatible decimal precision/scale") {
+    // Regression guard for https://github.com/apache/datafusion-comet/issues/4089.
+    // Reading Decimal(10,2) under a Decimal(5,0) read schema is unconditionally
+    // lossy: target precision is smaller than source precision and scales differ.
+    // Spark's vectorized reader throws SchemaColumnConvertNotSupportedException
+    // here on all versions. The native_datafusion scan must reject this in its
+    // schema adapter rather than letting Spark Cast silently rescale/truncate.
+    withSQLConf(
+      CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_DATAFUSION,
+      SQLConf.USE_V1_SOURCE_LIST.key -> "parquet") {
+      withTempPath { dir =>
+        val path = dir.getCanonicalPath
+        spark
+          .sql("select cast('123.45' as decimal(10,2)) as d " +
+            "union all select cast('67.89' as decimal(10,2))")
+          .write
+          .parquet(path)
+        val df = spark.read.schema("d decimal(5,0)").parquet(path)
+        assertThrows[SparkException](df.collect())
+      }
+    }
+  }
+
   test("type widening: byte → short/int/long, short → int/long, int → long") {
     withSQLConf(CometConf.COMET_SCHEMA_EVOLUTION_ENABLED.key -> "true") {
       withTempPath { dir =>


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4089.

## Rationale for this change

When the `native_datafusion` scan reads a Parquet column whose physical type is `Decimal(p1, s1)` under a requested read schema of `Decimal(p2, s2)` with `s2 < s1`, the existing schema adapter falls through to Spark's `Cast` expression. `Cast` happily truncates fractional digits, producing wrong values silently. Spark's vectorized reader rejects this with `SchemaColumnConvertNotSupportedException`, and `native_iceberg_compat` already does the same via `TypeUtil.checkParquetType`. The native scan should match.

## What changes are included in this PR?

`native/core/src/parquet/schema_adapter.rs`: in `replace_with_spark_cast`, add a guard before the existing branches that returns `DataFusionError::Plan` when both `physical_type` and `target_type` are `Decimal128` and the target scale is smaller than the source scale.

The check is intentionally narrow:

- **Only fires on scale narrowing.** Precision-only changes with the same scale (e.g. `Decimal(5,2)` read as `Decimal(3,2)`) are still allowed and fall through to Spark's `Cast`, which produces null on per-value overflow. This matches Spark 4.0's parquet-mr fallback behavior exercised by `ParquetTypeWideningSuite`'s `parquet decimal type change Decimal(5, 2) -> Decimal(3, 2) overflows with parquet-mr` test.
- **Does not touch any other type path.** The closed prior attempt at broad schema validation (#3311) broke unrelated tests; this one does not.

## How are these changes tested?

Added a focused test to `ParquetReadSuite`: `native_datafusion rejects incompatible decimal precision/scale`. It writes `Decimal(10, 2)` data, reads it under `Decimal(5, 0)` (scale narrowed from 2 to 0), forces `spark.comet.scan.impl=native_datafusion` and `spark.sql.sources.useV1SourceList=parquet`, and asserts `collect()` raises `SparkException`. Verified against `ParquetReadV1Suite` (44 tests, all pass; 1 pre-existing test ignored).

The behavior is also covered by the per-impl matrix added in #4087 (`decimal(10,2) read as decimal(5,0): native_datafusion`), whose assertion will need flipping from "succeeds" to "throws" once that PR merges.