### PR TITLE
fix: reject string/binary read as numeric in native_datafusion scan

### DIFF
--- a/native/core/src/parquet/schema_adapter.rs
+++ b/native/core/src/parquet/schema_adapter.rs
@@ -385,6 +385,39 @@ impl SparkPhysicalExprAdapter {
             let physical_type = cast.input_field().data_type();
             let target_type = cast.target_field().data_type();
 
+            // Reject reading a string/binary Parquet column as a numeric type.
+            // Mirrors Spark's TypeUtil.checkParquetType for the BINARY case: a
+            // BINARY (or UTF8-annotated BINARY) physical column is only readable
+            // as StringType, BinaryType, or a binary-encoded decimal. Without
+            // this guard, Spark's Cast below (in is_adapting_schema mode) would
+            // delegate to DataFusion's cast, which silently parses the bytes
+            // (returning nulls for non-numeric strings or, depending on the
+            // path, raw byte reinterpretation). See issue #4088.
+            if matches!(
+                physical_type,
+                DataType::Utf8 | DataType::LargeUtf8 | DataType::Binary | DataType::LargeBinary
+            ) && matches!(
+                target_type,
+                DataType::Int8
+                    | DataType::Int16
+                    | DataType::Int32
+                    | DataType::Int64
+                    | DataType::UInt8
+                    | DataType::UInt16
+                    | DataType::UInt32
+                    | DataType::UInt64
+                    | DataType::Float32
+                    | DataType::Float64
+            ) {
+                return Err(DataFusionError::Plan(format!(
+                    "Parquet column cannot be converted. Column: [{}], \
+                     Expected: {}, Found: {}",
+                    cast.input_field().name(),
+                    target_type,
+                    physical_type,
+                )));
+            }
+
             // For complex nested types (Struct, List, Map), Timestamp timezone
             // mismatches, and Timestamp→Int64 (nanosAsLong), use CometCastColumnExpr
             // with spark_parquet_convert which handles field-name-based selection,

--- a/native/core/src/parquet/schema_adapter.rs
+++ b/native/core/src/parquet/schema_adapter.rs
@@ -385,29 +385,30 @@ impl SparkPhysicalExprAdapter {
             let physical_type = cast.input_field().data_type();
             let target_type = cast.target_field().data_type();
 
-            // Reject reading a string/binary Parquet column as a numeric type.
-            // Mirrors Spark's TypeUtil.checkParquetType for the BINARY case: a
-            // BINARY (or UTF8-annotated BINARY) physical column is only readable
-            // as StringType, BinaryType, or a binary-encoded decimal. Without
-            // this guard, Spark's Cast below (in is_adapting_schema mode) would
-            // delegate to DataFusion's cast, which silently parses the bytes
-            // (returning nulls for non-numeric strings or, depending on the
-            // path, raw byte reinterpretation). See issue #4088.
+            // Reject reading a string/binary Parquet column as anything other
+            // than string, binary, or a binary-encoded decimal. This mirrors
+            // Spark's TypeUtil.checkParquetType for the BINARY case (lines
+            // 208-221): a BINARY (or UTF8-annotated BINARY) physical column is
+            // only readable as StringType, BinaryType, or a binary-encoded
+            // decimal; every other target type (numeric, boolean, date,
+            // timestamp, ...) raises SchemaColumnConvertNotSupportedException.
+            //
+            // Without this guard, Spark's Cast below (in is_adapting_schema
+            // mode) falls through to DataFusion's cast, which silently parses
+            // the bytes (returning nulls for non-numeric strings, parsing
+            // date/timestamp/boolean strings, or in some paths reinterpreting
+            // raw bytes). See issue #4088.
             if matches!(
                 physical_type,
                 DataType::Utf8 | DataType::LargeUtf8 | DataType::Binary | DataType::LargeBinary
-            ) && matches!(
+            ) && !matches!(
                 target_type,
-                DataType::Int8
-                    | DataType::Int16
-                    | DataType::Int32
-                    | DataType::Int64
-                    | DataType::UInt8
-                    | DataType::UInt16
-                    | DataType::UInt32
-                    | DataType::UInt64
-                    | DataType::Float32
-                    | DataType::Float64
+                DataType::Utf8
+                    | DataType::LargeUtf8
+                    | DataType::Binary
+                    | DataType::LargeBinary
+                    | DataType::Decimal128(_, _)
+                    | DataType::Decimal256(_, _)
             ) {
                 return Err(DataFusionError::Plan(format!(
                     "Parquet column cannot be converted. Column: [{}], \

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -998,21 +998,26 @@ abstract class ParquetReadSuite extends CometTestBase {
     }
   }
 
-  test("native_datafusion rejects string read as numeric") {
+  test("native_datafusion rejects string read as non-string/binary type") {
     // Regression guard for https://github.com/apache/datafusion-comet/issues/4088.
-    // Spark's vectorized reader rejects reading a Parquet BINARY column as any
-    // numeric type on all versions (see TypeUtil.checkParquetType, BINARY case).
-    // The native_datafusion scan must do the same in its schema adapter rather
-    // than letting DataFusion's cast silently parse the bytes (returning nulls
-    // for non-numeric strings, or raw byte reinterpretation in some paths).
+    // Spark's vectorized reader rejects reading a Parquet BINARY column as
+    // anything except StringType, BinaryType, or a binary-encoded decimal (see
+    // TypeUtil.checkParquetType, BINARY case). The native_datafusion scan
+    // must do the same in its schema adapter rather than letting DataFusion's
+    // cast silently parse the bytes or reinterpret them.
     withSQLConf(
       CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_DATAFUSION,
       SQLConf.USE_V1_SOURCE_LIST.key -> "parquet") {
       withTempPath { dir =>
         val path = dir.getCanonicalPath
         Seq("a", "b", "c").toDF("c").write.parquet(path)
-        val df = spark.read.schema("c int").parquet(path)
-        assertThrows[SparkException](df.collect())
+        // Cover representative non-string/binary target types: numeric,
+        // boolean, date, and timestamp. Each would silently produce wrong
+        // results without the schema-adapter guard.
+        Seq("int", "bigint", "double", "boolean", "date", "timestamp").foreach { sqlType =>
+          val df = spark.read.schema(s"c $sqlType").parquet(path)
+          assertThrows[SparkException](df.collect())
+        }
       }
     }
   }

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -998,6 +998,25 @@ abstract class ParquetReadSuite extends CometTestBase {
     }
   }
 
+  test("native_datafusion rejects string read as numeric") {
+    // Regression guard for https://github.com/apache/datafusion-comet/issues/4088.
+    // Spark's vectorized reader rejects reading a Parquet BINARY column as any
+    // numeric type on all versions (see TypeUtil.checkParquetType, BINARY case).
+    // The native_datafusion scan must do the same in its schema adapter rather
+    // than letting DataFusion's cast silently parse the bytes (returning nulls
+    // for non-numeric strings, or raw byte reinterpretation in some paths).
+    withSQLConf(
+      CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_DATAFUSION,
+      SQLConf.USE_V1_SOURCE_LIST.key -> "parquet") {
+      withTempPath { dir =>
+        val path = dir.getCanonicalPath
+        Seq("a", "b", "c").toDF("c").write.parquet(path)
+        val df = spark.read.schema("c int").parquet(path)
+        assertThrows[SparkException](df.collect())
+      }
+    }
+  }
+
   test("type widening: byte → short/int/long, short → int/long, int → long") {
     withSQLConf(CometConf.COMET_SCHEMA_EVOLUTION_ENABLED.key -> "true") {
       withTempPath { dir =>


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4088.

## Rationale for this change

When the `native_datafusion` scan reads a Parquet `BINARY` (UTF8) column under a numeric read schema, the existing schema adapter creates a Spark `Cast` with `is_adapting_schema=true`. In that mode `Cast` delegates to DataFusion's cast, which parses the bytes (returning null on non-numeric strings, or in some paths reinterpreting the raw bytes). Spark's vectorized reader rejects this kind of mismatch with `SchemaColumnConvertNotSupportedException` on every supported version, and `native_iceberg_compat` already does the same via `TypeUtil.checkParquetType`. The native scan should match.

## What changes are included in this PR?

`native/core/src/parquet/schema_adapter.rs`: in `replace_with_spark_cast`, add a guard before the existing branches that returns `DataFusionError::Plan` when the source type is `Utf8`, `LargeUtf8`, `Binary`, or `LargeBinary` and the target type is any integer (`Int8`/`Int16`/`Int32`/`Int64`/`UInt*`) or floating-point type (`Float32`/`Float64`). The rule mirrors `TypeUtil.checkParquetType`'s `BINARY` case (lines 208-221), which only allows reading BINARY as `StringType`, `BinaryType`, or a binary-encoded decimal.

The check is intentionally narrow: it only fires for string/binary -> numeric mismatches and leaves every other type path unchanged.

## How are these changes tested?

Added a focused test to `ParquetReadSuite`: `native_datafusion rejects string read as numeric`. It writes string data, reads it under `c int`, forces `spark.comet.scan.impl=native_datafusion` and `spark.sql.sources.useV1SourceList=parquet`, and asserts that `collect()` raises `SparkException`. Verified against `ParquetReadV1Suite` (44 succeeded, no regressions; 1 pre-existing test ignored).

The behavior is also covered by the per-impl matrix added in #4087 (`string read as int: native_datafusion`), whose assertion will need flipping from "succeeds with garbage" to "throws" once that PR merges.