### PR TITLE
build: add spark-4.2 Maven profile targeting 4.2.0-preview4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -707,6 +707,27 @@ under the License.
     </profile>
 
     <profile>
+      <!-- WIP: Spark 4.2 preview support. Targets the 4.2.0-preview4 release; tests are not
+           wired up yet, this profile only aims to compile main sources. -->
+      <id>spark-4.2</id>
+      <properties>
+        <scala.version>2.13.18</scala.version>
+        <scala.binary.version>2.13</scala.binary.version>
+        <spark.version>4.2.0-preview4</spark.version>
+        <spark.version.short>4.2</spark.version.short>
+        <parquet.version>1.17.0</parquet.version>
+        <semanticdb.version>4.13.6</semanticdb.version>
+        <slf4j.version>2.0.17</slf4j.version>
+        <shims.majorVerSrc>spark-4.x</shims.majorVerSrc>
+        <shims.minorVerSrc>spark-4.2</shims.minorVerSrc>
+        <!-- Use jdk17 by default -->
+        <java.version>17</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+      </properties>
+    </profile>
+
+    <profile>
       <id>scala-2.12</id>
     </profile>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -299,6 +299,10 @@ under the License.
       </dependencies>
     </profile>
     <profile>
+      <id>spark-4.2</id>
+      <!-- 4.2 preview profile is build-only; no Iceberg or Jetty test dependencies are wired up. -->
+    </profile>
+    <profile>
       <id>generate-docs</id>
       <build>
         <plugins>

--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
@@ -28,6 +28,7 @@ import org.json4s.jackson.JsonMethods._
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.comet.{CometBatchScanExec, CometNativeExec}
+import org.apache.spark.sql.comet.shims.ShimDataSourceRDDPartition
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceRDD, DataSourceRDDPartition}
 import org.apache.spark.sql.types._
 
@@ -812,9 +813,8 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
         partitions.foreach { partition =>
           val partitionBuilder = OperatorOuterClass.IcebergScan.newBuilder()
 
-          val inputPartitions = partition
-            .asInstanceOf[DataSourceRDDPartition]
-            .inputPartitions
+          val inputPartitions = ShimDataSourceRDDPartition
+            .inputPartitions(partition.asInstanceOf[DataSourceRDDPartition])
 
           inputPartitions.foreach { inputPartition =>
             val inputPartClass = inputPartition.getClass

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometBatchScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometBatchScanExec.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst._
 import org.apache.spark.sql.catalyst.expressions.{Attribute, DynamicPruningExpression, Expression, Literal, SortOrder}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.util.truncatedString
+import org.apache.spark.sql.comet.shims.ShimCometBatchScanExec
 import org.apache.spark.sql.connector.read._
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.datasources.v2._
@@ -43,7 +44,8 @@ case class CometBatchScanExec(
     runtimeFilters: Seq[Expression],
     @transient nativeIcebergScanMetadata: Option[CometIcebergNativeScanMetadata] = None)
     extends DataSourceV2ScanExecBase
-    with CometPlan {
+    with CometPlan
+    with ShimCometBatchScanExec {
   def ordering: Option[Seq[SortOrder]] = wrapped.ordering
 
   wrapped.logicalLink.foreach(setLogicalLink)
@@ -130,7 +132,7 @@ case class CometBatchScanExec(
     redact(result)
   }
 
-  private def wrappedScan: BatchScanExec = {
+  protected def wrappedScan: BatchScanExec = {
     // The runtime filters in this scan could be transformed by optimizer rules such as
     // `PlanAdaptiveDynamicPruningFilters`, while the one in the wrapped scan is not. And
     // since `inputRDD` uses the latter and therefore will be incorrect if we don't set it here.
@@ -153,7 +155,7 @@ case class CometBatchScanExec(
       case _ => Map.empty
     })
 
-  @transient override lazy val partitions: Seq[Seq[InputPartition]] = wrappedScan.partitions
+  @transient override lazy val partitions = shimPartitions
 
   override def supportsColumnar: Boolean = true
 }

--- a/spark/src/main/spark-3.x/org/apache/spark/sql/comet/shims/ShimCometBatchScanExec.scala
+++ b/spark/src/main/spark-3.x/org/apache/spark/sql/comet/shims/ShimCometBatchScanExec.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet.shims
+
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+
+trait ShimCometBatchScanExec {
+  protected def wrappedScan: BatchScanExec
+
+  // Spark 3.4 and 3.5 expose `partitions` as Seq[Seq[InputPartition]] (same as 4.0/4.1);
+  // 4.2 changed it to Seq[Option[InputPartition]]. The concrete subclass overrides
+  // `partitions` to delegate to `shimPartitions`, which carries the version-specific
+  // element type.
+  @transient lazy val shimPartitions: Seq[Seq[InputPartition]] = wrappedScan.partitions
+}

--- a/spark/src/main/spark-3.x/org/apache/spark/sql/comet/shims/ShimDataSourceRDDPartition.scala
+++ b/spark/src/main/spark-3.x/org/apache/spark/sql/comet/shims/ShimDataSourceRDDPartition.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet.shims
+
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.datasources.v2.DataSourceRDDPartition
+
+object ShimDataSourceRDDPartition {
+  // In Spark 3.4, 3.5, 4.0, and 4.1 a DataSourceRDDPartition holds a Seq[InputPartition]
+  // under `inputPartitions`. In 4.2 it was renamed to a single `inputPartition`.
+  def inputPartitions(p: DataSourceRDDPartition): Seq[InputPartition] = p.inputPartitions
+}

--- a/spark/src/main/spark-4.0/org/apache/spark/sql/comet/shims/ShimCometBatchScanExec.scala
+++ b/spark/src/main/spark-4.0/org/apache/spark/sql/comet/shims/ShimCometBatchScanExec.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet.shims
+
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+
+trait ShimCometBatchScanExec {
+  protected def wrappedScan: BatchScanExec
+
+  // Spark 4.0 and 4.1 expose `partitions` as Seq[Seq[InputPartition]]; 4.2 changed it to
+  // Seq[Option[InputPartition]]. The concrete subclass overrides `partitions` to delegate
+  // to `shimPartitions`, which carries the version-specific element type.
+  @transient lazy val shimPartitions: Seq[Seq[InputPartition]] = wrappedScan.partitions
+}

--- a/spark/src/main/spark-4.0/org/apache/spark/sql/comet/shims/ShimDataSourceRDDPartition.scala
+++ b/spark/src/main/spark-4.0/org/apache/spark/sql/comet/shims/ShimDataSourceRDDPartition.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet.shims
+
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.datasources.v2.DataSourceRDDPartition
+
+object ShimDataSourceRDDPartition {
+  // In Spark 4.0 and 4.1 a DataSourceRDDPartition holds a Seq[InputPartition] under
+  // `inputPartitions`. In 4.2 it was renamed to a single `inputPartition`.
+  def inputPartitions(p: DataSourceRDDPartition): Seq[InputPartition] = p.inputPartitions
+}

--- a/spark/src/main/spark-4.1/org/apache/spark/sql/comet/shims/ShimCometBatchScanExec.scala
+++ b/spark/src/main/spark-4.1/org/apache/spark/sql/comet/shims/ShimCometBatchScanExec.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet.shims
+
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+
+trait ShimCometBatchScanExec {
+  protected def wrappedScan: BatchScanExec
+
+  // Spark 4.0 and 4.1 expose `partitions` as Seq[Seq[InputPartition]]; 4.2 changed it to
+  // Seq[Option[InputPartition]]. The concrete subclass overrides `partitions` to delegate
+  // to `shimPartitions`, which carries the version-specific element type.
+  @transient lazy val shimPartitions: Seq[Seq[InputPartition]] = wrappedScan.partitions
+}

--- a/spark/src/main/spark-4.1/org/apache/spark/sql/comet/shims/ShimDataSourceRDDPartition.scala
+++ b/spark/src/main/spark-4.1/org/apache/spark/sql/comet/shims/ShimDataSourceRDDPartition.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet.shims
+
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.datasources.v2.DataSourceRDDPartition
+
+object ShimDataSourceRDDPartition {
+  // In Spark 4.0 and 4.1 a DataSourceRDDPartition holds a Seq[InputPartition] under
+  // `inputPartitions`. In 4.2 it was renamed to a single `inputPartition`.
+  def inputPartitions(p: DataSourceRDDPartition): Seq[InputPartition] = p.inputPartitions
+}

--- a/spark/src/main/spark-4.2/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-4.2/org/apache/comet/shims/CometExprShim.scala
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.shims
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate.Sum
+import org.apache.spark.sql.catalyst.expressions.json.StructsToJsonEvaluator
+import org.apache.spark.sql.catalyst.expressions.objects.{Invoke, StaticInvoke}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.types.StringTypeWithCollation
+import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, DataTypes, StringType}
+
+import org.apache.comet.CometSparkSessionExtensions.withInfo
+import org.apache.comet.expressions.{CometCast, CometEvalMode}
+import org.apache.comet.serde.{CommonStringExprs, Compatible, ExprOuterClass, Incompatible}
+import org.apache.comet.serde.ExprOuterClass.{BinaryOutputStyle, Expr}
+import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, optExprWithInfo, scalarFunctionExprToProto, scalarFunctionExprToProtoWithReturnType}
+
+/**
+ * `CometExprShim` acts as a shim for parsing expressions from different Spark versions.
+ */
+trait CometExprShim extends CommonStringExprs {
+  protected def evalMode(c: Cast): CometEvalMode.Value =
+    CometEvalModeUtil.fromSparkEvalMode(c.evalMode)
+
+  protected def binaryOutputStyle: BinaryOutputStyle = {
+    // In Spark 4.1, BINARY_OUTPUT_STYLE is an enumConf so getConf already returns the enum value.
+    SQLConf.get.getConf(SQLConf.BINARY_OUTPUT_STYLE) match {
+      case Some(SQLConf.BinaryOutputStyle.UTF8) => BinaryOutputStyle.UTF8
+      case Some(SQLConf.BinaryOutputStyle.BASIC) => BinaryOutputStyle.BASIC
+      case Some(SQLConf.BinaryOutputStyle.BASE64) => BinaryOutputStyle.BASE64
+      case Some(SQLConf.BinaryOutputStyle.HEX) => BinaryOutputStyle.HEX
+      case _ => BinaryOutputStyle.HEX_DISCRETE
+    }
+  }
+
+  def versionSpecificExprToProtoInternal(
+      expr: Expression,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[Expr] = {
+    expr match {
+      case knc: KnownNotContainsNull =>
+        // On Spark 4.0, array_compact rewrites to KnownNotContainsNull(ArrayFilter(IsNotNull)).
+        // Strip the wrapper and serialize the inner ArrayFilter as spark_array_compact.
+        knc.child match {
+          case filter: ArrayFilter =>
+            filter.function.children.headOption match {
+              case Some(_: IsNotNull) =>
+                val arrayChild = filter.left
+                val elementType = arrayChild.dataType.asInstanceOf[ArrayType].elementType
+                val arrayExprProto = exprToProtoInternal(arrayChild, inputs, binding)
+                val returnType = ArrayType(elementType)
+                val scalarExpr = scalarFunctionExprToProtoWithReturnType(
+                  "spark_array_compact",
+                  returnType,
+                  false,
+                  arrayExprProto)
+                optExprWithInfo(scalarExpr, knc, arrayChild)
+              case _ => exprToProtoInternal(knc.child, inputs, binding)
+            }
+          case _ => exprToProtoInternal(knc.child, inputs, binding)
+        }
+
+      case s: StaticInvoke
+          if s.staticObject == classOf[StringDecode] &&
+            s.dataType.isInstanceOf[StringType] &&
+            s.functionName == "decode" &&
+            s.arguments.size == 4 &&
+            s.inputTypes == Seq(
+              BinaryType,
+              StringTypeWithCollation(supportsTrimCollation = true),
+              BooleanType,
+              BooleanType) =>
+        val Seq(bin, charset, _, _) = s.arguments
+        stringDecode(expr, charset, bin, inputs, binding)
+
+      case expr @ ToPrettyString(child, timeZoneId) =>
+        val castSupported = CometCast.isSupported(
+          child.dataType,
+          DataTypes.StringType,
+          timeZoneId,
+          CometEvalMode.TRY)
+
+        val isCastSupported = castSupported match {
+          case Compatible(_) => true
+          case Incompatible(_) => true
+          case _ => false
+        }
+
+        if (isCastSupported) {
+          exprToProtoInternal(child, inputs, binding) match {
+            case Some(p) =>
+              val toPrettyString = ExprOuterClass.ToPrettyString
+                .newBuilder()
+                .setChild(p)
+                .setTimezone(timeZoneId.getOrElse("UTC"))
+                .setBinaryOutputStyle(binaryOutputStyle)
+                .build()
+              Some(
+                ExprOuterClass.Expr
+                  .newBuilder()
+                  .setToPrettyString(toPrettyString)
+                  .build())
+            case _ =>
+              withInfo(expr, child)
+              None
+          }
+        } else {
+          None
+        }
+
+      case wb: WidthBucket =>
+        val childExprs = wb.children.map(exprToProtoInternal(_, inputs, binding))
+        val optExpr = scalarFunctionExprToProto("width_bucket", childExprs: _*)
+        optExprWithInfo(optExpr, wb, wb.children: _*)
+
+      // In Spark 4.0, StructsToJson is a RuntimeReplaceable whose replacement is
+      // Invoke(Literal(StructsToJsonEvaluator), "evaluate", ...). Reconstruct the
+      // original StructsToJson and recurse so support-level checks apply.
+      case i: Invoke =>
+        (i.targetObject, i.functionName, i.arguments) match {
+          case (Literal(evaluator: StructsToJsonEvaluator, _), "evaluate", Seq(child)) =>
+            exprToProtoInternal(
+              StructsToJson(evaluator.options, child, evaluator.timeZoneId),
+              inputs,
+              binding)
+          case _ => None
+        }
+
+      case _ => None
+    }
+  }
+}
+
+object CometEvalModeUtil {
+  def fromSparkEvalMode(evalMode: EvalMode.Value): CometEvalMode.Value = evalMode match {
+    case EvalMode.LEGACY => CometEvalMode.LEGACY
+    case EvalMode.TRY => CometEvalMode.TRY
+    case EvalMode.ANSI => CometEvalMode.ANSI
+  }
+
+  // In Spark 4.1, Sum carries a NumericEvalContext rather than a direct EvalMode.
+  def sumEvalMode(s: Sum): EvalMode.Value = s.evalContext.evalMode
+}

--- a/spark/src/main/spark-4.2/org/apache/spark/sql/comet/shims/ShimCometBatchScanExec.scala
+++ b/spark/src/main/spark-4.2/org/apache/spark/sql/comet/shims/ShimCometBatchScanExec.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet.shims
+
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+
+trait ShimCometBatchScanExec {
+  protected def wrappedScan: BatchScanExec
+
+  // Spark 4.2 changed `partitions` from Seq[Seq[InputPartition]] to Seq[Option[InputPartition]].
+  @transient lazy val shimPartitions: Seq[Option[InputPartition]] = wrappedScan.partitions
+}

--- a/spark/src/main/spark-4.2/org/apache/spark/sql/comet/shims/ShimDataSourceRDDPartition.scala
+++ b/spark/src/main/spark-4.2/org/apache/spark/sql/comet/shims/ShimDataSourceRDDPartition.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet.shims
+
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.datasources.v2.DataSourceRDDPartition
+
+object ShimDataSourceRDDPartition {
+  // Spark 4.2 reduced DataSourceRDDPartition to a single optional `inputPartition` (was
+  // `inputPartitions: Seq[InputPartition]` in 4.0/4.1).
+  def inputPartitions(p: DataSourceRDDPartition): Seq[InputPartition] = p.inputPartition.toSeq
+}


### PR DESCRIPTION
## Which issue does this PR close?

Part of #4113

## Rationale for this change

Spark 4.2.0-preview4 is published on Maven Central. Adding a build-only profile lets us start tracking 4.2 API drift incrementally rather than discovering everything in one pass when the GA release lands.


## What changes are included in this PR?

A new `spark-4.2` Maven profile in `pom.xml` and `spark/pom.xml`. Profile properties:

| property            | value           |
| ------------------- | --------------- |
| `spark.version`     | `4.2.0-preview4`|
| `scala.version`     | `2.13.18`       |
| `parquet.version`   | `1.17.0`        |
| `slf4j.version`     | `2.0.17`        |
| `shims.majorVerSrc` | `spark-4.x`     |
| `shims.minorVerSrc` | `spark-4.2`     |

A new `spark/src/main/spark-4.2/` shim tree with `CometExprShim.scala` (copied unchanged from `spark-4.1`).

Two Spark API changes between 4.1 and 4.2 required new shims. Because the new behavior diverges between 4.0/4.1 and 4.2, the new shim files live in the per-minor source roots (`spark-4.0`, `spark-4.1`, `spark-4.2`) rather than `spark-4.x`:

- `DataSourceV2ScanExecBase.partitions` changed from `Seq[Seq[InputPartition]]` to `Seq[Option[InputPartition]]`. The `partitions` override on `CometBatchScanExec` was extracted into a new `ShimCometBatchScanExec` trait that exposes the value as `shimPartitions`; the concrete override in `CometBatchScanExec` simply delegates to it.
- `DataSourceRDDPartition.inputPartitions: Seq[InputPartition]` was replaced by `inputPartition: Option[InputPartition]`. The reflective access in `CometIcebergNativeScan` now goes through a new `ShimDataSourceRDDPartition` helper that normalizes both shapes back to `Seq[InputPartition]`.

Out of scope (intentionally not wired up):
- Test sources, test profile dependencies (Iceberg runtime, Jetty)
- Plan-stability golden files for 4.2
- CI matrix entries for 4.2
- Any 4.2-specific expression handling beyond what 4.1 already does

## How are these changes tested?

CI