### PR TITLE
ci: pin JDK per Spark version in Iceberg workflow matrix

### DIFF
--- a/.github/workflows/iceberg_spark_test.yml
+++ b/.github/workflows/iceberg_spark_test.yml
@@ -120,10 +120,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        java-version: [11, 17]
         iceberg-version: [{short: '1.8', full: '1.8.1'}, {short: '1.9', full: '1.9.1'}, {short: '1.10', full: '1.10.0'}]
         spark-version: [{short: '3.4', full: '3.4.3'}, {short: '3.5', full: '3.5.8'}]
         scala-version: ['2.13']
+        include:
+          - spark-version: {short: '3.4', full: '3.4.3'}
+            java-version: 11
+          - spark-version: {short: '3.5', full: '3.5.8'}
+            java-version: 17
       fail-fast: false
     name: iceberg-spark/${{ matrix.os }}/iceberg-${{ matrix.iceberg-version.full }}/spark-${{ matrix.spark-version.full }}/scala-${{ matrix.scala-version }}/java-${{ matrix.java-version }}
     runs-on: ${{ matrix.os }}
@@ -163,10 +167,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        java-version: [11, 17]
         iceberg-version: [{short: '1.8', full: '1.8.1'}, {short: '1.9', full: '1.9.1'}, {short: '1.10', full: '1.10.0'}]
         spark-version: [{short: '3.4', full: '3.4.3'}, {short: '3.5', full: '3.5.8'}]
         scala-version: ['2.13']
+        include:
+          - spark-version: {short: '3.4', full: '3.4.3'}
+            java-version: 11
+          - spark-version: {short: '3.5', full: '3.5.8'}
+            java-version: 17
       fail-fast: false
     name: iceberg-spark-extensions/${{ matrix.os }}/iceberg-${{ matrix.iceberg-version.full }}/spark-${{ matrix.spark-version.full }}/scala-${{ matrix.scala-version }}/java-${{ matrix.java-version }}
     runs-on: ${{ matrix.os }}
@@ -206,10 +214,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        java-version: [11, 17]
         iceberg-version: [{short: '1.8', full: '1.8.1'}, {short: '1.9', full: '1.9.1'}, {short: '1.10', full: '1.10.0'}]
         spark-version: [{short: '3.4', full: '3.4.3'}, {short: '3.5', full: '3.5.8'}]
         scala-version: ['2.13']
+        include:
+          - spark-version: {short: '3.4', full: '3.4.3'}
+            java-version: 11
+          - spark-version: {short: '3.5', full: '3.5.8'}
+            java-version: 17
       fail-fast: false
     name: iceberg-spark-runtime/${{ matrix.os }}/iceberg-${{ matrix.iceberg-version.full }}/spark-${{ matrix.spark-version.full }}/scala-${{ matrix.scala-version }}/java-${{ matrix.java-version }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4101 .

## Rationale for this change
- Iceberg's own CI does not exhaustively cross JDK with every Spark version; we are overcovering relative to upstream.
- JDK 11 vs 17 differences that affect Comet are caught elsewhere: pr_build_linux.yml and spark_sql_test.yml both run JDK 11 + 17 against multiple Spark versions.
- The Iceberg suites are about Iceberg/Comet integration, not JVM-level differences; the same JDK delta is unlikely to surface there but not in the broader matrix.
- Frees CI capacity to add Spark 4.0.1 and 4.1.1 to the matrix without a net increase in PR runtime.

## What changes are included in this PR?
The java-version: [11, 17] axis is removed from the base matrix of all three test jobs (iceberg-spark, iceberg-spark-extensions, iceberg-spark-runtime) and replaced with an `include:` block that injects the appropriate JDK per Spark version:

- Spark 3.4.3 → JDK 11
- Spark 3.5.8 → JDK 17

This reduces test jobs from 36 to 18 per PR with no changes to step logic or variable references.

## How are these changes tested?
CI on this PR shows 18 jobs instead of 36.
