### PR TITLE
ci: reduce macOS PR matrix to single Spark 4.0 profile

### DIFF
--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -129,17 +129,11 @@ jobs:
       matrix:
         os: [macos-14]
 
-        # the goal with these profiles is to get coverage of all Java, Scala, and Spark
-        # versions without testing all possible combinations, which would be overkill
+        # macOS runs cover platform-specific concerns (native library loading, FFI,
+        # threading, shuffle on Apple Silicon) that are largely independent of the
+        # Spark/Scala/JDK version. Full matrix coverage already happens on Linux,
+        # so we run only the newest supported profile here.
         profile:
-          - name: "Spark 3.4, JDK 11, Scala 2.12"
-            java_version: "11"
-            maven_opts: "-Pspark-3.4 -Pscala-2.12"
-
-          - name: "Spark 3.5, JDK 17, Scala 2.13"
-            java_version: "17"
-            maven_opts: "-Pspark-3.5 -Pscala-2.13"
-
           - name: "Spark 4.0, JDK 17, Scala 2.13"
             java_version: "17"
             maven_opts: "-Pspark-4.0 -Pscala-2.13"
@@ -274,6 +268,6 @@ jobs:
         uses: ./.github/actions/java-test
         with:
           artifact_name: ${{ matrix.os }}-${{ matrix.profile.name }}-${{ matrix.suite.name }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-          suites: ${{ matrix.suite.name == 'sql' && matrix.profile.name == 'Spark 3.4, JDK 11, Scala 2.12' && '' || matrix.suite.value }}
+          suites: ${{ matrix.suite.value }}
           maven_opts: ${{ matrix.profile.maven_opts }}
           skip-native-build: true


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4102 (Option A).

## Rationale for this change

The macOS PR workflow currently runs 3 profiles (Spark 3.4 / JDK 11 / Scala 2.12, Spark 3.5 / JDK 17 / Scala 2.13, Spark 4.0 / JDK 17 / Scala 2.13) across 7 suites, for 21 jobs per PR. macOS runners cost roughly 2x Linux minutes, making this the most expensive workflow per job.

The macOS workflow exists primarily to catch platform-specific issues on Apple Silicon: native library loading, FFI, threading, and shuffle. Those concerns are largely independent of the Spark/Scala/JDK version. Full Spark/Java/Scala matrix coverage already happens on Linux in `pr_build_linux.yml`, so running 3 Spark profiles on macOS is duplicative for everything that is not platform-sensitive.

## What changes are included in this PR?

- Remove the `Spark 3.4, JDK 11, Scala 2.12` and `Spark 3.5, JDK 17, Scala 2.13` matrix entries from `.github/workflows/pr_build_macos.yml`, keeping only `Spark 4.0, JDK 17, Scala 2.13`.
- Drop the now-dead conditional that skipped the `sql` suite under the Spark 3.4 profile.
- Update the comment on the `profile` block to explain the macOS-specific rationale.

Reduces the macOS PR matrix from 21 jobs to 7.

## How are these changes tested?

CI on this PR exercises the new matrix. If a regression slips through that depends on Spark version on macOS, we can add a second profile back.