### PR TITLE
ci: Enable Comet PR test matrix and TPCDS plan-stability for Spark 4.2

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -97,9 +97,10 @@ jobs:
           - name: "Spark 4.0, JDK 21"
             java_version: "21"
             maven_opts: "-Pspark-4.0"
-          # Spark 4.1 is intentionally absent: the lint job invokes -Psemanticdb,
-          # but semanticdb-scalac_2.13.17 is not yet published, so we cannot
-          # currently run scalafix against the spark-4.1 profile.
+          # Spark 4.1 and 4.2 are intentionally absent: the lint job invokes -Psemanticdb,
+          # but semanticdb-scalac for those Scala patch versions (2.13.17 / 2.13.18) is not
+          # yet published, so we cannot currently run scalafix against the spark-4.1 or
+          # spark-4.2 profiles.
       fail-fast: false
     steps:
       - uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0  # v2.1.0
@@ -304,6 +305,11 @@ jobs:
           - name: "Spark 4.1, JDK 17"
             java_version: "17"
             maven_opts: "-Pspark-4.1"
+            scan_impl: "auto"
+
+          - name: "Spark 4.2, JDK 17"
+            java_version: "17"
+            maven_opts: "-Pspark-4.2"
             scan_impl: "auto"
         suite:
           - name: "fuzz"

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -144,6 +144,12 @@ jobs:
             # runtime; the scala-2.13 profile would override it back to 2.13.16 and break.
             maven_opts: "-Pspark-4.1"
 
+          - name: "Spark 4.2, JDK 17, Scala 2.13"
+            java_version: "17"
+            # The spark-4.2 profile pins Scala to 2.13.18 to match Spark 4.2.0-preview4's
+            # runtime; the scala-2.13 profile would override it back to 2.13.16 and break.
+            maven_opts: "-Pspark-4.2"
+
         suite:
           - name: "fuzz"
             value: |

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -300,7 +300,28 @@ under the License.
     </profile>
     <profile>
       <id>spark-4.2</id>
-      <!-- 4.2 preview profile is build-only; no Iceberg or Jetty test dependencies are wired up. -->
+      <dependencies>
+        <!-- iceberg-spark-runtime-4.2 is not yet published; reuse the 4.0 runtime -->
+        <dependency>
+          <groupId>org.apache.iceberg</groupId>
+          <artifactId>iceberg-spark-runtime-4.0_${scala.binary.version}</artifactId>
+          <version>1.10.0</version>
+          <scope>test</scope>
+        </dependency>
+        <!-- Jetty 11.x for Spark 4.2 (jakarta.servlet); matches Spark 4.2.0-preview4's jetty.version -->
+        <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-server</artifactId>
+          <version>11.0.26</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-servlet</artifactId>
+          <version>11.0.26</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
     </profile>
     <profile>
       <id>generate-docs</id>

--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -169,6 +169,10 @@ object CometSparkSessionExtensions extends Logging {
     org.apache.spark.SPARK_VERSION >= "4.1"
   }
 
+  def isSpark42Plus: Boolean = {
+    org.apache.spark.SPARK_VERSION >= "4.2"
+  }
+
   /**
    * Whether we should override Spark memory configuration for Comet. This only returns true when
    * Comet native execution is enabled and/or Comet shuffle is enabled and Comet doesn't use

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q1.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q1.native_datafusion/extended.txt
@@ -1,0 +1,52 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometProject
+         :     :  +- CometBroadcastHashJoin
+         :     :     :- CometFilter
+         :     :     :  +- CometHashAggregate
+         :     :     :     +- CometExchange
+         :     :     :        +- CometHashAggregate
+         :     :     :           +- CometProject
+         :     :     :              +- CometBroadcastHashJoin
+         :     :     :                 :- CometFilter
+         :     :     :                 :  +- CometNativeScan parquet spark_catalog.default.store_returns
+         :     :     :                 :        +- CometSubqueryBroadcast
+         :     :     :                 :           +- CometBroadcastExchange
+         :     :     :                 :              +- CometProject
+         :     :     :                 :                 +- CometFilter
+         :     :     :                 :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :     :                 +- CometBroadcastExchange
+         :     :     :                    +- CometProject
+         :     :     :                       +- CometFilter
+         :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :     +- CometBroadcastExchange
+         :     :        +- CometFilter
+         :     :           +- CometHashAggregate
+         :     :              +- CometExchange
+         :     :                 +- CometHashAggregate
+         :     :                    +- CometHashAggregate
+         :     :                       +- CometExchange
+         :     :                          +- CometHashAggregate
+         :     :                             +- CometProject
+         :     :                                +- CometBroadcastHashJoin
+         :     :                                   :- CometFilter
+         :     :                                   :  +- CometNativeScan parquet spark_catalog.default.store_returns
+         :     :                                   :        +- ReusedSubquery
+         :     :                                   +- CometBroadcastExchange
+         :     :                                      +- CometProject
+         :     :                                         +- CometFilter
+         :     :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     +- CometBroadcastExchange
+         :        +- CometProject
+         :           +- CometFilter
+         :              +- CometNativeScan parquet spark_catalog.default.store
+         +- CometBroadcastExchange
+            +- CometProject
+               +- CometFilter
+                  +- CometNativeScan parquet spark_catalog.default.customer
+
+Comet accelerated 47 out of 49 eligible operators (95%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q1.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q1.native_iceberg_compat/extended.txt
@@ -1,0 +1,53 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometProject
+         :     :  +- CometBroadcastHashJoin
+         :     :     :- CometFilter
+         :     :     :  +- CometHashAggregate
+         :     :     :     +- CometExchange
+         :     :     :        +- CometHashAggregate
+         :     :     :           +- CometProject
+         :     :     :              +- CometBroadcastHashJoin
+         :     :     :                 :- CometFilter
+         :     :     :                 :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+         :     :     :                 :        +- SubqueryBroadcast
+         :     :     :                 :           +- BroadcastExchange
+         :     :     :                 :              +- CometNativeColumnarToRow
+         :     :     :                 :                 +- CometProject
+         :     :     :                 :                    +- CometFilter
+         :     :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :     :                 +- CometBroadcastExchange
+         :     :     :                    +- CometProject
+         :     :     :                       +- CometFilter
+         :     :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :     +- CometBroadcastExchange
+         :     :        +- CometFilter
+         :     :           +- CometHashAggregate
+         :     :              +- CometExchange
+         :     :                 +- CometHashAggregate
+         :     :                    +- CometHashAggregate
+         :     :                       +- CometExchange
+         :     :                          +- CometHashAggregate
+         :     :                             +- CometProject
+         :     :                                +- CometBroadcastHashJoin
+         :     :                                   :- CometFilter
+         :     :                                   :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+         :     :                                   :        +- ReusedSubquery
+         :     :                                   +- CometBroadcastExchange
+         :     :                                      +- CometProject
+         :     :                                         +- CometFilter
+         :     :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     +- CometBroadcastExchange
+         :        +- CometProject
+         :           +- CometFilter
+         :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+         +- CometBroadcastExchange
+            +- CometProject
+               +- CometFilter
+                  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+
+Comet accelerated 46 out of 49 eligible operators (93%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q10.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q10.native_datafusion/extended.txt
@@ -1,0 +1,61 @@
+TakeOrderedAndProject
++- HashAggregate
+   +- Exchange
+      +- HashAggregate
+         +- Project
+            +- BroadcastHashJoin
+               :- Project
+               :  +- BroadcastHashJoin
+               :     :- Project
+               :     :  +- Filter
+               :     :     +- BroadcastHashJoin
+               :     :        :-  BroadcastHashJoin [COMET: Unsupported join type ExistenceJoin(exists#1)]
+               :     :        :  :- CometNativeColumnarToRow
+               :     :        :  :  +- CometBroadcastHashJoin
+               :     :        :  :     :- CometFilter
+               :     :        :  :     :  +- CometNativeScan parquet spark_catalog.default.customer
+               :     :        :  :     +- CometBroadcastExchange
+               :     :        :  :        +- CometProject
+               :     :        :  :           +- CometBroadcastHashJoin
+               :     :        :  :              :- CometNativeScan parquet spark_catalog.default.store_sales
+               :     :        :  :              :     +- CometSubqueryBroadcast
+               :     :        :  :              :        +- CometBroadcastExchange
+               :     :        :  :              :           +- CometProject
+               :     :        :  :              :              +- CometFilter
+               :     :        :  :              :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     :        :  :              +- CometBroadcastExchange
+               :     :        :  :                 +- CometProject
+               :     :        :  :                    +- CometFilter
+               :     :        :  :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     :        :  +- BroadcastExchange
+               :     :        :     +- CometNativeColumnarToRow
+               :     :        :        +- CometProject
+               :     :        :           +- CometBroadcastHashJoin
+               :     :        :              :- CometNativeScan parquet spark_catalog.default.web_sales
+               :     :        :              :     +- ReusedSubquery
+               :     :        :              +- CometBroadcastExchange
+               :     :        :                 +- CometProject
+               :     :        :                    +- CometFilter
+               :     :        :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     :        +- BroadcastExchange
+               :     :           +- CometNativeColumnarToRow
+               :     :              +- CometProject
+               :     :                 +- CometBroadcastHashJoin
+               :     :                    :- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :     :                    :     +- ReusedSubquery
+               :     :                    +- CometBroadcastExchange
+               :     :                       +- CometProject
+               :     :                          +- CometFilter
+               :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     +- BroadcastExchange
+               :        +- CometNativeColumnarToRow
+               :           +- CometProject
+               :              +- CometFilter
+               :                 +- CometNativeScan parquet spark_catalog.default.customer_address
+               +- BroadcastExchange
+                  +- CometNativeColumnarToRow
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.customer_demographics
+
+Comet accelerated 35 out of 54 eligible operators (64%). Final plan contains 5 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q10.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q10.native_iceberg_compat/extended.txt
@@ -1,0 +1,62 @@
+TakeOrderedAndProject
++- HashAggregate
+   +- Exchange
+      +- HashAggregate
+         +- Project
+            +- BroadcastHashJoin
+               :- Project
+               :  +- BroadcastHashJoin
+               :     :- Project
+               :     :  +- Filter
+               :     :     +- BroadcastHashJoin
+               :     :        :-  BroadcastHashJoin [COMET: Unsupported join type ExistenceJoin(exists#1)]
+               :     :        :  :- CometNativeColumnarToRow
+               :     :        :  :  +- CometBroadcastHashJoin
+               :     :        :  :     :- CometFilter
+               :     :        :  :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+               :     :        :  :     +- CometBroadcastExchange
+               :     :        :  :        +- CometProject
+               :     :        :  :           +- CometBroadcastHashJoin
+               :     :        :  :              :- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :     :        :  :              :     +- SubqueryBroadcast
+               :     :        :  :              :        +- BroadcastExchange
+               :     :        :  :              :           +- CometNativeColumnarToRow
+               :     :        :  :              :              +- CometProject
+               :     :        :  :              :                 +- CometFilter
+               :     :        :  :              :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     :        :  :              +- CometBroadcastExchange
+               :     :        :  :                 +- CometProject
+               :     :        :  :                    +- CometFilter
+               :     :        :  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     :        :  +- BroadcastExchange
+               :     :        :     +- CometNativeColumnarToRow
+               :     :        :        +- CometProject
+               :     :        :           +- CometBroadcastHashJoin
+               :     :        :              :- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :     :        :              :     +- ReusedSubquery
+               :     :        :              +- CometBroadcastExchange
+               :     :        :                 +- CometProject
+               :     :        :                    +- CometFilter
+               :     :        :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     :        +- BroadcastExchange
+               :     :           +- CometNativeColumnarToRow
+               :     :              +- CometProject
+               :     :                 +- CometBroadcastHashJoin
+               :     :                    :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :     :                    :     +- ReusedSubquery
+               :     :                    +- CometBroadcastExchange
+               :     :                       +- CometProject
+               :     :                          +- CometFilter
+               :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     +- BroadcastExchange
+               :        +- CometNativeColumnarToRow
+               :           +- CometProject
+               :              +- CometFilter
+               :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+               +- BroadcastExchange
+                  +- CometNativeColumnarToRow
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+
+Comet accelerated 34 out of 54 eligible operators (62%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q11.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q11.native_datafusion/extended.txt
@@ -1,0 +1,89 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometProject
+         :     :  +- CometBroadcastHashJoin
+         :     :     :- CometFilter
+         :     :     :  +- CometHashAggregate
+         :     :     :     +- CometExchange
+         :     :     :        +- CometHashAggregate
+         :     :     :           +- CometProject
+         :     :     :              +- CometBroadcastHashJoin
+         :     :     :                 :- CometProject
+         :     :     :                 :  +- CometBroadcastHashJoin
+         :     :     :                 :     :- CometProject
+         :     :     :                 :     :  +- CometFilter
+         :     :     :                 :     :     +- CometNativeScan parquet spark_catalog.default.customer
+         :     :     :                 :     +- CometBroadcastExchange
+         :     :     :                 :        +- CometFilter
+         :     :     :                 :           +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     :     :                 :                 +- CometSubqueryBroadcast
+         :     :     :                 :                    +- CometBroadcastExchange
+         :     :     :                 :                       +- CometFilter
+         :     :     :                 :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :     :                 +- CometBroadcastExchange
+         :     :     :                    +- CometFilter
+         :     :     :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :     +- CometBroadcastExchange
+         :     :        +- CometHashAggregate
+         :     :           +- CometExchange
+         :     :              +- CometHashAggregate
+         :     :                 +- CometProject
+         :     :                    +- CometBroadcastHashJoin
+         :     :                       :- CometProject
+         :     :                       :  +- CometBroadcastHashJoin
+         :     :                       :     :- CometProject
+         :     :                       :     :  +- CometFilter
+         :     :                       :     :     +- CometNativeScan parquet spark_catalog.default.customer
+         :     :                       :     +- CometBroadcastExchange
+         :     :                       :        +- CometFilter
+         :     :                       :           +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     :                       :                 +- CometSubqueryBroadcast
+         :     :                       :                    +- CometBroadcastExchange
+         :     :                       :                       +- CometFilter
+         :     :                       :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :                       +- CometBroadcastExchange
+         :     :                          +- CometFilter
+         :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     +- CometBroadcastExchange
+         :        +- CometFilter
+         :           +- CometHashAggregate
+         :              +- CometExchange
+         :                 +- CometHashAggregate
+         :                    +- CometProject
+         :                       +- CometBroadcastHashJoin
+         :                          :- CometProject
+         :                          :  +- CometBroadcastHashJoin
+         :                          :     :- CometProject
+         :                          :     :  +- CometFilter
+         :                          :     :     +- CometNativeScan parquet spark_catalog.default.customer
+         :                          :     +- CometBroadcastExchange
+         :                          :        +- CometFilter
+         :                          :           +- CometNativeScan parquet spark_catalog.default.web_sales
+         :                          :                 +- ReusedSubquery
+         :                          +- CometBroadcastExchange
+         :                             +- CometFilter
+         :                                +- CometNativeScan parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometFilter
+                           :     :     +- CometNativeScan parquet spark_catalog.default.customer
+                           :     +- CometBroadcastExchange
+                           :        +- CometFilter
+                           :           +- CometNativeScan parquet spark_catalog.default.web_sales
+                           :                 +- ReusedSubquery
+                           +- CometBroadcastExchange
+                              +- CometFilter
+                                 +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 82 out of 86 eligible operators (95%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q11.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q11.native_iceberg_compat/extended.txt
@@ -1,0 +1,91 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometProject
+         :     :  +- CometBroadcastHashJoin
+         :     :     :- CometFilter
+         :     :     :  +- CometHashAggregate
+         :     :     :     +- CometExchange
+         :     :     :        +- CometHashAggregate
+         :     :     :           +- CometProject
+         :     :     :              +- CometBroadcastHashJoin
+         :     :     :                 :- CometProject
+         :     :     :                 :  +- CometBroadcastHashJoin
+         :     :     :                 :     :- CometProject
+         :     :     :                 :     :  +- CometFilter
+         :     :     :                 :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         :     :     :                 :     +- CometBroadcastExchange
+         :     :     :                 :        +- CometFilter
+         :     :     :                 :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     :     :                 :                 +- SubqueryBroadcast
+         :     :     :                 :                    +- BroadcastExchange
+         :     :     :                 :                       +- CometNativeColumnarToRow
+         :     :     :                 :                          +- CometFilter
+         :     :     :                 :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :     :                 +- CometBroadcastExchange
+         :     :     :                    +- CometFilter
+         :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :     +- CometBroadcastExchange
+         :     :        +- CometHashAggregate
+         :     :           +- CometExchange
+         :     :              +- CometHashAggregate
+         :     :                 +- CometProject
+         :     :                    +- CometBroadcastHashJoin
+         :     :                       :- CometProject
+         :     :                       :  +- CometBroadcastHashJoin
+         :     :                       :     :- CometProject
+         :     :                       :     :  +- CometFilter
+         :     :                       :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         :     :                       :     +- CometBroadcastExchange
+         :     :                       :        +- CometFilter
+         :     :                       :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     :                       :                 +- SubqueryBroadcast
+         :     :                       :                    +- BroadcastExchange
+         :     :                       :                       +- CometNativeColumnarToRow
+         :     :                       :                          +- CometFilter
+         :     :                       :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :                       +- CometBroadcastExchange
+         :     :                          +- CometFilter
+         :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     +- CometBroadcastExchange
+         :        +- CometFilter
+         :           +- CometHashAggregate
+         :              +- CometExchange
+         :                 +- CometHashAggregate
+         :                    +- CometProject
+         :                       +- CometBroadcastHashJoin
+         :                          :- CometProject
+         :                          :  +- CometBroadcastHashJoin
+         :                          :     :- CometProject
+         :                          :     :  +- CometFilter
+         :                          :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         :                          :     +- CometBroadcastExchange
+         :                          :        +- CometFilter
+         :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+         :                          :                 +- ReusedSubquery
+         :                          +- CometBroadcastExchange
+         :                             +- CometFilter
+         :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometFilter
+                           :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                           :     +- CometBroadcastExchange
+                           :        +- CometFilter
+                           :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                           :                 +- ReusedSubquery
+                           +- CometBroadcastExchange
+                              +- CometFilter
+                                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 80 out of 86 eligible operators (93%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q12.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q12.native_datafusion/extended.txt
@@ -1,0 +1,30 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometBroadcastHashJoin
+                              :     :- CometFilter
+                              :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                              :     :        +- CometSubqueryBroadcast
+                              :     :           +- CometBroadcastExchange
+                              :     :              +- CometProject
+                              :     :                 +- CometFilter
+                              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :     +- CometBroadcastExchange
+                              :        +- CometProject
+                              :           +- CometFilter
+                              :              +- CometNativeScan parquet spark_catalog.default.item
+                              +- CometBroadcastExchange
+                                 +- CometProject
+                                    +- CometFilter
+                                       +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 23 out of 27 eligible operators (85%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q12.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q12.native_iceberg_compat/extended.txt
@@ -1,0 +1,31 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometBroadcastHashJoin
+                              :     :- CometFilter
+                              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                              :     :        +- SubqueryBroadcast
+                              :     :           +- BroadcastExchange
+                              :     :              +- CometNativeColumnarToRow
+                              :     :                 +- CometProject
+                              :     :                    +- CometFilter
+                              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :     +- CometBroadcastExchange
+                              :        +- CometProject
+                              :           +- CometFilter
+                              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                              +- CometBroadcastExchange
+                                 +- CometProject
+                                    +- CometFilter
+                                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 22 out of 27 eligible operators (81%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q13.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q13.native_datafusion/extended.txt
@@ -1,0 +1,41 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometProject
+            +- CometBroadcastHashJoin
+               :- CometProject
+               :  +- CometBroadcastHashJoin
+               :     :- CometProject
+               :     :  +- CometBroadcastHashJoin
+               :     :     :- CometProject
+               :     :     :  +- CometBroadcastHashJoin
+               :     :     :     :- CometProject
+               :     :     :     :  +- CometBroadcastHashJoin
+               :     :     :     :     :- CometFilter
+               :     :     :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :     :     :     :     :        +- CometSubqueryBroadcast
+               :     :     :     :     :           +- CometBroadcastExchange
+               :     :     :     :     :              +- CometProject
+               :     :     :     :     :                 +- CometFilter
+               :     :     :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     :     :     :     +- CometBroadcastExchange
+               :     :     :     :        +- CometFilter
+               :     :     :     :           +- CometNativeScan parquet spark_catalog.default.store
+               :     :     :     +- CometBroadcastExchange
+               :     :     :        +- CometProject
+               :     :     :           +- CometFilter
+               :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+               :     :     +- CometBroadcastExchange
+               :     :        +- CometProject
+               :     :           +- CometFilter
+               :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     +- CometBroadcastExchange
+               :        +- CometProject
+               :           +- CometFilter
+               :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+               +- CometBroadcastExchange
+                  +- CometFilter
+                     +- CometNativeScan parquet spark_catalog.default.household_demographics
+
+Comet accelerated 37 out of 38 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q13.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q13.native_iceberg_compat/extended.txt
@@ -1,0 +1,42 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometProject
+            +- CometBroadcastHashJoin
+               :- CometProject
+               :  +- CometBroadcastHashJoin
+               :     :- CometProject
+               :     :  +- CometBroadcastHashJoin
+               :     :     :- CometProject
+               :     :     :  +- CometBroadcastHashJoin
+               :     :     :     :- CometProject
+               :     :     :     :  +- CometBroadcastHashJoin
+               :     :     :     :     :- CometFilter
+               :     :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :     :     :     :     :        +- SubqueryBroadcast
+               :     :     :     :     :           +- BroadcastExchange
+               :     :     :     :     :              +- CometNativeColumnarToRow
+               :     :     :     :     :                 +- CometProject
+               :     :     :     :     :                    +- CometFilter
+               :     :     :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     :     :     :     +- CometBroadcastExchange
+               :     :     :     :        +- CometFilter
+               :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+               :     :     :     +- CometBroadcastExchange
+               :     :     :        +- CometProject
+               :     :     :           +- CometFilter
+               :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+               :     :     +- CometBroadcastExchange
+               :     :        +- CometProject
+               :     :           +- CometFilter
+               :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     +- CometBroadcastExchange
+               :        +- CometProject
+               :           +- CometFilter
+               :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+               +- CometBroadcastExchange
+                  +- CometFilter
+                     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+
+Comet accelerated 36 out of 38 eligible operators (94%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q14a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q14a.native_datafusion/extended.txt
@@ -1,0 +1,462 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometExpand
+               +- CometUnion
+                  :- CometProject
+                  :  +- CometFilter
+                  :     :  +- Subquery
+                  :     :     +- CometNativeColumnarToRow
+                  :     :        +- CometHashAggregate
+                  :     :           +- CometExchange
+                  :     :              +- CometHashAggregate
+                  :     :                 +- CometUnion
+                  :     :                    :- CometProject
+                  :     :                    :  +- CometBroadcastHashJoin
+                  :     :                    :     :- CometNativeScan parquet spark_catalog.default.store_sales
+                  :     :                    :     :     +- ReusedSubquery
+                  :     :                    :     +- CometBroadcastExchange
+                  :     :                    :        +- CometProject
+                  :     :                    :           +- CometFilter
+                  :     :                    :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :                    :- CometProject
+                  :     :                    :  +- CometBroadcastHashJoin
+                  :     :                    :     :- CometNativeScan parquet spark_catalog.default.catalog_sales
+                  :     :                    :     :     +- ReusedSubquery
+                  :     :                    :     +- CometBroadcastExchange
+                  :     :                    :        +- CometProject
+                  :     :                    :           +- CometFilter
+                  :     :                    :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :                    +- CometProject
+                  :     :                       +- CometBroadcastHashJoin
+                  :     :                          :- CometNativeScan parquet spark_catalog.default.web_sales
+                  :     :                          :     +- ReusedSubquery
+                  :     :                          +- CometBroadcastExchange
+                  :     :                             +- CometProject
+                  :     :                                +- CometFilter
+                  :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     +- CometHashAggregate
+                  :        +- CometExchange
+                  :           +- CometHashAggregate
+                  :              +- CometProject
+                  :                 +- CometBroadcastHashJoin
+                  :                    :- CometProject
+                  :                    :  +- CometBroadcastHashJoin
+                  :                    :     :- CometBroadcastHashJoin
+                  :                    :     :  :- CometFilter
+                  :                    :     :  :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                  :                    :     :  :        +- CometSubqueryBroadcast
+                  :                    :     :  :           +- CometBroadcastExchange
+                  :                    :     :  :              +- CometProject
+                  :                    :     :  :                 +- CometFilter
+                  :                    :     :  :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :                    :     :  +- CometBroadcastExchange
+                  :                    :     :     +- CometProject
+                  :                    :     :        +- CometBroadcastHashJoin
+                  :                    :     :           :- CometFilter
+                  :                    :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+                  :                    :     :           +- CometBroadcastExchange
+                  :                    :     :              +- CometBroadcastHashJoin
+                  :                    :     :                 :- CometHashAggregate
+                  :                    :     :                 :  +- CometExchange
+                  :                    :     :                 :     +- CometHashAggregate
+                  :                    :     :                 :        +- CometProject
+                  :                    :     :                 :           +- CometBroadcastHashJoin
+                  :                    :     :                 :              :- CometProject
+                  :                    :     :                 :              :  +- CometBroadcastHashJoin
+                  :                    :     :                 :              :     :- CometFilter
+                  :                    :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                  :                    :     :                 :              :     :        +- CometSubqueryBroadcast
+                  :                    :     :                 :              :     :           +- CometBroadcastExchange
+                  :                    :     :                 :              :     :              +- CometProject
+                  :                    :     :                 :              :     :                 +- CometFilter
+                  :                    :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :                    :     :                 :              :     +- CometBroadcastExchange
+                  :                    :     :                 :              :        +- CometBroadcastHashJoin
+                  :                    :     :                 :              :           :- CometFilter
+                  :                    :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+                  :                    :     :                 :              :           +- CometBroadcastExchange
+                  :                    :     :                 :              :              +- CometProject
+                  :                    :     :                 :              :                 +- CometBroadcastHashJoin
+                  :                    :     :                 :              :                    :- CometProject
+                  :                    :     :                 :              :                    :  +- CometBroadcastHashJoin
+                  :                    :     :                 :              :                    :     :- CometFilter
+                  :                    :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                  :                    :     :                 :              :                    :     :        +- ReusedSubquery
+                  :                    :     :                 :              :                    :     +- CometBroadcastExchange
+                  :                    :     :                 :              :                    :        +- CometFilter
+                  :                    :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+                  :                    :     :                 :              :                    +- CometBroadcastExchange
+                  :                    :     :                 :              :                       +- CometProject
+                  :                    :     :                 :              :                          +- CometFilter
+                  :                    :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :                    :     :                 :              +- CometBroadcastExchange
+                  :                    :     :                 :                 +- CometProject
+                  :                    :     :                 :                    +- CometFilter
+                  :                    :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :                    :     :                 +- CometBroadcastExchange
+                  :                    :     :                    +- CometProject
+                  :                    :     :                       +- CometBroadcastHashJoin
+                  :                    :     :                          :- CometProject
+                  :                    :     :                          :  +- CometBroadcastHashJoin
+                  :                    :     :                          :     :- CometFilter
+                  :                    :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                  :                    :     :                          :     :        +- ReusedSubquery
+                  :                    :     :                          :     +- CometBroadcastExchange
+                  :                    :     :                          :        +- CometFilter
+                  :                    :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+                  :                    :     :                          +- CometBroadcastExchange
+                  :                    :     :                             +- CometProject
+                  :                    :     :                                +- CometFilter
+                  :                    :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :                    :     +- CometBroadcastExchange
+                  :                    :        +- CometBroadcastHashJoin
+                  :                    :           :- CometFilter
+                  :                    :           :  +- CometNativeScan parquet spark_catalog.default.item
+                  :                    :           +- CometBroadcastExchange
+                  :                    :              +- CometProject
+                  :                    :                 +- CometBroadcastHashJoin
+                  :                    :                    :- CometFilter
+                  :                    :                    :  +- CometNativeScan parquet spark_catalog.default.item
+                  :                    :                    +- CometBroadcastExchange
+                  :                    :                       +- CometBroadcastHashJoin
+                  :                    :                          :- CometHashAggregate
+                  :                    :                          :  +- CometExchange
+                  :                    :                          :     +- CometHashAggregate
+                  :                    :                          :        +- CometProject
+                  :                    :                          :           +- CometBroadcastHashJoin
+                  :                    :                          :              :- CometProject
+                  :                    :                          :              :  +- CometBroadcastHashJoin
+                  :                    :                          :              :     :- CometFilter
+                  :                    :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                  :                    :                          :              :     :        +- CometSubqueryBroadcast
+                  :                    :                          :              :     :           +- CometBroadcastExchange
+                  :                    :                          :              :     :              +- CometProject
+                  :                    :                          :              :     :                 +- CometFilter
+                  :                    :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :                    :                          :              :     +- CometBroadcastExchange
+                  :                    :                          :              :        +- CometBroadcastHashJoin
+                  :                    :                          :              :           :- CometFilter
+                  :                    :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+                  :                    :                          :              :           +- CometBroadcastExchange
+                  :                    :                          :              :              +- CometProject
+                  :                    :                          :              :                 +- CometBroadcastHashJoin
+                  :                    :                          :              :                    :- CometProject
+                  :                    :                          :              :                    :  +- CometBroadcastHashJoin
+                  :                    :                          :              :                    :     :- CometFilter
+                  :                    :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                  :                    :                          :              :                    :     :        +- ReusedSubquery
+                  :                    :                          :              :                    :     +- CometBroadcastExchange
+                  :                    :                          :              :                    :        +- CometFilter
+                  :                    :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+                  :                    :                          :              :                    +- CometBroadcastExchange
+                  :                    :                          :              :                       +- CometProject
+                  :                    :                          :              :                          +- CometFilter
+                  :                    :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :                    :                          :              +- CometBroadcastExchange
+                  :                    :                          :                 +- CometProject
+                  :                    :                          :                    +- CometFilter
+                  :                    :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :                    :                          +- CometBroadcastExchange
+                  :                    :                             +- CometProject
+                  :                    :                                +- CometBroadcastHashJoin
+                  :                    :                                   :- CometProject
+                  :                    :                                   :  +- CometBroadcastHashJoin
+                  :                    :                                   :     :- CometFilter
+                  :                    :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                  :                    :                                   :     :        +- ReusedSubquery
+                  :                    :                                   :     +- CometBroadcastExchange
+                  :                    :                                   :        +- CometFilter
+                  :                    :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+                  :                    :                                   +- CometBroadcastExchange
+                  :                    :                                      +- CometProject
+                  :                    :                                         +- CometFilter
+                  :                    :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :                    +- CometBroadcastExchange
+                  :                       +- CometProject
+                  :                          +- CometFilter
+                  :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :- CometProject
+                  :  +- CometFilter
+                  :     :  +- ReusedSubquery
+                  :     +- CometHashAggregate
+                  :        +- CometExchange
+                  :           +- CometHashAggregate
+                  :              +- CometProject
+                  :                 +- CometBroadcastHashJoin
+                  :                    :- CometProject
+                  :                    :  +- CometBroadcastHashJoin
+                  :                    :     :- CometBroadcastHashJoin
+                  :                    :     :  :- CometFilter
+                  :                    :     :  :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                  :                    :     :  :        +- ReusedSubquery
+                  :                    :     :  +- CometBroadcastExchange
+                  :                    :     :     +- CometProject
+                  :                    :     :        +- CometBroadcastHashJoin
+                  :                    :     :           :- CometFilter
+                  :                    :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+                  :                    :     :           +- CometBroadcastExchange
+                  :                    :     :              +- CometBroadcastHashJoin
+                  :                    :     :                 :- CometHashAggregate
+                  :                    :     :                 :  +- CometExchange
+                  :                    :     :                 :     +- CometHashAggregate
+                  :                    :     :                 :        +- CometProject
+                  :                    :     :                 :           +- CometBroadcastHashJoin
+                  :                    :     :                 :              :- CometProject
+                  :                    :     :                 :              :  +- CometBroadcastHashJoin
+                  :                    :     :                 :              :     :- CometFilter
+                  :                    :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                  :                    :     :                 :              :     :        +- CometSubqueryBroadcast
+                  :                    :     :                 :              :     :           +- CometBroadcastExchange
+                  :                    :     :                 :              :     :              +- CometProject
+                  :                    :     :                 :              :     :                 +- CometFilter
+                  :                    :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :                    :     :                 :              :     +- CometBroadcastExchange
+                  :                    :     :                 :              :        +- CometBroadcastHashJoin
+                  :                    :     :                 :              :           :- CometFilter
+                  :                    :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+                  :                    :     :                 :              :           +- CometBroadcastExchange
+                  :                    :     :                 :              :              +- CometProject
+                  :                    :     :                 :              :                 +- CometBroadcastHashJoin
+                  :                    :     :                 :              :                    :- CometProject
+                  :                    :     :                 :              :                    :  +- CometBroadcastHashJoin
+                  :                    :     :                 :              :                    :     :- CometFilter
+                  :                    :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                  :                    :     :                 :              :                    :     :        +- ReusedSubquery
+                  :                    :     :                 :              :                    :     +- CometBroadcastExchange
+                  :                    :     :                 :              :                    :        +- CometFilter
+                  :                    :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+                  :                    :     :                 :              :                    +- CometBroadcastExchange
+                  :                    :     :                 :              :                       +- CometProject
+                  :                    :     :                 :              :                          +- CometFilter
+                  :                    :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :                    :     :                 :              +- CometBroadcastExchange
+                  :                    :     :                 :                 +- CometProject
+                  :                    :     :                 :                    +- CometFilter
+                  :                    :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :                    :     :                 +- CometBroadcastExchange
+                  :                    :     :                    +- CometProject
+                  :                    :     :                       +- CometBroadcastHashJoin
+                  :                    :     :                          :- CometProject
+                  :                    :     :                          :  +- CometBroadcastHashJoin
+                  :                    :     :                          :     :- CometFilter
+                  :                    :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                  :                    :     :                          :     :        +- ReusedSubquery
+                  :                    :     :                          :     +- CometBroadcastExchange
+                  :                    :     :                          :        +- CometFilter
+                  :                    :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+                  :                    :     :                          +- CometBroadcastExchange
+                  :                    :     :                             +- CometProject
+                  :                    :     :                                +- CometFilter
+                  :                    :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :                    :     +- CometBroadcastExchange
+                  :                    :        +- CometBroadcastHashJoin
+                  :                    :           :- CometFilter
+                  :                    :           :  +- CometNativeScan parquet spark_catalog.default.item
+                  :                    :           +- CometBroadcastExchange
+                  :                    :              +- CometProject
+                  :                    :                 +- CometBroadcastHashJoin
+                  :                    :                    :- CometFilter
+                  :                    :                    :  +- CometNativeScan parquet spark_catalog.default.item
+                  :                    :                    +- CometBroadcastExchange
+                  :                    :                       +- CometBroadcastHashJoin
+                  :                    :                          :- CometHashAggregate
+                  :                    :                          :  +- CometExchange
+                  :                    :                          :     +- CometHashAggregate
+                  :                    :                          :        +- CometProject
+                  :                    :                          :           +- CometBroadcastHashJoin
+                  :                    :                          :              :- CometProject
+                  :                    :                          :              :  +- CometBroadcastHashJoin
+                  :                    :                          :              :     :- CometFilter
+                  :                    :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                  :                    :                          :              :     :        +- CometSubqueryBroadcast
+                  :                    :                          :              :     :           +- CometBroadcastExchange
+                  :                    :                          :              :     :              +- CometProject
+                  :                    :                          :              :     :                 +- CometFilter
+                  :                    :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :                    :                          :              :     +- CometBroadcastExchange
+                  :                    :                          :              :        +- CometBroadcastHashJoin
+                  :                    :                          :              :           :- CometFilter
+                  :                    :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+                  :                    :                          :              :           +- CometBroadcastExchange
+                  :                    :                          :              :              +- CometProject
+                  :                    :                          :              :                 +- CometBroadcastHashJoin
+                  :                    :                          :              :                    :- CometProject
+                  :                    :                          :              :                    :  +- CometBroadcastHashJoin
+                  :                    :                          :              :                    :     :- CometFilter
+                  :                    :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                  :                    :                          :              :                    :     :        +- ReusedSubquery
+                  :                    :                          :              :                    :     +- CometBroadcastExchange
+                  :                    :                          :              :                    :        +- CometFilter
+                  :                    :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+                  :                    :                          :              :                    +- CometBroadcastExchange
+                  :                    :                          :              :                       +- CometProject
+                  :                    :                          :              :                          +- CometFilter
+                  :                    :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :                    :                          :              +- CometBroadcastExchange
+                  :                    :                          :                 +- CometProject
+                  :                    :                          :                    +- CometFilter
+                  :                    :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :                    :                          +- CometBroadcastExchange
+                  :                    :                             +- CometProject
+                  :                    :                                +- CometBroadcastHashJoin
+                  :                    :                                   :- CometProject
+                  :                    :                                   :  +- CometBroadcastHashJoin
+                  :                    :                                   :     :- CometFilter
+                  :                    :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                  :                    :                                   :     :        +- ReusedSubquery
+                  :                    :                                   :     +- CometBroadcastExchange
+                  :                    :                                   :        +- CometFilter
+                  :                    :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+                  :                    :                                   +- CometBroadcastExchange
+                  :                    :                                      +- CometProject
+                  :                    :                                         +- CometFilter
+                  :                    :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :                    +- CometBroadcastExchange
+                  :                       +- CometProject
+                  :                          +- CometFilter
+                  :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                  +- CometProject
+                     +- CometFilter
+                        :  +- ReusedSubquery
+                        +- CometHashAggregate
+                           +- CometExchange
+                              +- CometHashAggregate
+                                 +- CometProject
+                                    +- CometBroadcastHashJoin
+                                       :- CometProject
+                                       :  +- CometBroadcastHashJoin
+                                       :     :- CometBroadcastHashJoin
+                                       :     :  :- CometFilter
+                                       :     :  :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                                       :     :  :        +- ReusedSubquery
+                                       :     :  +- CometBroadcastExchange
+                                       :     :     +- CometProject
+                                       :     :        +- CometBroadcastHashJoin
+                                       :     :           :- CometFilter
+                                       :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+                                       :     :           +- CometBroadcastExchange
+                                       :     :              +- CometBroadcastHashJoin
+                                       :     :                 :- CometHashAggregate
+                                       :     :                 :  +- CometExchange
+                                       :     :                 :     +- CometHashAggregate
+                                       :     :                 :        +- CometProject
+                                       :     :                 :           +- CometBroadcastHashJoin
+                                       :     :                 :              :- CometProject
+                                       :     :                 :              :  +- CometBroadcastHashJoin
+                                       :     :                 :              :     :- CometFilter
+                                       :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                       :     :                 :              :     :        +- CometSubqueryBroadcast
+                                       :     :                 :              :     :           +- CometBroadcastExchange
+                                       :     :                 :              :     :              +- CometProject
+                                       :     :                 :              :     :                 +- CometFilter
+                                       :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       :     :                 :              :     +- CometBroadcastExchange
+                                       :     :                 :              :        +- CometBroadcastHashJoin
+                                       :     :                 :              :           :- CometFilter
+                                       :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+                                       :     :                 :              :           +- CometBroadcastExchange
+                                       :     :                 :              :              +- CometProject
+                                       :     :                 :              :                 +- CometBroadcastHashJoin
+                                       :     :                 :              :                    :- CometProject
+                                       :     :                 :              :                    :  +- CometBroadcastHashJoin
+                                       :     :                 :              :                    :     :- CometFilter
+                                       :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                                       :     :                 :              :                    :     :        +- ReusedSubquery
+                                       :     :                 :              :                    :     +- CometBroadcastExchange
+                                       :     :                 :              :                    :        +- CometFilter
+                                       :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+                                       :     :                 :              :                    +- CometBroadcastExchange
+                                       :     :                 :              :                       +- CometProject
+                                       :     :                 :              :                          +- CometFilter
+                                       :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       :     :                 :              +- CometBroadcastExchange
+                                       :     :                 :                 +- CometProject
+                                       :     :                 :                    +- CometFilter
+                                       :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       :     :                 +- CometBroadcastExchange
+                                       :     :                    +- CometProject
+                                       :     :                       +- CometBroadcastHashJoin
+                                       :     :                          :- CometProject
+                                       :     :                          :  +- CometBroadcastHashJoin
+                                       :     :                          :     :- CometFilter
+                                       :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                                       :     :                          :     :        +- ReusedSubquery
+                                       :     :                          :     +- CometBroadcastExchange
+                                       :     :                          :        +- CometFilter
+                                       :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+                                       :     :                          +- CometBroadcastExchange
+                                       :     :                             +- CometProject
+                                       :     :                                +- CometFilter
+                                       :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       :     +- CometBroadcastExchange
+                                       :        +- CometBroadcastHashJoin
+                                       :           :- CometFilter
+                                       :           :  +- CometNativeScan parquet spark_catalog.default.item
+                                       :           +- CometBroadcastExchange
+                                       :              +- CometProject
+                                       :                 +- CometBroadcastHashJoin
+                                       :                    :- CometFilter
+                                       :                    :  +- CometNativeScan parquet spark_catalog.default.item
+                                       :                    +- CometBroadcastExchange
+                                       :                       +- CometBroadcastHashJoin
+                                       :                          :- CometHashAggregate
+                                       :                          :  +- CometExchange
+                                       :                          :     +- CometHashAggregate
+                                       :                          :        +- CometProject
+                                       :                          :           +- CometBroadcastHashJoin
+                                       :                          :              :- CometProject
+                                       :                          :              :  +- CometBroadcastHashJoin
+                                       :                          :              :     :- CometFilter
+                                       :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                       :                          :              :     :        +- CometSubqueryBroadcast
+                                       :                          :              :     :           +- CometBroadcastExchange
+                                       :                          :              :     :              +- CometProject
+                                       :                          :              :     :                 +- CometFilter
+                                       :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       :                          :              :     +- CometBroadcastExchange
+                                       :                          :              :        +- CometBroadcastHashJoin
+                                       :                          :              :           :- CometFilter
+                                       :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+                                       :                          :              :           +- CometBroadcastExchange
+                                       :                          :              :              +- CometProject
+                                       :                          :              :                 +- CometBroadcastHashJoin
+                                       :                          :              :                    :- CometProject
+                                       :                          :              :                    :  +- CometBroadcastHashJoin
+                                       :                          :              :                    :     :- CometFilter
+                                       :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                                       :                          :              :                    :     :        +- ReusedSubquery
+                                       :                          :              :                    :     +- CometBroadcastExchange
+                                       :                          :              :                    :        +- CometFilter
+                                       :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+                                       :                          :              :                    +- CometBroadcastExchange
+                                       :                          :              :                       +- CometProject
+                                       :                          :              :                          +- CometFilter
+                                       :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       :                          :              +- CometBroadcastExchange
+                                       :                          :                 +- CometProject
+                                       :                          :                    +- CometFilter
+                                       :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       :                          +- CometBroadcastExchange
+                                       :                             +- CometProject
+                                       :                                +- CometBroadcastHashJoin
+                                       :                                   :- CometProject
+                                       :                                   :  +- CometBroadcastHashJoin
+                                       :                                   :     :- CometFilter
+                                       :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                                       :                                   :     :        +- ReusedSubquery
+                                       :                                   :     +- CometBroadcastExchange
+                                       :                                   :        +- CometFilter
+                                       :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+                                       :                                   +- CometBroadcastExchange
+                                       :                                      +- CometProject
+                                       :                                         +- CometFilter
+                                       :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       +- CometBroadcastExchange
+                                          +- CometProject
+                                             +- CometFilter
+                                                +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 431 out of 458 eligible operators (94%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q14a.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q14a.native_iceberg_compat/extended.txt
@@ -1,0 +1,469 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometExpand
+               +- CometUnion
+                  :- CometProject
+                  :  +- CometFilter
+                  :     :  +- Subquery
+                  :     :     +- CometNativeColumnarToRow
+                  :     :        +- CometHashAggregate
+                  :     :           +- CometExchange
+                  :     :              +- CometHashAggregate
+                  :     :                 +- CometUnion
+                  :     :                    :- CometProject
+                  :     :                    :  +- CometBroadcastHashJoin
+                  :     :                    :     :- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :     :                    :     :     +- ReusedSubquery
+                  :     :                    :     +- CometBroadcastExchange
+                  :     :                    :        +- CometProject
+                  :     :                    :           +- CometFilter
+                  :     :                    :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :                    :- CometProject
+                  :     :                    :  +- CometBroadcastHashJoin
+                  :     :                    :     :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                  :     :                    :     :     +- ReusedSubquery
+                  :     :                    :     +- CometBroadcastExchange
+                  :     :                    :        +- CometProject
+                  :     :                    :           +- CometFilter
+                  :     :                    :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :                    +- CometProject
+                  :     :                       +- CometBroadcastHashJoin
+                  :     :                          :- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                  :     :                          :     +- ReusedSubquery
+                  :     :                          +- CometBroadcastExchange
+                  :     :                             +- CometProject
+                  :     :                                +- CometFilter
+                  :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     +- CometHashAggregate
+                  :        +- CometExchange
+                  :           +- CometHashAggregate
+                  :              +- CometProject
+                  :                 +- CometBroadcastHashJoin
+                  :                    :- CometProject
+                  :                    :  +- CometBroadcastHashJoin
+                  :                    :     :- CometBroadcastHashJoin
+                  :                    :     :  :- CometFilter
+                  :                    :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :                    :     :  :        +- SubqueryBroadcast
+                  :                    :     :  :           +- BroadcastExchange
+                  :                    :     :  :              +- CometNativeColumnarToRow
+                  :                    :     :  :                 +- CometProject
+                  :                    :     :  :                    +- CometFilter
+                  :                    :     :  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :                    :     :  +- CometBroadcastExchange
+                  :                    :     :     +- CometProject
+                  :                    :     :        +- CometBroadcastHashJoin
+                  :                    :     :           :- CometFilter
+                  :                    :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :                    :     :           +- CometBroadcastExchange
+                  :                    :     :              +- CometBroadcastHashJoin
+                  :                    :     :                 :- CometHashAggregate
+                  :                    :     :                 :  +- CometExchange
+                  :                    :     :                 :     +- CometHashAggregate
+                  :                    :     :                 :        +- CometProject
+                  :                    :     :                 :           +- CometBroadcastHashJoin
+                  :                    :     :                 :              :- CometProject
+                  :                    :     :                 :              :  +- CometBroadcastHashJoin
+                  :                    :     :                 :              :     :- CometFilter
+                  :                    :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :                    :     :                 :              :     :        +- SubqueryBroadcast
+                  :                    :     :                 :              :     :           +- BroadcastExchange
+                  :                    :     :                 :              :     :              +- CometNativeColumnarToRow
+                  :                    :     :                 :              :     :                 +- CometProject
+                  :                    :     :                 :              :     :                    +- CometFilter
+                  :                    :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :                    :     :                 :              :     +- CometBroadcastExchange
+                  :                    :     :                 :              :        +- CometBroadcastHashJoin
+                  :                    :     :                 :              :           :- CometFilter
+                  :                    :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :                    :     :                 :              :           +- CometBroadcastExchange
+                  :                    :     :                 :              :              +- CometProject
+                  :                    :     :                 :              :                 +- CometBroadcastHashJoin
+                  :                    :     :                 :              :                    :- CometProject
+                  :                    :     :                 :              :                    :  +- CometBroadcastHashJoin
+                  :                    :     :                 :              :                    :     :- CometFilter
+                  :                    :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                  :                    :     :                 :              :                    :     :        +- ReusedSubquery
+                  :                    :     :                 :              :                    :     +- CometBroadcastExchange
+                  :                    :     :                 :              :                    :        +- CometFilter
+                  :                    :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :                    :     :                 :              :                    +- CometBroadcastExchange
+                  :                    :     :                 :              :                       +- CometProject
+                  :                    :     :                 :              :                          +- CometFilter
+                  :                    :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :                    :     :                 :              +- CometBroadcastExchange
+                  :                    :     :                 :                 +- CometProject
+                  :                    :     :                 :                    +- CometFilter
+                  :                    :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :                    :     :                 +- CometBroadcastExchange
+                  :                    :     :                    +- CometProject
+                  :                    :     :                       +- CometBroadcastHashJoin
+                  :                    :     :                          :- CometProject
+                  :                    :     :                          :  +- CometBroadcastHashJoin
+                  :                    :     :                          :     :- CometFilter
+                  :                    :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                  :                    :     :                          :     :        +- ReusedSubquery
+                  :                    :     :                          :     +- CometBroadcastExchange
+                  :                    :     :                          :        +- CometFilter
+                  :                    :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :                    :     :                          +- CometBroadcastExchange
+                  :                    :     :                             +- CometProject
+                  :                    :     :                                +- CometFilter
+                  :                    :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :                    :     +- CometBroadcastExchange
+                  :                    :        +- CometBroadcastHashJoin
+                  :                    :           :- CometFilter
+                  :                    :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :                    :           +- CometBroadcastExchange
+                  :                    :              +- CometProject
+                  :                    :                 +- CometBroadcastHashJoin
+                  :                    :                    :- CometFilter
+                  :                    :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :                    :                    +- CometBroadcastExchange
+                  :                    :                       +- CometBroadcastHashJoin
+                  :                    :                          :- CometHashAggregate
+                  :                    :                          :  +- CometExchange
+                  :                    :                          :     +- CometHashAggregate
+                  :                    :                          :        +- CometProject
+                  :                    :                          :           +- CometBroadcastHashJoin
+                  :                    :                          :              :- CometProject
+                  :                    :                          :              :  +- CometBroadcastHashJoin
+                  :                    :                          :              :     :- CometFilter
+                  :                    :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :                    :                          :              :     :        +- SubqueryBroadcast
+                  :                    :                          :              :     :           +- BroadcastExchange
+                  :                    :                          :              :     :              +- CometNativeColumnarToRow
+                  :                    :                          :              :     :                 +- CometProject
+                  :                    :                          :              :     :                    +- CometFilter
+                  :                    :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :                    :                          :              :     +- CometBroadcastExchange
+                  :                    :                          :              :        +- CometBroadcastHashJoin
+                  :                    :                          :              :           :- CometFilter
+                  :                    :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :                    :                          :              :           +- CometBroadcastExchange
+                  :                    :                          :              :              +- CometProject
+                  :                    :                          :              :                 +- CometBroadcastHashJoin
+                  :                    :                          :              :                    :- CometProject
+                  :                    :                          :              :                    :  +- CometBroadcastHashJoin
+                  :                    :                          :              :                    :     :- CometFilter
+                  :                    :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                  :                    :                          :              :                    :     :        +- ReusedSubquery
+                  :                    :                          :              :                    :     +- CometBroadcastExchange
+                  :                    :                          :              :                    :        +- CometFilter
+                  :                    :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :                    :                          :              :                    +- CometBroadcastExchange
+                  :                    :                          :              :                       +- CometProject
+                  :                    :                          :              :                          +- CometFilter
+                  :                    :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :                    :                          :              +- CometBroadcastExchange
+                  :                    :                          :                 +- CometProject
+                  :                    :                          :                    +- CometFilter
+                  :                    :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :                    :                          +- CometBroadcastExchange
+                  :                    :                             +- CometProject
+                  :                    :                                +- CometBroadcastHashJoin
+                  :                    :                                   :- CometProject
+                  :                    :                                   :  +- CometBroadcastHashJoin
+                  :                    :                                   :     :- CometFilter
+                  :                    :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                  :                    :                                   :     :        +- ReusedSubquery
+                  :                    :                                   :     +- CometBroadcastExchange
+                  :                    :                                   :        +- CometFilter
+                  :                    :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :                    :                                   +- CometBroadcastExchange
+                  :                    :                                      +- CometProject
+                  :                    :                                         +- CometFilter
+                  :                    :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :                    +- CometBroadcastExchange
+                  :                       +- CometProject
+                  :                          +- CometFilter
+                  :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :- CometProject
+                  :  +- CometFilter
+                  :     :  +- ReusedSubquery
+                  :     +- CometHashAggregate
+                  :        +- CometExchange
+                  :           +- CometHashAggregate
+                  :              +- CometProject
+                  :                 +- CometBroadcastHashJoin
+                  :                    :- CometProject
+                  :                    :  +- CometBroadcastHashJoin
+                  :                    :     :- CometBroadcastHashJoin
+                  :                    :     :  :- CometFilter
+                  :                    :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                  :                    :     :  :        +- ReusedSubquery
+                  :                    :     :  +- CometBroadcastExchange
+                  :                    :     :     +- CometProject
+                  :                    :     :        +- CometBroadcastHashJoin
+                  :                    :     :           :- CometFilter
+                  :                    :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :                    :     :           +- CometBroadcastExchange
+                  :                    :     :              +- CometBroadcastHashJoin
+                  :                    :     :                 :- CometHashAggregate
+                  :                    :     :                 :  +- CometExchange
+                  :                    :     :                 :     +- CometHashAggregate
+                  :                    :     :                 :        +- CometProject
+                  :                    :     :                 :           +- CometBroadcastHashJoin
+                  :                    :     :                 :              :- CometProject
+                  :                    :     :                 :              :  +- CometBroadcastHashJoin
+                  :                    :     :                 :              :     :- CometFilter
+                  :                    :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :                    :     :                 :              :     :        +- SubqueryBroadcast
+                  :                    :     :                 :              :     :           +- BroadcastExchange
+                  :                    :     :                 :              :     :              +- CometNativeColumnarToRow
+                  :                    :     :                 :              :     :                 +- CometProject
+                  :                    :     :                 :              :     :                    +- CometFilter
+                  :                    :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :                    :     :                 :              :     +- CometBroadcastExchange
+                  :                    :     :                 :              :        +- CometBroadcastHashJoin
+                  :                    :     :                 :              :           :- CometFilter
+                  :                    :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :                    :     :                 :              :           +- CometBroadcastExchange
+                  :                    :     :                 :              :              +- CometProject
+                  :                    :     :                 :              :                 +- CometBroadcastHashJoin
+                  :                    :     :                 :              :                    :- CometProject
+                  :                    :     :                 :              :                    :  +- CometBroadcastHashJoin
+                  :                    :     :                 :              :                    :     :- CometFilter
+                  :                    :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                  :                    :     :                 :              :                    :     :        +- ReusedSubquery
+                  :                    :     :                 :              :                    :     +- CometBroadcastExchange
+                  :                    :     :                 :              :                    :        +- CometFilter
+                  :                    :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :                    :     :                 :              :                    +- CometBroadcastExchange
+                  :                    :     :                 :              :                       +- CometProject
+                  :                    :     :                 :              :                          +- CometFilter
+                  :                    :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :                    :     :                 :              +- CometBroadcastExchange
+                  :                    :     :                 :                 +- CometProject
+                  :                    :     :                 :                    +- CometFilter
+                  :                    :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :                    :     :                 +- CometBroadcastExchange
+                  :                    :     :                    +- CometProject
+                  :                    :     :                       +- CometBroadcastHashJoin
+                  :                    :     :                          :- CometProject
+                  :                    :     :                          :  +- CometBroadcastHashJoin
+                  :                    :     :                          :     :- CometFilter
+                  :                    :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                  :                    :     :                          :     :        +- ReusedSubquery
+                  :                    :     :                          :     +- CometBroadcastExchange
+                  :                    :     :                          :        +- CometFilter
+                  :                    :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :                    :     :                          +- CometBroadcastExchange
+                  :                    :     :                             +- CometProject
+                  :                    :     :                                +- CometFilter
+                  :                    :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :                    :     +- CometBroadcastExchange
+                  :                    :        +- CometBroadcastHashJoin
+                  :                    :           :- CometFilter
+                  :                    :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :                    :           +- CometBroadcastExchange
+                  :                    :              +- CometProject
+                  :                    :                 +- CometBroadcastHashJoin
+                  :                    :                    :- CometFilter
+                  :                    :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :                    :                    +- CometBroadcastExchange
+                  :                    :                       +- CometBroadcastHashJoin
+                  :                    :                          :- CometHashAggregate
+                  :                    :                          :  +- CometExchange
+                  :                    :                          :     +- CometHashAggregate
+                  :                    :                          :        +- CometProject
+                  :                    :                          :           +- CometBroadcastHashJoin
+                  :                    :                          :              :- CometProject
+                  :                    :                          :              :  +- CometBroadcastHashJoin
+                  :                    :                          :              :     :- CometFilter
+                  :                    :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :                    :                          :              :     :        +- SubqueryBroadcast
+                  :                    :                          :              :     :           +- BroadcastExchange
+                  :                    :                          :              :     :              +- CometNativeColumnarToRow
+                  :                    :                          :              :     :                 +- CometProject
+                  :                    :                          :              :     :                    +- CometFilter
+                  :                    :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :                    :                          :              :     +- CometBroadcastExchange
+                  :                    :                          :              :        +- CometBroadcastHashJoin
+                  :                    :                          :              :           :- CometFilter
+                  :                    :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :                    :                          :              :           +- CometBroadcastExchange
+                  :                    :                          :              :              +- CometProject
+                  :                    :                          :              :                 +- CometBroadcastHashJoin
+                  :                    :                          :              :                    :- CometProject
+                  :                    :                          :              :                    :  +- CometBroadcastHashJoin
+                  :                    :                          :              :                    :     :- CometFilter
+                  :                    :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                  :                    :                          :              :                    :     :        +- ReusedSubquery
+                  :                    :                          :              :                    :     +- CometBroadcastExchange
+                  :                    :                          :              :                    :        +- CometFilter
+                  :                    :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :                    :                          :              :                    +- CometBroadcastExchange
+                  :                    :                          :              :                       +- CometProject
+                  :                    :                          :              :                          +- CometFilter
+                  :                    :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :                    :                          :              +- CometBroadcastExchange
+                  :                    :                          :                 +- CometProject
+                  :                    :                          :                    +- CometFilter
+                  :                    :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :                    :                          +- CometBroadcastExchange
+                  :                    :                             +- CometProject
+                  :                    :                                +- CometBroadcastHashJoin
+                  :                    :                                   :- CometProject
+                  :                    :                                   :  +- CometBroadcastHashJoin
+                  :                    :                                   :     :- CometFilter
+                  :                    :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                  :                    :                                   :     :        +- ReusedSubquery
+                  :                    :                                   :     +- CometBroadcastExchange
+                  :                    :                                   :        +- CometFilter
+                  :                    :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :                    :                                   +- CometBroadcastExchange
+                  :                    :                                      +- CometProject
+                  :                    :                                         +- CometFilter
+                  :                    :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :                    +- CometBroadcastExchange
+                  :                       +- CometProject
+                  :                          +- CometFilter
+                  :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  +- CometProject
+                     +- CometFilter
+                        :  +- ReusedSubquery
+                        +- CometHashAggregate
+                           +- CometExchange
+                              +- CometHashAggregate
+                                 +- CometProject
+                                    +- CometBroadcastHashJoin
+                                       :- CometProject
+                                       :  +- CometBroadcastHashJoin
+                                       :     :- CometBroadcastHashJoin
+                                       :     :  :- CometFilter
+                                       :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                       :     :  :        +- ReusedSubquery
+                                       :     :  +- CometBroadcastExchange
+                                       :     :     +- CometProject
+                                       :     :        +- CometBroadcastHashJoin
+                                       :     :           :- CometFilter
+                                       :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                       :     :           +- CometBroadcastExchange
+                                       :     :              +- CometBroadcastHashJoin
+                                       :     :                 :- CometHashAggregate
+                                       :     :                 :  +- CometExchange
+                                       :     :                 :     +- CometHashAggregate
+                                       :     :                 :        +- CometProject
+                                       :     :                 :           +- CometBroadcastHashJoin
+                                       :     :                 :              :- CometProject
+                                       :     :                 :              :  +- CometBroadcastHashJoin
+                                       :     :                 :              :     :- CometFilter
+                                       :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                       :     :                 :              :     :        +- SubqueryBroadcast
+                                       :     :                 :              :     :           +- BroadcastExchange
+                                       :     :                 :              :     :              +- CometNativeColumnarToRow
+                                       :     :                 :              :     :                 +- CometProject
+                                       :     :                 :              :     :                    +- CometFilter
+                                       :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       :     :                 :              :     +- CometBroadcastExchange
+                                       :     :                 :              :        +- CometBroadcastHashJoin
+                                       :     :                 :              :           :- CometFilter
+                                       :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                       :     :                 :              :           +- CometBroadcastExchange
+                                       :     :                 :              :              +- CometProject
+                                       :     :                 :              :                 +- CometBroadcastHashJoin
+                                       :     :                 :              :                    :- CometProject
+                                       :     :                 :              :                    :  +- CometBroadcastHashJoin
+                                       :     :                 :              :                    :     :- CometFilter
+                                       :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                                       :     :                 :              :                    :     :        +- ReusedSubquery
+                                       :     :                 :              :                    :     +- CometBroadcastExchange
+                                       :     :                 :              :                    :        +- CometFilter
+                                       :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                       :     :                 :              :                    +- CometBroadcastExchange
+                                       :     :                 :              :                       +- CometProject
+                                       :     :                 :              :                          +- CometFilter
+                                       :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       :     :                 :              +- CometBroadcastExchange
+                                       :     :                 :                 +- CometProject
+                                       :     :                 :                    +- CometFilter
+                                       :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       :     :                 +- CometBroadcastExchange
+                                       :     :                    +- CometProject
+                                       :     :                       +- CometBroadcastHashJoin
+                                       :     :                          :- CometProject
+                                       :     :                          :  +- CometBroadcastHashJoin
+                                       :     :                          :     :- CometFilter
+                                       :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                       :     :                          :     :        +- ReusedSubquery
+                                       :     :                          :     +- CometBroadcastExchange
+                                       :     :                          :        +- CometFilter
+                                       :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                       :     :                          +- CometBroadcastExchange
+                                       :     :                             +- CometProject
+                                       :     :                                +- CometFilter
+                                       :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       :     +- CometBroadcastExchange
+                                       :        +- CometBroadcastHashJoin
+                                       :           :- CometFilter
+                                       :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                       :           +- CometBroadcastExchange
+                                       :              +- CometProject
+                                       :                 +- CometBroadcastHashJoin
+                                       :                    :- CometFilter
+                                       :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                       :                    +- CometBroadcastExchange
+                                       :                       +- CometBroadcastHashJoin
+                                       :                          :- CometHashAggregate
+                                       :                          :  +- CometExchange
+                                       :                          :     +- CometHashAggregate
+                                       :                          :        +- CometProject
+                                       :                          :           +- CometBroadcastHashJoin
+                                       :                          :              :- CometProject
+                                       :                          :              :  +- CometBroadcastHashJoin
+                                       :                          :              :     :- CometFilter
+                                       :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                       :                          :              :     :        +- SubqueryBroadcast
+                                       :                          :              :     :           +- BroadcastExchange
+                                       :                          :              :     :              +- CometNativeColumnarToRow
+                                       :                          :              :     :                 +- CometProject
+                                       :                          :              :     :                    +- CometFilter
+                                       :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       :                          :              :     +- CometBroadcastExchange
+                                       :                          :              :        +- CometBroadcastHashJoin
+                                       :                          :              :           :- CometFilter
+                                       :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                       :                          :              :           +- CometBroadcastExchange
+                                       :                          :              :              +- CometProject
+                                       :                          :              :                 +- CometBroadcastHashJoin
+                                       :                          :              :                    :- CometProject
+                                       :                          :              :                    :  +- CometBroadcastHashJoin
+                                       :                          :              :                    :     :- CometFilter
+                                       :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                                       :                          :              :                    :     :        +- ReusedSubquery
+                                       :                          :              :                    :     +- CometBroadcastExchange
+                                       :                          :              :                    :        +- CometFilter
+                                       :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                       :                          :              :                    +- CometBroadcastExchange
+                                       :                          :              :                       +- CometProject
+                                       :                          :              :                          +- CometFilter
+                                       :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       :                          :              +- CometBroadcastExchange
+                                       :                          :                 +- CometProject
+                                       :                          :                    +- CometFilter
+                                       :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       :                          +- CometBroadcastExchange
+                                       :                             +- CometProject
+                                       :                                +- CometBroadcastHashJoin
+                                       :                                   :- CometProject
+                                       :                                   :  +- CometBroadcastHashJoin
+                                       :                                   :     :- CometFilter
+                                       :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                       :                                   :     :        +- ReusedSubquery
+                                       :                                   :     +- CometBroadcastExchange
+                                       :                                   :        +- CometFilter
+                                       :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                       :                                   +- CometBroadcastExchange
+                                       :                                      +- CometProject
+                                       :                                         +- CometFilter
+                                       :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       +- CometBroadcastExchange
+                                          +- CometProject
+                                             +- CometFilter
+                                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 424 out of 458 eligible operators (92%). Final plan contains 9 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q14b.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q14b.native_datafusion/extended.txt
@@ -1,0 +1,345 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometBroadcastHashJoin
+      :- CometFilter
+      :  :  +- Subquery
+      :  :     +- CometNativeColumnarToRow
+      :  :        +- CometHashAggregate
+      :  :           +- CometExchange
+      :  :              +- CometHashAggregate
+      :  :                 +- CometUnion
+      :  :                    :- CometProject
+      :  :                    :  +- CometBroadcastHashJoin
+      :  :                    :     :- CometNativeScan parquet spark_catalog.default.store_sales
+      :  :                    :     :     +- ReusedSubquery
+      :  :                    :     +- CometBroadcastExchange
+      :  :                    :        +- CometProject
+      :  :                    :           +- CometFilter
+      :  :                    :              +- CometNativeScan parquet spark_catalog.default.date_dim
+      :  :                    :- CometProject
+      :  :                    :  +- CometBroadcastHashJoin
+      :  :                    :     :- CometNativeScan parquet spark_catalog.default.catalog_sales
+      :  :                    :     :     +- ReusedSubquery
+      :  :                    :     +- CometBroadcastExchange
+      :  :                    :        +- CometProject
+      :  :                    :           +- CometFilter
+      :  :                    :              +- CometNativeScan parquet spark_catalog.default.date_dim
+      :  :                    +- CometProject
+      :  :                       +- CometBroadcastHashJoin
+      :  :                          :- CometNativeScan parquet spark_catalog.default.web_sales
+      :  :                          :     +- ReusedSubquery
+      :  :                          +- CometBroadcastExchange
+      :  :                             +- CometProject
+      :  :                                +- CometFilter
+      :  :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+      :  +- CometHashAggregate
+      :     +- CometExchange
+      :        +- CometHashAggregate
+      :           +- CometProject
+      :              +- CometBroadcastHashJoin
+      :                 :- CometProject
+      :                 :  +- CometBroadcastHashJoin
+      :                 :     :- CometBroadcastHashJoin
+      :                 :     :  :- CometFilter
+      :                 :     :  :  +- CometNativeScan parquet spark_catalog.default.store_sales
+      :                 :     :  :        +- CometSubqueryBroadcast
+      :                 :     :  :           +- CometBroadcastExchange
+      :                 :     :  :              +- CometProject
+      :                 :     :  :                 +- CometFilter
+      :                 :     :  :                    :  +- ReusedSubquery
+      :                 :     :  :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 :     :  :                          +- Subquery
+      :                 :     :  :                             +- CometNativeColumnarToRow
+      :                 :     :  :                                +- CometProject
+      :                 :     :  :                                   +- CometFilter
+      :                 :     :  :                                      +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 :     :  +- CometBroadcastExchange
+      :                 :     :     +- CometProject
+      :                 :     :        +- CometBroadcastHashJoin
+      :                 :     :           :- CometFilter
+      :                 :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+      :                 :     :           +- CometBroadcastExchange
+      :                 :     :              +- CometBroadcastHashJoin
+      :                 :     :                 :- CometHashAggregate
+      :                 :     :                 :  +- CometExchange
+      :                 :     :                 :     +- CometHashAggregate
+      :                 :     :                 :        +- CometProject
+      :                 :     :                 :           +- CometBroadcastHashJoin
+      :                 :     :                 :              :- CometProject
+      :                 :     :                 :              :  +- CometBroadcastHashJoin
+      :                 :     :                 :              :     :- CometFilter
+      :                 :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+      :                 :     :                 :              :     :        +- CometSubqueryBroadcast
+      :                 :     :                 :              :     :           +- CometBroadcastExchange
+      :                 :     :                 :              :     :              +- CometProject
+      :                 :     :                 :              :     :                 +- CometFilter
+      :                 :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 :     :                 :              :     +- CometBroadcastExchange
+      :                 :     :                 :              :        +- CometBroadcastHashJoin
+      :                 :     :                 :              :           :- CometFilter
+      :                 :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+      :                 :     :                 :              :           +- CometBroadcastExchange
+      :                 :     :                 :              :              +- CometProject
+      :                 :     :                 :              :                 +- CometBroadcastHashJoin
+      :                 :     :                 :              :                    :- CometProject
+      :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+      :                 :     :                 :              :                    :     :- CometFilter
+      :                 :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+      :                 :     :                 :              :                    :     :        +- ReusedSubquery
+      :                 :     :                 :              :                    :     +- CometBroadcastExchange
+      :                 :     :                 :              :                    :        +- CometFilter
+      :                 :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+      :                 :     :                 :              :                    +- CometBroadcastExchange
+      :                 :     :                 :              :                       +- CometProject
+      :                 :     :                 :              :                          +- CometFilter
+      :                 :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 :     :                 :              +- CometBroadcastExchange
+      :                 :     :                 :                 +- CometProject
+      :                 :     :                 :                    +- CometFilter
+      :                 :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 :     :                 +- CometBroadcastExchange
+      :                 :     :                    +- CometProject
+      :                 :     :                       +- CometBroadcastHashJoin
+      :                 :     :                          :- CometProject
+      :                 :     :                          :  +- CometBroadcastHashJoin
+      :                 :     :                          :     :- CometFilter
+      :                 :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+      :                 :     :                          :     :        +- ReusedSubquery
+      :                 :     :                          :     +- CometBroadcastExchange
+      :                 :     :                          :        +- CometFilter
+      :                 :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+      :                 :     :                          +- CometBroadcastExchange
+      :                 :     :                             +- CometProject
+      :                 :     :                                +- CometFilter
+      :                 :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 :     +- CometBroadcastExchange
+      :                 :        +- CometBroadcastHashJoin
+      :                 :           :- CometFilter
+      :                 :           :  +- CometNativeScan parquet spark_catalog.default.item
+      :                 :           +- CometBroadcastExchange
+      :                 :              +- CometProject
+      :                 :                 +- CometBroadcastHashJoin
+      :                 :                    :- CometFilter
+      :                 :                    :  +- CometNativeScan parquet spark_catalog.default.item
+      :                 :                    +- CometBroadcastExchange
+      :                 :                       +- CometBroadcastHashJoin
+      :                 :                          :- CometHashAggregate
+      :                 :                          :  +- CometExchange
+      :                 :                          :     +- CometHashAggregate
+      :                 :                          :        +- CometProject
+      :                 :                          :           +- CometBroadcastHashJoin
+      :                 :                          :              :- CometProject
+      :                 :                          :              :  +- CometBroadcastHashJoin
+      :                 :                          :              :     :- CometFilter
+      :                 :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+      :                 :                          :              :     :        +- CometSubqueryBroadcast
+      :                 :                          :              :     :           +- CometBroadcastExchange
+      :                 :                          :              :     :              +- CometProject
+      :                 :                          :              :     :                 +- CometFilter
+      :                 :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 :                          :              :     +- CometBroadcastExchange
+      :                 :                          :              :        +- CometBroadcastHashJoin
+      :                 :                          :              :           :- CometFilter
+      :                 :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+      :                 :                          :              :           +- CometBroadcastExchange
+      :                 :                          :              :              +- CometProject
+      :                 :                          :              :                 +- CometBroadcastHashJoin
+      :                 :                          :              :                    :- CometProject
+      :                 :                          :              :                    :  +- CometBroadcastHashJoin
+      :                 :                          :              :                    :     :- CometFilter
+      :                 :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+      :                 :                          :              :                    :     :        +- ReusedSubquery
+      :                 :                          :              :                    :     +- CometBroadcastExchange
+      :                 :                          :              :                    :        +- CometFilter
+      :                 :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+      :                 :                          :              :                    +- CometBroadcastExchange
+      :                 :                          :              :                       +- CometProject
+      :                 :                          :              :                          +- CometFilter
+      :                 :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 :                          :              +- CometBroadcastExchange
+      :                 :                          :                 +- CometProject
+      :                 :                          :                    +- CometFilter
+      :                 :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 :                          +- CometBroadcastExchange
+      :                 :                             +- CometProject
+      :                 :                                +- CometBroadcastHashJoin
+      :                 :                                   :- CometProject
+      :                 :                                   :  +- CometBroadcastHashJoin
+      :                 :                                   :     :- CometFilter
+      :                 :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+      :                 :                                   :     :        +- ReusedSubquery
+      :                 :                                   :     +- CometBroadcastExchange
+      :                 :                                   :        +- CometFilter
+      :                 :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+      :                 :                                   +- CometBroadcastExchange
+      :                 :                                      +- CometProject
+      :                 :                                         +- CometFilter
+      :                 :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 +- CometBroadcastExchange
+      :                    +- CometProject
+      :                       +- CometFilter
+      :                          :  +- ReusedSubquery
+      :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                                +- Subquery
+      :                                   +- CometNativeColumnarToRow
+      :                                      +- CometProject
+      :                                         +- CometFilter
+      :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+      +- CometBroadcastExchange
+         +- CometFilter
+            :  +- ReusedSubquery
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometBroadcastHashJoin
+                           :     :  :- CometFilter
+                           :     :  :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                           :     :  :        +- CometSubqueryBroadcast
+                           :     :  :           +- CometBroadcastExchange
+                           :     :  :              +- CometProject
+                           :     :  :                 +- CometFilter
+                           :     :  :                    :  +- ReusedSubquery
+                           :     :  :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     :  :                          +- Subquery
+                           :     :  :                             +- CometNativeColumnarToRow
+                           :     :  :                                +- CometProject
+                           :     :  :                                   +- CometFilter
+                           :     :  :                                      +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     :  +- CometBroadcastExchange
+                           :     :     +- CometProject
+                           :     :        +- CometBroadcastHashJoin
+                           :     :           :- CometFilter
+                           :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+                           :     :           +- CometBroadcastExchange
+                           :     :              +- CometBroadcastHashJoin
+                           :     :                 :- CometHashAggregate
+                           :     :                 :  +- CometExchange
+                           :     :                 :     +- CometHashAggregate
+                           :     :                 :        +- CometProject
+                           :     :                 :           +- CometBroadcastHashJoin
+                           :     :                 :              :- CometProject
+                           :     :                 :              :  +- CometBroadcastHashJoin
+                           :     :                 :              :     :- CometFilter
+                           :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                           :     :                 :              :     :        +- CometSubqueryBroadcast
+                           :     :                 :              :     :           +- CometBroadcastExchange
+                           :     :                 :              :     :              +- CometProject
+                           :     :                 :              :     :                 +- CometFilter
+                           :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     :                 :              :     +- CometBroadcastExchange
+                           :     :                 :              :        +- CometBroadcastHashJoin
+                           :     :                 :              :           :- CometFilter
+                           :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+                           :     :                 :              :           +- CometBroadcastExchange
+                           :     :                 :              :              +- CometProject
+                           :     :                 :              :                 +- CometBroadcastHashJoin
+                           :     :                 :              :                    :- CometProject
+                           :     :                 :              :                    :  +- CometBroadcastHashJoin
+                           :     :                 :              :                    :     :- CometFilter
+                           :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                           :     :                 :              :                    :     :        +- ReusedSubquery
+                           :     :                 :              :                    :     +- CometBroadcastExchange
+                           :     :                 :              :                    :        +- CometFilter
+                           :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+                           :     :                 :              :                    +- CometBroadcastExchange
+                           :     :                 :              :                       +- CometProject
+                           :     :                 :              :                          +- CometFilter
+                           :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     :                 :              +- CometBroadcastExchange
+                           :     :                 :                 +- CometProject
+                           :     :                 :                    +- CometFilter
+                           :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     :                 +- CometBroadcastExchange
+                           :     :                    +- CometProject
+                           :     :                       +- CometBroadcastHashJoin
+                           :     :                          :- CometProject
+                           :     :                          :  +- CometBroadcastHashJoin
+                           :     :                          :     :- CometFilter
+                           :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                           :     :                          :     :        +- ReusedSubquery
+                           :     :                          :     +- CometBroadcastExchange
+                           :     :                          :        +- CometFilter
+                           :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+                           :     :                          +- CometBroadcastExchange
+                           :     :                             +- CometProject
+                           :     :                                +- CometFilter
+                           :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     +- CometBroadcastExchange
+                           :        +- CometBroadcastHashJoin
+                           :           :- CometFilter
+                           :           :  +- CometNativeScan parquet spark_catalog.default.item
+                           :           +- CometBroadcastExchange
+                           :              +- CometProject
+                           :                 +- CometBroadcastHashJoin
+                           :                    :- CometFilter
+                           :                    :  +- CometNativeScan parquet spark_catalog.default.item
+                           :                    +- CometBroadcastExchange
+                           :                       +- CometBroadcastHashJoin
+                           :                          :- CometHashAggregate
+                           :                          :  +- CometExchange
+                           :                          :     +- CometHashAggregate
+                           :                          :        +- CometProject
+                           :                          :           +- CometBroadcastHashJoin
+                           :                          :              :- CometProject
+                           :                          :              :  +- CometBroadcastHashJoin
+                           :                          :              :     :- CometFilter
+                           :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                           :                          :              :     :        +- CometSubqueryBroadcast
+                           :                          :              :     :           +- CometBroadcastExchange
+                           :                          :              :     :              +- CometProject
+                           :                          :              :     :                 +- CometFilter
+                           :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :                          :              :     +- CometBroadcastExchange
+                           :                          :              :        +- CometBroadcastHashJoin
+                           :                          :              :           :- CometFilter
+                           :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+                           :                          :              :           +- CometBroadcastExchange
+                           :                          :              :              +- CometProject
+                           :                          :              :                 +- CometBroadcastHashJoin
+                           :                          :              :                    :- CometProject
+                           :                          :              :                    :  +- CometBroadcastHashJoin
+                           :                          :              :                    :     :- CometFilter
+                           :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                           :                          :              :                    :     :        +- ReusedSubquery
+                           :                          :              :                    :     +- CometBroadcastExchange
+                           :                          :              :                    :        +- CometFilter
+                           :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+                           :                          :              :                    +- CometBroadcastExchange
+                           :                          :              :                       +- CometProject
+                           :                          :              :                          +- CometFilter
+                           :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :                          :              +- CometBroadcastExchange
+                           :                          :                 +- CometProject
+                           :                          :                    +- CometFilter
+                           :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :                          +- CometBroadcastExchange
+                           :                             +- CometProject
+                           :                                +- CometBroadcastHashJoin
+                           :                                   :- CometProject
+                           :                                   :  +- CometBroadcastHashJoin
+                           :                                   :     :- CometFilter
+                           :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                           :                                   :     :        +- ReusedSubquery
+                           :                                   :     +- CometBroadcastExchange
+                           :                                   :        +- CometFilter
+                           :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+                           :                                   +- CometBroadcastExchange
+                           :                                      +- CometProject
+                           :                                         +- CometFilter
+                           :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+                           +- CometBroadcastExchange
+                              +- CometProject
+                                 +- CometFilter
+                                    :  +- ReusedSubquery
+                                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                          +- Subquery
+                                             +- CometNativeColumnarToRow
+                                                +- CometProject
+                                                   +- CometFilter
+                                                      +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 310 out of 337 eligible operators (91%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q14b.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q14b.native_iceberg_compat/extended.txt
@@ -1,0 +1,343 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometBroadcastHashJoin
+      :- CometFilter
+      :  :  +- Subquery
+      :  :     +- CometNativeColumnarToRow
+      :  :        +- CometHashAggregate
+      :  :           +- CometExchange
+      :  :              +- CometHashAggregate
+      :  :                 +- CometUnion
+      :  :                    :- CometProject
+      :  :                    :  +- CometBroadcastHashJoin
+      :  :                    :     :- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+      :  :                    :     :     +- ReusedSubquery
+      :  :                    :     +- CometBroadcastExchange
+      :  :                    :        +- CometProject
+      :  :                    :           +- CometFilter
+      :  :                    :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :  :                    :- CometProject
+      :  :                    :  +- CometBroadcastHashJoin
+      :  :                    :     :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+      :  :                    :     :     +- ReusedSubquery
+      :  :                    :     +- CometBroadcastExchange
+      :  :                    :        +- CometProject
+      :  :                    :           +- CometFilter
+      :  :                    :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :  :                    +- CometProject
+      :  :                       +- CometBroadcastHashJoin
+      :  :                          :- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+      :  :                          :     +- ReusedSubquery
+      :  :                          +- CometBroadcastExchange
+      :  :                             +- CometProject
+      :  :                                +- CometFilter
+      :  :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :  +- CometHashAggregate
+      :     +- CometExchange
+      :        +- CometHashAggregate
+      :           +- CometProject
+      :              +- CometBroadcastHashJoin
+      :                 :- CometProject
+      :                 :  +- CometBroadcastHashJoin
+      :                 :     :- CometBroadcastHashJoin
+      :                 :     :  :- CometFilter
+      :                 :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+      :                 :     :  :        +- SubqueryBroadcast
+      :                 :     :  :           +- BroadcastExchange
+      :                 :     :  :              +- CometNativeColumnarToRow
+      :                 :     :  :                 +- CometProject
+      :                 :     :  :                    +- CometFilter
+      :                 :     :  :                       :  +- ReusedSubquery
+      :                 :     :  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 :     :  :                             +- Subquery
+      :                 :     :  :                                +- CometNativeColumnarToRow
+      :                 :     :  :                                   +- CometProject
+      :                 :     :  :                                      +- CometFilter
+      :                 :     :  :                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 :     :  +- CometBroadcastExchange
+      :                 :     :     +- CometProject
+      :                 :     :        +- CometBroadcastHashJoin
+      :                 :     :           :- CometFilter
+      :                 :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                 :     :           +- CometBroadcastExchange
+      :                 :     :              +- CometBroadcastHashJoin
+      :                 :     :                 :- CometHashAggregate
+      :                 :     :                 :  +- CometExchange
+      :                 :     :                 :     +- CometHashAggregate
+      :                 :     :                 :        +- CometProject
+      :                 :     :                 :           +- CometBroadcastHashJoin
+      :                 :     :                 :              :- CometProject
+      :                 :     :                 :              :  +- CometBroadcastHashJoin
+      :                 :     :                 :              :     :- CometFilter
+      :                 :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+      :                 :     :                 :              :     :        +- SubqueryBroadcast
+      :                 :     :                 :              :     :           +- BroadcastExchange
+      :                 :     :                 :              :     :              +- CometNativeColumnarToRow
+      :                 :     :                 :              :     :                 +- CometProject
+      :                 :     :                 :              :     :                    +- CometFilter
+      :                 :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 :     :                 :              :     +- CometBroadcastExchange
+      :                 :     :                 :              :        +- CometBroadcastHashJoin
+      :                 :     :                 :              :           :- CometFilter
+      :                 :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                 :     :                 :              :           +- CometBroadcastExchange
+      :                 :     :                 :              :              +- CometProject
+      :                 :     :                 :              :                 +- CometBroadcastHashJoin
+      :                 :     :                 :              :                    :- CometProject
+      :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+      :                 :     :                 :              :                    :     :- CometFilter
+      :                 :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+      :                 :     :                 :              :                    :     :        +- ReusedSubquery
+      :                 :     :                 :              :                    :     +- CometBroadcastExchange
+      :                 :     :                 :              :                    :        +- CometFilter
+      :                 :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                 :     :                 :              :                    +- CometBroadcastExchange
+      :                 :     :                 :              :                       +- CometProject
+      :                 :     :                 :              :                          +- CometFilter
+      :                 :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 :     :                 :              +- CometBroadcastExchange
+      :                 :     :                 :                 +- CometProject
+      :                 :     :                 :                    +- CometFilter
+      :                 :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 :     :                 +- CometBroadcastExchange
+      :                 :     :                    +- CometProject
+      :                 :     :                       +- CometBroadcastHashJoin
+      :                 :     :                          :- CometProject
+      :                 :     :                          :  +- CometBroadcastHashJoin
+      :                 :     :                          :     :- CometFilter
+      :                 :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+      :                 :     :                          :     :        +- ReusedSubquery
+      :                 :     :                          :     +- CometBroadcastExchange
+      :                 :     :                          :        +- CometFilter
+      :                 :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                 :     :                          +- CometBroadcastExchange
+      :                 :     :                             +- CometProject
+      :                 :     :                                +- CometFilter
+      :                 :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 :     +- CometBroadcastExchange
+      :                 :        +- CometBroadcastHashJoin
+      :                 :           :- CometFilter
+      :                 :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                 :           +- CometBroadcastExchange
+      :                 :              +- CometProject
+      :                 :                 +- CometBroadcastHashJoin
+      :                 :                    :- CometFilter
+      :                 :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                 :                    +- CometBroadcastExchange
+      :                 :                       +- CometBroadcastHashJoin
+      :                 :                          :- CometHashAggregate
+      :                 :                          :  +- CometExchange
+      :                 :                          :     +- CometHashAggregate
+      :                 :                          :        +- CometProject
+      :                 :                          :           +- CometBroadcastHashJoin
+      :                 :                          :              :- CometProject
+      :                 :                          :              :  +- CometBroadcastHashJoin
+      :                 :                          :              :     :- CometFilter
+      :                 :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+      :                 :                          :              :     :        +- SubqueryBroadcast
+      :                 :                          :              :     :           +- BroadcastExchange
+      :                 :                          :              :     :              +- CometNativeColumnarToRow
+      :                 :                          :              :     :                 +- CometProject
+      :                 :                          :              :     :                    +- CometFilter
+      :                 :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 :                          :              :     +- CometBroadcastExchange
+      :                 :                          :              :        +- CometBroadcastHashJoin
+      :                 :                          :              :           :- CometFilter
+      :                 :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                 :                          :              :           +- CometBroadcastExchange
+      :                 :                          :              :              +- CometProject
+      :                 :                          :              :                 +- CometBroadcastHashJoin
+      :                 :                          :              :                    :- CometProject
+      :                 :                          :              :                    :  +- CometBroadcastHashJoin
+      :                 :                          :              :                    :     :- CometFilter
+      :                 :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+      :                 :                          :              :                    :     :        +- ReusedSubquery
+      :                 :                          :              :                    :     +- CometBroadcastExchange
+      :                 :                          :              :                    :        +- CometFilter
+      :                 :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                 :                          :              :                    +- CometBroadcastExchange
+      :                 :                          :              :                       +- CometProject
+      :                 :                          :              :                          +- CometFilter
+      :                 :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 :                          :              +- CometBroadcastExchange
+      :                 :                          :                 +- CometProject
+      :                 :                          :                    +- CometFilter
+      :                 :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 :                          +- CometBroadcastExchange
+      :                 :                             +- CometProject
+      :                 :                                +- CometBroadcastHashJoin
+      :                 :                                   :- CometProject
+      :                 :                                   :  +- CometBroadcastHashJoin
+      :                 :                                   :     :- CometFilter
+      :                 :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+      :                 :                                   :     :        +- ReusedSubquery
+      :                 :                                   :     +- CometBroadcastExchange
+      :                 :                                   :        +- CometFilter
+      :                 :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                 :                                   +- CometBroadcastExchange
+      :                 :                                      +- CometProject
+      :                 :                                         +- CometFilter
+      :                 :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 +- CometBroadcastExchange
+      :                    +- CometProject
+      :                       +- CometFilter
+      :                          :  +- ReusedSubquery
+      :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                                +- ReusedSubquery
+      +- CometBroadcastExchange
+         +- CometFilter
+            :  +- ReusedSubquery
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometBroadcastHashJoin
+                           :     :  :- CometFilter
+                           :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                           :     :  :        +- SubqueryBroadcast
+                           :     :  :           +- BroadcastExchange
+                           :     :  :              +- CometNativeColumnarToRow
+                           :     :  :                 +- CometProject
+                           :     :  :                    +- CometFilter
+                           :     :  :                       :  +- ReusedSubquery
+                           :     :  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     :  :                             +- Subquery
+                           :     :  :                                +- CometNativeColumnarToRow
+                           :     :  :                                   +- CometProject
+                           :     :  :                                      +- CometFilter
+                           :     :  :                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     :  +- CometBroadcastExchange
+                           :     :     +- CometProject
+                           :     :        +- CometBroadcastHashJoin
+                           :     :           :- CometFilter
+                           :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :     :           +- CometBroadcastExchange
+                           :     :              +- CometBroadcastHashJoin
+                           :     :                 :- CometHashAggregate
+                           :     :                 :  +- CometExchange
+                           :     :                 :     +- CometHashAggregate
+                           :     :                 :        +- CometProject
+                           :     :                 :           +- CometBroadcastHashJoin
+                           :     :                 :              :- CometProject
+                           :     :                 :              :  +- CometBroadcastHashJoin
+                           :     :                 :              :     :- CometFilter
+                           :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                           :     :                 :              :     :        +- SubqueryBroadcast
+                           :     :                 :              :     :           +- BroadcastExchange
+                           :     :                 :              :     :              +- CometNativeColumnarToRow
+                           :     :                 :              :     :                 +- CometProject
+                           :     :                 :              :     :                    +- CometFilter
+                           :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     :                 :              :     +- CometBroadcastExchange
+                           :     :                 :              :        +- CometBroadcastHashJoin
+                           :     :                 :              :           :- CometFilter
+                           :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :     :                 :              :           +- CometBroadcastExchange
+                           :     :                 :              :              +- CometProject
+                           :     :                 :              :                 +- CometBroadcastHashJoin
+                           :     :                 :              :                    :- CometProject
+                           :     :                 :              :                    :  +- CometBroadcastHashJoin
+                           :     :                 :              :                    :     :- CometFilter
+                           :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                           :     :                 :              :                    :     :        +- ReusedSubquery
+                           :     :                 :              :                    :     +- CometBroadcastExchange
+                           :     :                 :              :                    :        +- CometFilter
+                           :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :     :                 :              :                    +- CometBroadcastExchange
+                           :     :                 :              :                       +- CometProject
+                           :     :                 :              :                          +- CometFilter
+                           :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     :                 :              +- CometBroadcastExchange
+                           :     :                 :                 +- CometProject
+                           :     :                 :                    +- CometFilter
+                           :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     :                 +- CometBroadcastExchange
+                           :     :                    +- CometProject
+                           :     :                       +- CometBroadcastHashJoin
+                           :     :                          :- CometProject
+                           :     :                          :  +- CometBroadcastHashJoin
+                           :     :                          :     :- CometFilter
+                           :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                           :     :                          :     :        +- ReusedSubquery
+                           :     :                          :     +- CometBroadcastExchange
+                           :     :                          :        +- CometFilter
+                           :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :     :                          +- CometBroadcastExchange
+                           :     :                             +- CometProject
+                           :     :                                +- CometFilter
+                           :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     +- CometBroadcastExchange
+                           :        +- CometBroadcastHashJoin
+                           :           :- CometFilter
+                           :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :           +- CometBroadcastExchange
+                           :              +- CometProject
+                           :                 +- CometBroadcastHashJoin
+                           :                    :- CometFilter
+                           :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :                    +- CometBroadcastExchange
+                           :                       +- CometBroadcastHashJoin
+                           :                          :- CometHashAggregate
+                           :                          :  +- CometExchange
+                           :                          :     +- CometHashAggregate
+                           :                          :        +- CometProject
+                           :                          :           +- CometBroadcastHashJoin
+                           :                          :              :- CometProject
+                           :                          :              :  +- CometBroadcastHashJoin
+                           :                          :              :     :- CometFilter
+                           :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                           :                          :              :     :        +- SubqueryBroadcast
+                           :                          :              :     :           +- BroadcastExchange
+                           :                          :              :     :              +- CometNativeColumnarToRow
+                           :                          :              :     :                 +- CometProject
+                           :                          :              :     :                    +- CometFilter
+                           :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :                          :              :     +- CometBroadcastExchange
+                           :                          :              :        +- CometBroadcastHashJoin
+                           :                          :              :           :- CometFilter
+                           :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :                          :              :           +- CometBroadcastExchange
+                           :                          :              :              +- CometProject
+                           :                          :              :                 +- CometBroadcastHashJoin
+                           :                          :              :                    :- CometProject
+                           :                          :              :                    :  +- CometBroadcastHashJoin
+                           :                          :              :                    :     :- CometFilter
+                           :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                           :                          :              :                    :     :        +- ReusedSubquery
+                           :                          :              :                    :     +- CometBroadcastExchange
+                           :                          :              :                    :        +- CometFilter
+                           :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :                          :              :                    +- CometBroadcastExchange
+                           :                          :              :                       +- CometProject
+                           :                          :              :                          +- CometFilter
+                           :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :                          :              +- CometBroadcastExchange
+                           :                          :                 +- CometProject
+                           :                          :                    +- CometFilter
+                           :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :                          +- CometBroadcastExchange
+                           :                             +- CometProject
+                           :                                +- CometBroadcastHashJoin
+                           :                                   :- CometProject
+                           :                                   :  +- CometBroadcastHashJoin
+                           :                                   :     :- CometFilter
+                           :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                           :                                   :     :        +- ReusedSubquery
+                           :                                   :     +- CometBroadcastExchange
+                           :                                   :        +- CometFilter
+                           :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :                                   +- CometBroadcastExchange
+                           :                                      +- CometProject
+                           :                                         +- CometFilter
+                           :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           +- CometBroadcastExchange
+                              +- CometProject
+                                 +- CometFilter
+                                    :  +- ReusedSubquery
+                                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                          +- ReusedSubquery
+
+Comet accelerated 298 out of 331 eligible operators (90%). Final plan contains 10 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q15.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q15.native_datafusion/extended.txt
@@ -1,0 +1,31 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometFilter
+                  :     :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                  :     :     :        +- CometSubqueryBroadcast
+                  :     :     :           +- CometBroadcastExchange
+                  :     :     :              +- CometProject
+                  :     :     :                 +- CometFilter
+                  :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometFilter
+                  :     :           +- CometNativeScan parquet spark_catalog.default.customer
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 27 out of 28 eligible operators (96%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q15.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q15.native_iceberg_compat/extended.txt
@@ -1,0 +1,32 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometFilter
+                  :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                  :     :     :        +- SubqueryBroadcast
+                  :     :     :           +- BroadcastExchange
+                  :     :     :              +- CometNativeColumnarToRow
+                  :     :     :                 +- CometProject
+                  :     :     :                    +- CometFilter
+                  :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometFilter
+                  :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 26 out of 28 eligible operators (92%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q16.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q16.native_datafusion/extended.txt
@@ -1,0 +1,43 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometColumnarExchange
+      +- HashAggregate
+         +-  HashAggregate [COMET: Unsupported aggregation mode PartialMerge]
+            +- CometNativeColumnarToRow
+               +- CometHashAggregate
+                  +- CometProject
+                     +- CometBroadcastHashJoin
+                        :- CometProject
+                        :  +- CometBroadcastHashJoin
+                        :     :- CometProject
+                        :     :  +- CometBroadcastHashJoin
+                        :     :     :- CometSortMergeJoin
+                        :     :     :  :- CometProject
+                        :     :     :  :  +- CometSortMergeJoin
+                        :     :     :  :     :- CometSort
+                        :     :     :  :     :  +- CometExchange
+                        :     :     :  :     :     +- CometProject
+                        :     :     :  :     :        +- CometFilter
+                        :     :     :  :     :           +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                        :     :     :  :     +- CometSort
+                        :     :     :  :        +- CometExchange
+                        :     :     :  :           +- CometProject
+                        :     :     :  :              +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                        :     :     :  +- CometSort
+                        :     :     :     +- CometExchange
+                        :     :     :        +- CometProject
+                        :     :     :           +- CometNativeScan parquet spark_catalog.default.catalog_returns
+                        :     :     +- CometBroadcastExchange
+                        :     :        +- CometProject
+                        :     :           +- CometFilter
+                        :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                        :     +- CometBroadcastExchange
+                        :        +- CometProject
+                        :           +- CometFilter
+                        :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                        +- CometBroadcastExchange
+                           +- CometProject
+                              +- CometFilter
+                                 +- CometNativeScan parquet spark_catalog.default.call_center
+
+Comet accelerated 37 out of 39 eligible operators (94%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q16.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q16.native_iceberg_compat/extended.txt
@@ -1,0 +1,43 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometColumnarExchange
+      +- HashAggregate
+         +-  HashAggregate [COMET: Unsupported aggregation mode PartialMerge]
+            +- CometNativeColumnarToRow
+               +- CometHashAggregate
+                  +- CometProject
+                     +- CometBroadcastHashJoin
+                        :- CometProject
+                        :  +- CometBroadcastHashJoin
+                        :     :- CometProject
+                        :     :  +- CometBroadcastHashJoin
+                        :     :     :- CometSortMergeJoin
+                        :     :     :  :- CometProject
+                        :     :     :  :  +- CometSortMergeJoin
+                        :     :     :  :     :- CometSort
+                        :     :     :  :     :  +- CometExchange
+                        :     :     :  :     :     +- CometProject
+                        :     :     :  :     :        +- CometFilter
+                        :     :     :  :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                        :     :     :  :     +- CometSort
+                        :     :     :  :        +- CometExchange
+                        :     :     :  :           +- CometProject
+                        :     :     :  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                        :     :     :  +- CometSort
+                        :     :     :     +- CometExchange
+                        :     :     :        +- CometProject
+                        :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+                        :     :     +- CometBroadcastExchange
+                        :     :        +- CometProject
+                        :     :           +- CometFilter
+                        :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                        :     +- CometBroadcastExchange
+                        :        +- CometProject
+                        :           +- CometFilter
+                        :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                        +- CometBroadcastExchange
+                           +- CometProject
+                              +- CometFilter
+                                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.call_center
+
+Comet accelerated 37 out of 39 eligible operators (94%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q17.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q17.native_datafusion/extended.txt
@@ -1,0 +1,60 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometProject
+                  :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :- CometProject
+                  :     :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :     :- CometProject
+                  :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :     :     :- CometFilter
+                  :     :     :     :     :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                  :     :     :     :     :     :     :        +- CometSubqueryBroadcast
+                  :     :     :     :     :     :     :           +- CometBroadcastExchange
+                  :     :     :     :     :     :     :              +- CometProject
+                  :     :     :     :     :     :     :                 +- CometFilter
+                  :     :     :     :     :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :     :     :        +- CometFilter
+                  :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.store_returns
+                  :     :     :     :     :     :                 +- CometSubqueryBroadcast
+                  :     :     :     :     :     :                    +- CometBroadcastExchange
+                  :     :     :     :     :     :                       +- CometProject
+                  :     :     :     :     :     :                          +- CometFilter
+                  :     :     :     :     :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :     :        +- CometFilter
+                  :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                  :     :     :     :     :                 +- ReusedSubquery
+                  :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :        +- CometProject
+                  :     :     :     :           +- CometFilter
+                  :     :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometProject
+                  :     :     :           +- CometFilter
+                  :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometNativeScan parquet spark_catalog.default.store
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 54 out of 57 eligible operators (94%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q17.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q17.native_iceberg_compat/extended.txt
@@ -1,0 +1,62 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometProject
+                  :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :- CometProject
+                  :     :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :     :- CometProject
+                  :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :     :     :- CometFilter
+                  :     :     :     :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :     :     :     :     :     :     :        +- SubqueryBroadcast
+                  :     :     :     :     :     :     :           +- BroadcastExchange
+                  :     :     :     :     :     :     :              +- CometNativeColumnarToRow
+                  :     :     :     :     :     :     :                 +- CometProject
+                  :     :     :     :     :     :     :                    +- CometFilter
+                  :     :     :     :     :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :     :     :        +- CometFilter
+                  :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+                  :     :     :     :     :     :                 +- SubqueryBroadcast
+                  :     :     :     :     :     :                    +- BroadcastExchange
+                  :     :     :     :     :     :                       +- CometNativeColumnarToRow
+                  :     :     :     :     :     :                          +- CometProject
+                  :     :     :     :     :     :                             +- CometFilter
+                  :     :     :     :     :     :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :     :        +- CometFilter
+                  :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                  :     :     :     :     :                 +- ReusedSubquery
+                  :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :        +- CometProject
+                  :     :     :     :           +- CometFilter
+                  :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometProject
+                  :     :     :           +- CometFilter
+                  :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 52 out of 57 eligible operators (91%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q18.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q18.native_datafusion/extended.txt
@@ -1,0 +1,50 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometExpand
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometProject
+                     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :- CometProject
+                     :     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :     :- CometProject
+                     :     :     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :     :     :- CometFilter
+                     :     :     :     :     :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                     :     :     :     :     :     :        +- CometSubqueryBroadcast
+                     :     :     :     :     :     :           +- CometBroadcastExchange
+                     :     :     :     :     :     :              +- CometProject
+                     :     :     :     :     :     :                 +- CometFilter
+                     :     :     :     :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :     :     :     :     :     +- CometBroadcastExchange
+                     :     :     :     :     :        +- CometProject
+                     :     :     :     :     :           +- CometFilter
+                     :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+                     :     :     :     :     +- CometBroadcastExchange
+                     :     :     :     :        +- CometProject
+                     :     :     :     :           +- CometFilter
+                     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer
+                     :     :     :     +- CometBroadcastExchange
+                     :     :     :        +- CometFilter
+                     :     :     :           +- CometNativeScan parquet spark_catalog.default.customer_demographics
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometProject
+                     :     :           +- CometFilter
+                     :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                     +- CometBroadcastExchange
+                        +- CometProject
+                           +- CometFilter
+                              +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 46 out of 47 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q18.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q18.native_iceberg_compat/extended.txt
@@ -1,0 +1,51 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometExpand
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometProject
+                     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :- CometProject
+                     :     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :     :- CometProject
+                     :     :     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :     :     :- CometFilter
+                     :     :     :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                     :     :     :     :     :     :        +- SubqueryBroadcast
+                     :     :     :     :     :     :           +- BroadcastExchange
+                     :     :     :     :     :     :              +- CometNativeColumnarToRow
+                     :     :     :     :     :     :                 +- CometProject
+                     :     :     :     :     :     :                    +- CometFilter
+                     :     :     :     :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :     :     :     :     :     +- CometBroadcastExchange
+                     :     :     :     :     :        +- CometProject
+                     :     :     :     :     :           +- CometFilter
+                     :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+                     :     :     :     :     +- CometBroadcastExchange
+                     :     :     :     :        +- CometProject
+                     :     :     :     :           +- CometFilter
+                     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                     :     :     :     +- CometBroadcastExchange
+                     :     :     :        +- CometFilter
+                     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometProject
+                     :     :           +- CometFilter
+                     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     +- CometBroadcastExchange
+                        +- CometProject
+                           +- CometFilter
+                              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 45 out of 47 eligible operators (95%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q19.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q19.native_datafusion/extended.txt
@@ -1,0 +1,38 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometProject
+                  :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :- CometProject
+                  :     :     :     :     :  +- CometFilter
+                  :     :     :     :     :     +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :        +- CometFilter
+                  :     :     :     :           +- CometNativeScan parquet spark_catalog.default.store_sales
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometProject
+                  :     :     :           +- CometFilter
+                  :     :     :              +- CometNativeScan parquet spark_catalog.default.item
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometFilter
+                  :     :           +- CometNativeScan parquet spark_catalog.default.customer
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.store
+
+Comet accelerated 35 out of 35 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q19.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q19.native_iceberg_compat/extended.txt
@@ -1,0 +1,38 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometProject
+                  :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :- CometProject
+                  :     :     :     :     :  +- CometFilter
+                  :     :     :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :        +- CometFilter
+                  :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometProject
+                  :     :     :           +- CometFilter
+                  :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometFilter
+                  :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+
+Comet accelerated 35 out of 35 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q2.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q2.native_datafusion/extended.txt
@@ -1,0 +1,60 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometProject
+         +- CometBroadcastHashJoin
+            :- CometProject
+            :  +- CometBroadcastHashJoin
+            :     :- CometHashAggregate
+            :     :  +- CometExchange
+            :     :     +- CometHashAggregate
+            :     :        +- CometUnion
+            :     :           :- CometProject
+            :     :           :  +- CometBroadcastHashJoin
+            :     :           :     :- CometProject
+            :     :           :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+            :     :           :     +- CometBroadcastExchange
+            :     :           :        +- CometProject
+            :     :           :           +- CometFilter
+            :     :           :              +- CometNativeScan parquet spark_catalog.default.date_dim
+            :     :           +- CometProject
+            :     :              +- CometBroadcastHashJoin
+            :     :                 :- CometProject
+            :     :                 :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+            :     :                 +- CometBroadcastExchange
+            :     :                    +- CometProject
+            :     :                       +- CometFilter
+            :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+            :     +- CometBroadcastExchange
+            :        +- CometProject
+            :           +- CometFilter
+            :              +- CometNativeScan parquet spark_catalog.default.date_dim
+            +- CometBroadcastExchange
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometHashAggregate
+                     :  +- CometExchange
+                     :     +- CometHashAggregate
+                     :        +- CometUnion
+                     :           :- CometProject
+                     :           :  +- CometBroadcastHashJoin
+                     :           :     :- CometProject
+                     :           :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                     :           :     +- CometBroadcastExchange
+                     :           :        +- CometProject
+                     :           :           +- CometFilter
+                     :           :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :           +- CometProject
+                     :              +- CometBroadcastHashJoin
+                     :                 :- CometProject
+                     :                 :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                     :                 +- CometBroadcastExchange
+                     :                    +- CometProject
+                     :                       +- CometFilter
+                     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+                     +- CometBroadcastExchange
+                        +- CometProject
+                           +- CometFilter
+                              +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 57 out of 57 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q2.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q2.native_iceberg_compat/extended.txt
@@ -1,0 +1,60 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometProject
+         +- CometBroadcastHashJoin
+            :- CometProject
+            :  +- CometBroadcastHashJoin
+            :     :- CometHashAggregate
+            :     :  +- CometExchange
+            :     :     +- CometHashAggregate
+            :     :        +- CometUnion
+            :     :           :- CometProject
+            :     :           :  +- CometBroadcastHashJoin
+            :     :           :     :- CometProject
+            :     :           :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+            :     :           :     +- CometBroadcastExchange
+            :     :           :        +- CometProject
+            :     :           :           +- CometFilter
+            :     :           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :     :           +- CometProject
+            :     :              +- CometBroadcastHashJoin
+            :     :                 :- CometProject
+            :     :                 :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+            :     :                 +- CometBroadcastExchange
+            :     :                    +- CometProject
+            :     :                       +- CometFilter
+            :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :     +- CometBroadcastExchange
+            :        +- CometProject
+            :           +- CometFilter
+            :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            +- CometBroadcastExchange
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometHashAggregate
+                     :  +- CometExchange
+                     :     +- CometHashAggregate
+                     :        +- CometUnion
+                     :           :- CometProject
+                     :           :  +- CometBroadcastHashJoin
+                     :           :     :- CometProject
+                     :           :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                     :           :     +- CometBroadcastExchange
+                     :           :        +- CometProject
+                     :           :           +- CometFilter
+                     :           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :           +- CometProject
+                     :              +- CometBroadcastHashJoin
+                     :                 :- CometProject
+                     :                 :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                     :                 +- CometBroadcastExchange
+                     :                    +- CometProject
+                     :                       +- CometFilter
+                     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     +- CometBroadcastExchange
+                        +- CometProject
+                           +- CometFilter
+                              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 57 out of 57 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q20.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q20.native_datafusion/extended.txt
@@ -1,0 +1,30 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometBroadcastHashJoin
+                              :     :- CometFilter
+                              :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                              :     :        +- CometSubqueryBroadcast
+                              :     :           +- CometBroadcastExchange
+                              :     :              +- CometProject
+                              :     :                 +- CometFilter
+                              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :     +- CometBroadcastExchange
+                              :        +- CometProject
+                              :           +- CometFilter
+                              :              +- CometNativeScan parquet spark_catalog.default.item
+                              +- CometBroadcastExchange
+                                 +- CometProject
+                                    +- CometFilter
+                                       +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 23 out of 27 eligible operators (85%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q20.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q20.native_iceberg_compat/extended.txt
@@ -1,0 +1,31 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometBroadcastHashJoin
+                              :     :- CometFilter
+                              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                              :     :        +- SubqueryBroadcast
+                              :     :           +- BroadcastExchange
+                              :     :              +- CometNativeColumnarToRow
+                              :     :                 +- CometProject
+                              :     :                    +- CometFilter
+                              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :     +- CometBroadcastExchange
+                              :        +- CometProject
+                              :           +- CometFilter
+                              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                              +- CometBroadcastExchange
+                                 +- CometProject
+                                    +- CometFilter
+                                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 22 out of 27 eligible operators (81%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q21.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q21.native_datafusion/extended.txt
@@ -1,0 +1,30 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometFilter
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometFilter
+                     :     :     :  +- CometNativeScan parquet spark_catalog.default.inventory
+                     :     :     :        +- CometSubqueryBroadcast
+                     :     :     :           +- CometBroadcastExchange
+                     :     :     :              +- CometFilter
+                     :     :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometFilter
+                     :     :           +- CometNativeScan parquet spark_catalog.default.warehouse
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              +- CometNativeScan parquet spark_catalog.default.item
+                     +- CometBroadcastExchange
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 26 out of 27 eligible operators (96%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q21.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q21.native_iceberg_compat/extended.txt
@@ -1,0 +1,31 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometFilter
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometFilter
+                     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.inventory
+                     :     :     :        +- SubqueryBroadcast
+                     :     :     :           +- BroadcastExchange
+                     :     :     :              +- CometNativeColumnarToRow
+                     :     :     :                 +- CometFilter
+                     :     :     :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometFilter
+                     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.warehouse
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                     +- CometBroadcastExchange
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 25 out of 27 eligible operators (92%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q22.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q22.native_datafusion/extended.txt
@@ -1,0 +1,32 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometExpand
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometFilter
+                     :     :     :  +- CometNativeScan parquet spark_catalog.default.inventory
+                     :     :     :        +- CometSubqueryBroadcast
+                     :     :     :           +- CometBroadcastExchange
+                     :     :     :              +- CometProject
+                     :     :     :                 +- CometFilter
+                     :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometProject
+                     :     :           +- CometFilter
+                     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              +- CometNativeScan parquet spark_catalog.default.item
+                     +- CometBroadcastExchange
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.warehouse
+
+Comet accelerated 28 out of 29 eligible operators (96%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q22.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q22.native_iceberg_compat/extended.txt
@@ -1,0 +1,33 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometExpand
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometFilter
+                     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.inventory
+                     :     :     :        +- SubqueryBroadcast
+                     :     :     :           +- BroadcastExchange
+                     :     :     :              +- CometNativeColumnarToRow
+                     :     :     :                 +- CometProject
+                     :     :     :                    +- CometFilter
+                     :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometProject
+                     :     :           +- CometFilter
+                     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                     +- CometBroadcastExchange
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.warehouse
+
+Comet accelerated 27 out of 29 eligible operators (93%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q23a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q23a.native_datafusion/extended.txt
@@ -1,0 +1,142 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometUnion
+            :- CometProject
+            :  +- CometBroadcastHashJoin
+            :     :- CometProject
+            :     :  +- CometSortMergeJoin
+            :     :     :- CometSort
+            :     :     :  +- CometExchange
+            :     :     :     +- CometProject
+            :     :     :        +- CometBroadcastHashJoin
+            :     :     :           :- CometNativeScan parquet spark_catalog.default.catalog_sales
+            :     :     :           :     +- CometSubqueryBroadcast
+            :     :     :           :        +- CometBroadcastExchange
+            :     :     :           :           +- CometProject
+            :     :     :           :              +- CometFilter
+            :     :     :           :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+            :     :     :           +- CometBroadcastExchange
+            :     :     :              +- CometProject
+            :     :     :                 +- CometFilter
+            :     :     :                    +- CometHashAggregate
+            :     :     :                       +- CometExchange
+            :     :     :                          +- CometHashAggregate
+            :     :     :                             +- CometProject
+            :     :     :                                +- CometBroadcastHashJoin
+            :     :     :                                   :- CometProject
+            :     :     :                                   :  +- CometBroadcastHashJoin
+            :     :     :                                   :     :- CometFilter
+            :     :     :                                   :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+            :     :     :                                   :     :        +- CometSubqueryBroadcast
+            :     :     :                                   :     :           +- CometBroadcastExchange
+            :     :     :                                   :     :              +- CometProject
+            :     :     :                                   :     :                 +- CometFilter
+            :     :     :                                   :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+            :     :     :                                   :     +- CometBroadcastExchange
+            :     :     :                                   :        +- CometProject
+            :     :     :                                   :           +- CometFilter
+            :     :     :                                   :              +- CometNativeScan parquet spark_catalog.default.date_dim
+            :     :     :                                   +- CometBroadcastExchange
+            :     :     :                                      +- CometFilter
+            :     :     :                                         +- CometNativeScan parquet spark_catalog.default.item
+            :     :     +- CometSort
+            :     :        +- CometProject
+            :     :           +- CometFilter
+            :     :              :  +- Subquery
+            :     :              :     +- CometNativeColumnarToRow
+            :     :              :        +- CometHashAggregate
+            :     :              :           +- CometExchange
+            :     :              :              +- CometHashAggregate
+            :     :              :                 +- CometHashAggregate
+            :     :              :                    +- CometExchange
+            :     :              :                       +- CometHashAggregate
+            :     :              :                          +- CometProject
+            :     :              :                             +- CometBroadcastHashJoin
+            :     :              :                                :- CometProject
+            :     :              :                                :  +- CometBroadcastHashJoin
+            :     :              :                                :     :- CometFilter
+            :     :              :                                :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+            :     :              :                                :     :        +- CometSubqueryBroadcast
+            :     :              :                                :     :           +- CometBroadcastExchange
+            :     :              :                                :     :              +- CometProject
+            :     :              :                                :     :                 +- CometFilter
+            :     :              :                                :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+            :     :              :                                :     +- CometBroadcastExchange
+            :     :              :                                :        +- CometFilter
+            :     :              :                                :           +- CometNativeScan parquet spark_catalog.default.customer
+            :     :              :                                +- CometBroadcastExchange
+            :     :              :                                   +- CometProject
+            :     :              :                                      +- CometFilter
+            :     :              :                                         +- CometNativeScan parquet spark_catalog.default.date_dim
+            :     :              +- CometHashAggregate
+            :     :                 +- CometExchange
+            :     :                    +- CometHashAggregate
+            :     :                       +- CometProject
+            :     :                          +- CometBroadcastHashJoin
+            :     :                             :- CometProject
+            :     :                             :  +- CometFilter
+            :     :                             :     +- CometNativeScan parquet spark_catalog.default.store_sales
+            :     :                             +- CometBroadcastExchange
+            :     :                                +- CometFilter
+            :     :                                   +- CometNativeScan parquet spark_catalog.default.customer
+            :     +- CometBroadcastExchange
+            :        +- CometProject
+            :           +- CometFilter
+            :              +- CometNativeScan parquet spark_catalog.default.date_dim
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometSortMergeJoin
+                  :     :- CometSort
+                  :     :  +- CometExchange
+                  :     :     +- CometProject
+                  :     :        +- CometBroadcastHashJoin
+                  :     :           :- CometNativeScan parquet spark_catalog.default.web_sales
+                  :     :           :     +- ReusedSubquery
+                  :     :           +- CometBroadcastExchange
+                  :     :              +- CometProject
+                  :     :                 +- CometFilter
+                  :     :                    +- CometHashAggregate
+                  :     :                       +- CometExchange
+                  :     :                          +- CometHashAggregate
+                  :     :                             +- CometProject
+                  :     :                                +- CometBroadcastHashJoin
+                  :     :                                   :- CometProject
+                  :     :                                   :  +- CometBroadcastHashJoin
+                  :     :                                   :     :- CometFilter
+                  :     :                                   :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                  :     :                                   :     :        +- CometSubqueryBroadcast
+                  :     :                                   :     :           +- CometBroadcastExchange
+                  :     :                                   :     :              +- CometProject
+                  :     :                                   :     :                 +- CometFilter
+                  :     :                                   :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :                                   :     +- CometBroadcastExchange
+                  :     :                                   :        +- CometProject
+                  :     :                                   :           +- CometFilter
+                  :     :                                   :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :                                   +- CometBroadcastExchange
+                  :     :                                      +- CometFilter
+                  :     :                                         +- CometNativeScan parquet spark_catalog.default.item
+                  :     +- CometSort
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              :  +- ReusedSubquery
+                  :              +- CometHashAggregate
+                  :                 +- CometExchange
+                  :                    +- CometHashAggregate
+                  :                       +- CometProject
+                  :                          +- CometBroadcastHashJoin
+                  :                             :- CometProject
+                  :                             :  +- CometFilter
+                  :                             :     +- CometNativeScan parquet spark_catalog.default.store_sales
+                  :                             +- CometBroadcastExchange
+                  :                                +- CometFilter
+                  :                                   +- CometNativeScan parquet spark_catalog.default.customer
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 131 out of 138 eligible operators (94%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q23a.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q23a.native_iceberg_compat/extended.txt
@@ -1,0 +1,146 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometUnion
+            :- CometProject
+            :  +- CometBroadcastHashJoin
+            :     :- CometProject
+            :     :  +- CometSortMergeJoin
+            :     :     :- CometSort
+            :     :     :  +- CometExchange
+            :     :     :     +- CometProject
+            :     :     :        +- CometBroadcastHashJoin
+            :     :     :           :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+            :     :     :           :     +- SubqueryBroadcast
+            :     :     :           :        +- BroadcastExchange
+            :     :     :           :           +- CometNativeColumnarToRow
+            :     :     :           :              +- CometProject
+            :     :     :           :                 +- CometFilter
+            :     :     :           :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :     :     :           +- CometBroadcastExchange
+            :     :     :              +- CometProject
+            :     :     :                 +- CometFilter
+            :     :     :                    +- CometHashAggregate
+            :     :     :                       +- CometExchange
+            :     :     :                          +- CometHashAggregate
+            :     :     :                             +- CometProject
+            :     :     :                                +- CometBroadcastHashJoin
+            :     :     :                                   :- CometProject
+            :     :     :                                   :  +- CometBroadcastHashJoin
+            :     :     :                                   :     :- CometFilter
+            :     :     :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+            :     :     :                                   :     :        +- SubqueryBroadcast
+            :     :     :                                   :     :           +- BroadcastExchange
+            :     :     :                                   :     :              +- CometNativeColumnarToRow
+            :     :     :                                   :     :                 +- CometProject
+            :     :     :                                   :     :                    +- CometFilter
+            :     :     :                                   :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :     :     :                                   :     +- CometBroadcastExchange
+            :     :     :                                   :        +- CometProject
+            :     :     :                                   :           +- CometFilter
+            :     :     :                                   :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :     :     :                                   +- CometBroadcastExchange
+            :     :     :                                      +- CometFilter
+            :     :     :                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+            :     :     +- CometSort
+            :     :        +- CometProject
+            :     :           +- CometFilter
+            :     :              :  +- Subquery
+            :     :              :     +- CometNativeColumnarToRow
+            :     :              :        +- CometHashAggregate
+            :     :              :           +- CometExchange
+            :     :              :              +- CometHashAggregate
+            :     :              :                 +- CometHashAggregate
+            :     :              :                    +- CometExchange
+            :     :              :                       +- CometHashAggregate
+            :     :              :                          +- CometProject
+            :     :              :                             +- CometBroadcastHashJoin
+            :     :              :                                :- CometProject
+            :     :              :                                :  +- CometBroadcastHashJoin
+            :     :              :                                :     :- CometFilter
+            :     :              :                                :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+            :     :              :                                :     :        +- SubqueryBroadcast
+            :     :              :                                :     :           +- BroadcastExchange
+            :     :              :                                :     :              +- CometNativeColumnarToRow
+            :     :              :                                :     :                 +- CometProject
+            :     :              :                                :     :                    +- CometFilter
+            :     :              :                                :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :     :              :                                :     +- CometBroadcastExchange
+            :     :              :                                :        +- CometFilter
+            :     :              :                                :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+            :     :              :                                +- CometBroadcastExchange
+            :     :              :                                   +- CometProject
+            :     :              :                                      +- CometFilter
+            :     :              :                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :     :              +- CometHashAggregate
+            :     :                 +- CometExchange
+            :     :                    +- CometHashAggregate
+            :     :                       +- CometProject
+            :     :                          +- CometBroadcastHashJoin
+            :     :                             :- CometProject
+            :     :                             :  +- CometFilter
+            :     :                             :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+            :     :                             +- CometBroadcastExchange
+            :     :                                +- CometFilter
+            :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+            :     +- CometBroadcastExchange
+            :        +- CometProject
+            :           +- CometFilter
+            :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometSortMergeJoin
+                  :     :- CometSort
+                  :     :  +- CometExchange
+                  :     :     +- CometProject
+                  :     :        +- CometBroadcastHashJoin
+                  :     :           :- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                  :     :           :     +- ReusedSubquery
+                  :     :           +- CometBroadcastExchange
+                  :     :              +- CometProject
+                  :     :                 +- CometFilter
+                  :     :                    +- CometHashAggregate
+                  :     :                       +- CometExchange
+                  :     :                          +- CometHashAggregate
+                  :     :                             +- CometProject
+                  :     :                                +- CometBroadcastHashJoin
+                  :     :                                   :- CometProject
+                  :     :                                   :  +- CometBroadcastHashJoin
+                  :     :                                   :     :- CometFilter
+                  :     :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :     :                                   :     :        +- SubqueryBroadcast
+                  :     :                                   :     :           +- BroadcastExchange
+                  :     :                                   :     :              +- CometNativeColumnarToRow
+                  :     :                                   :     :                 +- CometProject
+                  :     :                                   :     :                    +- CometFilter
+                  :     :                                   :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :                                   :     +- CometBroadcastExchange
+                  :     :                                   :        +- CometProject
+                  :     :                                   :           +- CometFilter
+                  :     :                                   :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :                                   +- CometBroadcastExchange
+                  :     :                                      +- CometFilter
+                  :     :                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :     +- CometSort
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              :  +- ReusedSubquery
+                  :              +- CometHashAggregate
+                  :                 +- CometExchange
+                  :                    +- CometHashAggregate
+                  :                       +- CometProject
+                  :                          +- CometBroadcastHashJoin
+                  :                             :- CometProject
+                  :                             :  +- CometFilter
+                  :                             :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :                             +- CometBroadcastExchange
+                  :                                +- CometFilter
+                  :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 127 out of 138 eligible operators (92%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q23b.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q23b.native_datafusion/extended.txt
@@ -1,0 +1,194 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometUnion
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometProject
+      :           +- CometBroadcastHashJoin
+      :              :- CometProject
+      :              :  +- CometBroadcastHashJoin
+      :              :     :- CometSortMergeJoin
+      :              :     :  :- CometSort
+      :              :     :  :  +- CometExchange
+      :              :     :  :     +- CometProject
+      :              :     :  :        +- CometBroadcastHashJoin
+      :              :     :  :           :- CometFilter
+      :              :     :  :           :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+      :              :     :  :           :        +- CometSubqueryBroadcast
+      :              :     :  :           :           +- CometBroadcastExchange
+      :              :     :  :           :              +- CometProject
+      :              :     :  :           :                 +- CometFilter
+      :              :     :  :           :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+      :              :     :  :           +- CometBroadcastExchange
+      :              :     :  :              +- CometProject
+      :              :     :  :                 +- CometFilter
+      :              :     :  :                    +- CometHashAggregate
+      :              :     :  :                       +- CometExchange
+      :              :     :  :                          +- CometHashAggregate
+      :              :     :  :                             +- CometProject
+      :              :     :  :                                +- CometBroadcastHashJoin
+      :              :     :  :                                   :- CometProject
+      :              :     :  :                                   :  +- CometBroadcastHashJoin
+      :              :     :  :                                   :     :- CometFilter
+      :              :     :  :                                   :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+      :              :     :  :                                   :     :        +- CometSubqueryBroadcast
+      :              :     :  :                                   :     :           +- CometBroadcastExchange
+      :              :     :  :                                   :     :              +- CometProject
+      :              :     :  :                                   :     :                 +- CometFilter
+      :              :     :  :                                   :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+      :              :     :  :                                   :     +- CometBroadcastExchange
+      :              :     :  :                                   :        +- CometProject
+      :              :     :  :                                   :           +- CometFilter
+      :              :     :  :                                   :              +- CometNativeScan parquet spark_catalog.default.date_dim
+      :              :     :  :                                   +- CometBroadcastExchange
+      :              :     :  :                                      +- CometFilter
+      :              :     :  :                                         +- CometNativeScan parquet spark_catalog.default.item
+      :              :     :  +- CometSort
+      :              :     :     +- CometProject
+      :              :     :        +- CometFilter
+      :              :     :           :  +- Subquery
+      :              :     :           :     +- CometNativeColumnarToRow
+      :              :     :           :        +- CometHashAggregate
+      :              :     :           :           +- CometExchange
+      :              :     :           :              +- CometHashAggregate
+      :              :     :           :                 +- CometHashAggregate
+      :              :     :           :                    +- CometExchange
+      :              :     :           :                       +- CometHashAggregate
+      :              :     :           :                          +- CometProject
+      :              :     :           :                             +- CometBroadcastHashJoin
+      :              :     :           :                                :- CometProject
+      :              :     :           :                                :  +- CometBroadcastHashJoin
+      :              :     :           :                                :     :- CometFilter
+      :              :     :           :                                :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+      :              :     :           :                                :     :        +- CometSubqueryBroadcast
+      :              :     :           :                                :     :           +- CometBroadcastExchange
+      :              :     :           :                                :     :              +- CometProject
+      :              :     :           :                                :     :                 +- CometFilter
+      :              :     :           :                                :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+      :              :     :           :                                :     +- CometBroadcastExchange
+      :              :     :           :                                :        +- CometFilter
+      :              :     :           :                                :           +- CometNativeScan parquet spark_catalog.default.customer
+      :              :     :           :                                +- CometBroadcastExchange
+      :              :     :           :                                   +- CometProject
+      :              :     :           :                                      +- CometFilter
+      :              :     :           :                                         +- CometNativeScan parquet spark_catalog.default.date_dim
+      :              :     :           +- CometHashAggregate
+      :              :     :              +- CometExchange
+      :              :     :                 +- CometHashAggregate
+      :              :     :                    +- CometProject
+      :              :     :                       +- CometBroadcastHashJoin
+      :              :     :                          :- CometProject
+      :              :     :                          :  +- CometFilter
+      :              :     :                          :     +- CometNativeScan parquet spark_catalog.default.store_sales
+      :              :     :                          +- CometBroadcastExchange
+      :              :     :                             +- CometFilter
+      :              :     :                                +- CometNativeScan parquet spark_catalog.default.customer
+      :              :     +- CometBroadcastExchange
+      :              :        +- CometProject
+      :              :           +- CometSortMergeJoin
+      :              :              :- CometSort
+      :              :              :  +- CometExchange
+      :              :              :     +- CometFilter
+      :              :              :        +- CometNativeScan parquet spark_catalog.default.customer
+      :              :              +- CometSort
+      :              :                 +- CometProject
+      :              :                    +- CometFilter
+      :              :                       :  +- ReusedSubquery
+      :              :                       +- CometHashAggregate
+      :              :                          +- CometExchange
+      :              :                             +- CometHashAggregate
+      :              :                                +- CometProject
+      :              :                                   +- CometBroadcastHashJoin
+      :              :                                      :- CometProject
+      :              :                                      :  +- CometFilter
+      :              :                                      :     +- CometNativeScan parquet spark_catalog.default.store_sales
+      :              :                                      +- CometBroadcastExchange
+      :              :                                         +- CometFilter
+      :              :                                            +- CometNativeScan parquet spark_catalog.default.customer
+      :              +- CometBroadcastExchange
+      :                 +- CometProject
+      :                    +- CometFilter
+      :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometSortMergeJoin
+                     :     :  :- CometSort
+                     :     :  :  +- CometExchange
+                     :     :  :     +- CometProject
+                     :     :  :        +- CometBroadcastHashJoin
+                     :     :  :           :- CometFilter
+                     :     :  :           :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                     :     :  :           :        +- ReusedSubquery
+                     :     :  :           +- CometBroadcastExchange
+                     :     :  :              +- CometProject
+                     :     :  :                 +- CometFilter
+                     :     :  :                    +- CometHashAggregate
+                     :     :  :                       +- CometExchange
+                     :     :  :                          +- CometHashAggregate
+                     :     :  :                             +- CometProject
+                     :     :  :                                +- CometBroadcastHashJoin
+                     :     :  :                                   :- CometProject
+                     :     :  :                                   :  +- CometBroadcastHashJoin
+                     :     :  :                                   :     :- CometFilter
+                     :     :  :                                   :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                     :     :  :                                   :     :        +- CometSubqueryBroadcast
+                     :     :  :                                   :     :           +- CometBroadcastExchange
+                     :     :  :                                   :     :              +- CometProject
+                     :     :  :                                   :     :                 +- CometFilter
+                     :     :  :                                   :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :     :  :                                   :     +- CometBroadcastExchange
+                     :     :  :                                   :        +- CometProject
+                     :     :  :                                   :           +- CometFilter
+                     :     :  :                                   :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :     :  :                                   +- CometBroadcastExchange
+                     :     :  :                                      +- CometFilter
+                     :     :  :                                         +- CometNativeScan parquet spark_catalog.default.item
+                     :     :  +- CometSort
+                     :     :     +- CometProject
+                     :     :        +- CometFilter
+                     :     :           :  +- ReusedSubquery
+                     :     :           +- CometHashAggregate
+                     :     :              +- CometExchange
+                     :     :                 +- CometHashAggregate
+                     :     :                    +- CometProject
+                     :     :                       +- CometBroadcastHashJoin
+                     :     :                          :- CometProject
+                     :     :                          :  +- CometFilter
+                     :     :                          :     +- CometNativeScan parquet spark_catalog.default.store_sales
+                     :     :                          +- CometBroadcastExchange
+                     :     :                             +- CometFilter
+                     :     :                                +- CometNativeScan parquet spark_catalog.default.customer
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometSortMergeJoin
+                     :              :- CometSort
+                     :              :  +- CometExchange
+                     :              :     +- CometFilter
+                     :              :        +- CometNativeScan parquet spark_catalog.default.customer
+                     :              +- CometSort
+                     :                 +- CometProject
+                     :                    +- CometFilter
+                     :                       :  +- ReusedSubquery
+                     :                       +- CometHashAggregate
+                     :                          +- CometExchange
+                     :                             +- CometHashAggregate
+                     :                                +- CometProject
+                     :                                   +- CometBroadcastHashJoin
+                     :                                      :- CometProject
+                     :                                      :  +- CometFilter
+                     :                                      :     +- CometNativeScan parquet spark_catalog.default.store_sales
+                     :                                      +- CometBroadcastExchange
+                     :                                         +- CometFilter
+                     :                                            +- CometNativeScan parquet spark_catalog.default.customer
+                     +- CometBroadcastExchange
+                        +- CometProject
+                           +- CometFilter
+                              +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 181 out of 190 eligible operators (95%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q23b.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q23b.native_iceberg_compat/extended.txt
@@ -1,0 +1,198 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometUnion
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometProject
+      :           +- CometBroadcastHashJoin
+      :              :- CometProject
+      :              :  +- CometBroadcastHashJoin
+      :              :     :- CometSortMergeJoin
+      :              :     :  :- CometSort
+      :              :     :  :  +- CometExchange
+      :              :     :  :     +- CometProject
+      :              :     :  :        +- CometBroadcastHashJoin
+      :              :     :  :           :- CometFilter
+      :              :     :  :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+      :              :     :  :           :        +- SubqueryBroadcast
+      :              :     :  :           :           +- BroadcastExchange
+      :              :     :  :           :              +- CometNativeColumnarToRow
+      :              :     :  :           :                 +- CometProject
+      :              :     :  :           :                    +- CometFilter
+      :              :     :  :           :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :              :     :  :           +- CometBroadcastExchange
+      :              :     :  :              +- CometProject
+      :              :     :  :                 +- CometFilter
+      :              :     :  :                    +- CometHashAggregate
+      :              :     :  :                       +- CometExchange
+      :              :     :  :                          +- CometHashAggregate
+      :              :     :  :                             +- CometProject
+      :              :     :  :                                +- CometBroadcastHashJoin
+      :              :     :  :                                   :- CometProject
+      :              :     :  :                                   :  +- CometBroadcastHashJoin
+      :              :     :  :                                   :     :- CometFilter
+      :              :     :  :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+      :              :     :  :                                   :     :        +- SubqueryBroadcast
+      :              :     :  :                                   :     :           +- BroadcastExchange
+      :              :     :  :                                   :     :              +- CometNativeColumnarToRow
+      :              :     :  :                                   :     :                 +- CometProject
+      :              :     :  :                                   :     :                    +- CometFilter
+      :              :     :  :                                   :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :              :     :  :                                   :     +- CometBroadcastExchange
+      :              :     :  :                                   :        +- CometProject
+      :              :     :  :                                   :           +- CometFilter
+      :              :     :  :                                   :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :              :     :  :                                   +- CometBroadcastExchange
+      :              :     :  :                                      +- CometFilter
+      :              :     :  :                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :              :     :  +- CometSort
+      :              :     :     +- CometProject
+      :              :     :        +- CometFilter
+      :              :     :           :  +- Subquery
+      :              :     :           :     +- CometNativeColumnarToRow
+      :              :     :           :        +- CometHashAggregate
+      :              :     :           :           +- CometExchange
+      :              :     :           :              +- CometHashAggregate
+      :              :     :           :                 +- CometHashAggregate
+      :              :     :           :                    +- CometExchange
+      :              :     :           :                       +- CometHashAggregate
+      :              :     :           :                          +- CometProject
+      :              :     :           :                             +- CometBroadcastHashJoin
+      :              :     :           :                                :- CometProject
+      :              :     :           :                                :  +- CometBroadcastHashJoin
+      :              :     :           :                                :     :- CometFilter
+      :              :     :           :                                :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+      :              :     :           :                                :     :        +- SubqueryBroadcast
+      :              :     :           :                                :     :           +- BroadcastExchange
+      :              :     :           :                                :     :              +- CometNativeColumnarToRow
+      :              :     :           :                                :     :                 +- CometProject
+      :              :     :           :                                :     :                    +- CometFilter
+      :              :     :           :                                :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :              :     :           :                                :     +- CometBroadcastExchange
+      :              :     :           :                                :        +- CometFilter
+      :              :     :           :                                :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+      :              :     :           :                                +- CometBroadcastExchange
+      :              :     :           :                                   +- CometProject
+      :              :     :           :                                      +- CometFilter
+      :              :     :           :                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :              :     :           +- CometHashAggregate
+      :              :     :              +- CometExchange
+      :              :     :                 +- CometHashAggregate
+      :              :     :                    +- CometProject
+      :              :     :                       +- CometBroadcastHashJoin
+      :              :     :                          :- CometProject
+      :              :     :                          :  +- CometFilter
+      :              :     :                          :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+      :              :     :                          +- CometBroadcastExchange
+      :              :     :                             +- CometFilter
+      :              :     :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+      :              :     +- CometBroadcastExchange
+      :              :        +- CometProject
+      :              :           +- CometSortMergeJoin
+      :              :              :- CometSort
+      :              :              :  +- CometExchange
+      :              :              :     +- CometFilter
+      :              :              :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+      :              :              +- CometSort
+      :              :                 +- CometProject
+      :              :                    +- CometFilter
+      :              :                       :  +- ReusedSubquery
+      :              :                       +- CometHashAggregate
+      :              :                          +- CometExchange
+      :              :                             +- CometHashAggregate
+      :              :                                +- CometProject
+      :              :                                   +- CometBroadcastHashJoin
+      :              :                                      :- CometProject
+      :              :                                      :  +- CometFilter
+      :              :                                      :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+      :              :                                      +- CometBroadcastExchange
+      :              :                                         +- CometFilter
+      :              :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+      :              +- CometBroadcastExchange
+      :                 +- CometProject
+      :                    +- CometFilter
+      :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometSortMergeJoin
+                     :     :  :- CometSort
+                     :     :  :  +- CometExchange
+                     :     :  :     +- CometProject
+                     :     :  :        +- CometBroadcastHashJoin
+                     :     :  :           :- CometFilter
+                     :     :  :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                     :     :  :           :        +- ReusedSubquery
+                     :     :  :           +- CometBroadcastExchange
+                     :     :  :              +- CometProject
+                     :     :  :                 +- CometFilter
+                     :     :  :                    +- CometHashAggregate
+                     :     :  :                       +- CometExchange
+                     :     :  :                          +- CometHashAggregate
+                     :     :  :                             +- CometProject
+                     :     :  :                                +- CometBroadcastHashJoin
+                     :     :  :                                   :- CometProject
+                     :     :  :                                   :  +- CometBroadcastHashJoin
+                     :     :  :                                   :     :- CometFilter
+                     :     :  :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                     :     :  :                                   :     :        +- SubqueryBroadcast
+                     :     :  :                                   :     :           +- BroadcastExchange
+                     :     :  :                                   :     :              +- CometNativeColumnarToRow
+                     :     :  :                                   :     :                 +- CometProject
+                     :     :  :                                   :     :                    +- CometFilter
+                     :     :  :                                   :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :     :  :                                   :     +- CometBroadcastExchange
+                     :     :  :                                   :        +- CometProject
+                     :     :  :                                   :           +- CometFilter
+                     :     :  :                                   :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :     :  :                                   +- CometBroadcastExchange
+                     :     :  :                                      +- CometFilter
+                     :     :  :                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                     :     :  +- CometSort
+                     :     :     +- CometProject
+                     :     :        +- CometFilter
+                     :     :           :  +- ReusedSubquery
+                     :     :           +- CometHashAggregate
+                     :     :              +- CometExchange
+                     :     :                 +- CometHashAggregate
+                     :     :                    +- CometProject
+                     :     :                       +- CometBroadcastHashJoin
+                     :     :                          :- CometProject
+                     :     :                          :  +- CometFilter
+                     :     :                          :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                     :     :                          +- CometBroadcastExchange
+                     :     :                             +- CometFilter
+                     :     :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometSortMergeJoin
+                     :              :- CometSort
+                     :              :  +- CometExchange
+                     :              :     +- CometFilter
+                     :              :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                     :              +- CometSort
+                     :                 +- CometProject
+                     :                    +- CometFilter
+                     :                       :  +- ReusedSubquery
+                     :                       +- CometHashAggregate
+                     :                          +- CometExchange
+                     :                             +- CometHashAggregate
+                     :                                +- CometProject
+                     :                                   +- CometBroadcastHashJoin
+                     :                                      :- CometProject
+                     :                                      :  +- CometFilter
+                     :                                      :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                     :                                      +- CometBroadcastExchange
+                     :                                         +- CometFilter
+                     :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                     +- CometBroadcastExchange
+                        +- CometProject
+                           +- CometFilter
+                              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 177 out of 190 eligible operators (93%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q24a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q24a.native_datafusion/extended.txt
@@ -1,0 +1,92 @@
+Filter
+:  +- Subquery
+:     +- HashAggregate
+:        +- Exchange
+:           +- HashAggregate
+:              +- HashAggregate
+:                 +- Exchange
+:                    +- HashAggregate
+:                       +- Project
+:                          +-  BroadcastHashJoin [COMET: Comet is not compatible with Spark for case conversion in locale-specific cases. Set spark.comet.caseConversion.enabled=true to enable it anyway.]
+:                             :- CometNativeColumnarToRow
+:                             :  +- CometProject
+:                             :     +- CometBroadcastHashJoin
+:                             :        :- CometProject
+:                             :        :  +- CometBroadcastHashJoin
+:                             :        :     :- CometProject
+:                             :        :     :  +- CometBroadcastHashJoin
+:                             :        :     :     :- CometProject
+:                             :        :     :     :  +- CometSortMergeJoin
+:                             :        :     :     :     :- CometSort
+:                             :        :     :     :     :  +- CometExchange
+:                             :        :     :     :     :     +- CometProject
+:                             :        :     :     :     :        +- CometFilter
+:                             :        :     :     :     :           +- CometNativeScan parquet spark_catalog.default.store_sales
+:                             :        :     :     :     +- CometSort
+:                             :        :     :     :        +- CometExchange
+:                             :        :     :     :           +- CometProject
+:                             :        :     :     :              +- CometFilter
+:                             :        :     :     :                 +- CometNativeScan parquet spark_catalog.default.store_returns
+:                             :        :     :     +- CometBroadcastExchange
+:                             :        :     :        +- CometProject
+:                             :        :     :           +- CometFilter
+:                             :        :     :              +- CometNativeScan parquet spark_catalog.default.store
+:                             :        :     +- CometBroadcastExchange
+:                             :        :        +- CometProject
+:                             :        :           +- CometFilter
+:                             :        :              +- CometNativeScan parquet spark_catalog.default.item
+:                             :        +- CometBroadcastExchange
+:                             :           +- CometProject
+:                             :              +- CometFilter
+:                             :                 +- CometNativeScan parquet spark_catalog.default.customer
+:                             +- BroadcastExchange
+:                                +- CometNativeColumnarToRow
+:                                   +- CometProject
+:                                      +- CometFilter
+:                                         +- CometNativeScan parquet spark_catalog.default.customer_address
++- HashAggregate
+   +- Exchange
+      +- HashAggregate
+         +- HashAggregate
+            +- Exchange
+               +- HashAggregate
+                  +- Project
+                     +-  BroadcastHashJoin [COMET: Comet is not compatible with Spark for case conversion in locale-specific cases. Set spark.comet.caseConversion.enabled=true to enable it anyway.]
+                        :- CometNativeColumnarToRow
+                        :  +- CometProject
+                        :     +- CometBroadcastHashJoin
+                        :        :- CometProject
+                        :        :  +- CometBroadcastHashJoin
+                        :        :     :- CometProject
+                        :        :     :  +- CometBroadcastHashJoin
+                        :        :     :     :- CometProject
+                        :        :     :     :  +- CometSortMergeJoin
+                        :        :     :     :     :- CometSort
+                        :        :     :     :     :  +- CometExchange
+                        :        :     :     :     :     +- CometProject
+                        :        :     :     :     :        +- CometFilter
+                        :        :     :     :     :           +- CometNativeScan parquet spark_catalog.default.store_sales
+                        :        :     :     :     +- CometSort
+                        :        :     :     :        +- CometExchange
+                        :        :     :     :           +- CometProject
+                        :        :     :     :              +- CometFilter
+                        :        :     :     :                 +- CometNativeScan parquet spark_catalog.default.store_returns
+                        :        :     :     +- CometBroadcastExchange
+                        :        :     :        +- CometProject
+                        :        :     :           +- CometFilter
+                        :        :     :              +- CometNativeScan parquet spark_catalog.default.store
+                        :        :     +- CometBroadcastExchange
+                        :        :        +- CometProject
+                        :        :           +- CometFilter
+                        :        :              +- CometNativeScan parquet spark_catalog.default.item
+                        :        +- CometBroadcastExchange
+                        :           +- CometProject
+                        :              +- CometFilter
+                        :                 +- CometNativeScan parquet spark_catalog.default.customer
+                        +- BroadcastExchange
+                           +- CometNativeColumnarToRow
+                              +- CometProject
+                                 +- CometFilter
+                                    +- CometNativeScan parquet spark_catalog.default.customer_address
+
+Comet accelerated 66 out of 86 eligible operators (76%). Final plan contains 4 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q24a.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q24a.native_iceberg_compat/extended.txt
@@ -1,0 +1,92 @@
+Filter
+:  +- Subquery
+:     +- HashAggregate
+:        +- Exchange
+:           +- HashAggregate
+:              +- HashAggregate
+:                 +- Exchange
+:                    +- HashAggregate
+:                       +- Project
+:                          +-  BroadcastHashJoin [COMET: Comet is not compatible with Spark for case conversion in locale-specific cases. Set spark.comet.caseConversion.enabled=true to enable it anyway.]
+:                             :- CometNativeColumnarToRow
+:                             :  +- CometProject
+:                             :     +- CometBroadcastHashJoin
+:                             :        :- CometProject
+:                             :        :  +- CometBroadcastHashJoin
+:                             :        :     :- CometProject
+:                             :        :     :  +- CometBroadcastHashJoin
+:                             :        :     :     :- CometProject
+:                             :        :     :     :  +- CometSortMergeJoin
+:                             :        :     :     :     :- CometSort
+:                             :        :     :     :     :  +- CometExchange
+:                             :        :     :     :     :     +- CometProject
+:                             :        :     :     :     :        +- CometFilter
+:                             :        :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+:                             :        :     :     :     +- CometSort
+:                             :        :     :     :        +- CometExchange
+:                             :        :     :     :           +- CometProject
+:                             :        :     :     :              +- CometFilter
+:                             :        :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+:                             :        :     :     +- CometBroadcastExchange
+:                             :        :     :        +- CometProject
+:                             :        :     :           +- CometFilter
+:                             :        :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+:                             :        :     +- CometBroadcastExchange
+:                             :        :        +- CometProject
+:                             :        :           +- CometFilter
+:                             :        :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+:                             :        +- CometBroadcastExchange
+:                             :           +- CometProject
+:                             :              +- CometFilter
+:                             :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+:                             +- BroadcastExchange
+:                                +- CometNativeColumnarToRow
+:                                   +- CometProject
+:                                      +- CometFilter
+:                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
++- HashAggregate
+   +- Exchange
+      +- HashAggregate
+         +- HashAggregate
+            +- Exchange
+               +- HashAggregate
+                  +- Project
+                     +-  BroadcastHashJoin [COMET: Comet is not compatible with Spark for case conversion in locale-specific cases. Set spark.comet.caseConversion.enabled=true to enable it anyway.]
+                        :- CometNativeColumnarToRow
+                        :  +- CometProject
+                        :     +- CometBroadcastHashJoin
+                        :        :- CometProject
+                        :        :  +- CometBroadcastHashJoin
+                        :        :     :- CometProject
+                        :        :     :  +- CometBroadcastHashJoin
+                        :        :     :     :- CometProject
+                        :        :     :     :  +- CometSortMergeJoin
+                        :        :     :     :     :- CometSort
+                        :        :     :     :     :  +- CometExchange
+                        :        :     :     :     :     +- CometProject
+                        :        :     :     :     :        +- CometFilter
+                        :        :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                        :        :     :     :     +- CometSort
+                        :        :     :     :        +- CometExchange
+                        :        :     :     :           +- CometProject
+                        :        :     :     :              +- CometFilter
+                        :        :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+                        :        :     :     +- CometBroadcastExchange
+                        :        :     :        +- CometProject
+                        :        :     :           +- CometFilter
+                        :        :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                        :        :     +- CometBroadcastExchange
+                        :        :        +- CometProject
+                        :        :           +- CometFilter
+                        :        :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                        :        +- CometBroadcastExchange
+                        :           +- CometProject
+                        :              +- CometFilter
+                        :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                        +- BroadcastExchange
+                           +- CometNativeColumnarToRow
+                              +- CometProject
+                                 +- CometFilter
+                                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+
+Comet accelerated 66 out of 86 eligible operators (76%). Final plan contains 4 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q24b.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q24b.native_datafusion/extended.txt
@@ -1,0 +1,92 @@
+Filter
+:  +- Subquery
+:     +- HashAggregate
+:        +- Exchange
+:           +- HashAggregate
+:              +- HashAggregate
+:                 +- Exchange
+:                    +- HashAggregate
+:                       +- Project
+:                          +-  BroadcastHashJoin [COMET: Comet is not compatible with Spark for case conversion in locale-specific cases. Set spark.comet.caseConversion.enabled=true to enable it anyway.]
+:                             :- CometNativeColumnarToRow
+:                             :  +- CometProject
+:                             :     +- CometBroadcastHashJoin
+:                             :        :- CometProject
+:                             :        :  +- CometBroadcastHashJoin
+:                             :        :     :- CometProject
+:                             :        :     :  +- CometBroadcastHashJoin
+:                             :        :     :     :- CometProject
+:                             :        :     :     :  +- CometSortMergeJoin
+:                             :        :     :     :     :- CometSort
+:                             :        :     :     :     :  +- CometExchange
+:                             :        :     :     :     :     +- CometProject
+:                             :        :     :     :     :        +- CometFilter
+:                             :        :     :     :     :           +- CometNativeScan parquet spark_catalog.default.store_sales
+:                             :        :     :     :     +- CometSort
+:                             :        :     :     :        +- CometExchange
+:                             :        :     :     :           +- CometProject
+:                             :        :     :     :              +- CometFilter
+:                             :        :     :     :                 +- CometNativeScan parquet spark_catalog.default.store_returns
+:                             :        :     :     +- CometBroadcastExchange
+:                             :        :     :        +- CometProject
+:                             :        :     :           +- CometFilter
+:                             :        :     :              +- CometNativeScan parquet spark_catalog.default.store
+:                             :        :     +- CometBroadcastExchange
+:                             :        :        +- CometProject
+:                             :        :           +- CometFilter
+:                             :        :              +- CometNativeScan parquet spark_catalog.default.item
+:                             :        +- CometBroadcastExchange
+:                             :           +- CometProject
+:                             :              +- CometFilter
+:                             :                 +- CometNativeScan parquet spark_catalog.default.customer
+:                             +- BroadcastExchange
+:                                +- CometNativeColumnarToRow
+:                                   +- CometProject
+:                                      +- CometFilter
+:                                         +- CometNativeScan parquet spark_catalog.default.customer_address
++- HashAggregate
+   +- Exchange
+      +- HashAggregate
+         +- HashAggregate
+            +- Exchange
+               +- HashAggregate
+                  +- Project
+                     +-  BroadcastHashJoin [COMET: Comet is not compatible with Spark for case conversion in locale-specific cases. Set spark.comet.caseConversion.enabled=true to enable it anyway.]
+                        :- CometNativeColumnarToRow
+                        :  +- CometProject
+                        :     +- CometBroadcastHashJoin
+                        :        :- CometProject
+                        :        :  +- CometBroadcastHashJoin
+                        :        :     :- CometProject
+                        :        :     :  +- CometBroadcastHashJoin
+                        :        :     :     :- CometProject
+                        :        :     :     :  +- CometSortMergeJoin
+                        :        :     :     :     :- CometSort
+                        :        :     :     :     :  +- CometExchange
+                        :        :     :     :     :     +- CometProject
+                        :        :     :     :     :        +- CometFilter
+                        :        :     :     :     :           +- CometNativeScan parquet spark_catalog.default.store_sales
+                        :        :     :     :     +- CometSort
+                        :        :     :     :        +- CometExchange
+                        :        :     :     :           +- CometProject
+                        :        :     :     :              +- CometFilter
+                        :        :     :     :                 +- CometNativeScan parquet spark_catalog.default.store_returns
+                        :        :     :     +- CometBroadcastExchange
+                        :        :     :        +- CometProject
+                        :        :     :           +- CometFilter
+                        :        :     :              +- CometNativeScan parquet spark_catalog.default.store
+                        :        :     +- CometBroadcastExchange
+                        :        :        +- CometProject
+                        :        :           +- CometFilter
+                        :        :              +- CometNativeScan parquet spark_catalog.default.item
+                        :        +- CometBroadcastExchange
+                        :           +- CometProject
+                        :              +- CometFilter
+                        :                 +- CometNativeScan parquet spark_catalog.default.customer
+                        +- BroadcastExchange
+                           +- CometNativeColumnarToRow
+                              +- CometProject
+                                 +- CometFilter
+                                    +- CometNativeScan parquet spark_catalog.default.customer_address
+
+Comet accelerated 66 out of 86 eligible operators (76%). Final plan contains 4 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q24b.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q24b.native_iceberg_compat/extended.txt
@@ -1,0 +1,92 @@
+Filter
+:  +- Subquery
+:     +- HashAggregate
+:        +- Exchange
+:           +- HashAggregate
+:              +- HashAggregate
+:                 +- Exchange
+:                    +- HashAggregate
+:                       +- Project
+:                          +-  BroadcastHashJoin [COMET: Comet is not compatible with Spark for case conversion in locale-specific cases. Set spark.comet.caseConversion.enabled=true to enable it anyway.]
+:                             :- CometNativeColumnarToRow
+:                             :  +- CometProject
+:                             :     +- CometBroadcastHashJoin
+:                             :        :- CometProject
+:                             :        :  +- CometBroadcastHashJoin
+:                             :        :     :- CometProject
+:                             :        :     :  +- CometBroadcastHashJoin
+:                             :        :     :     :- CometProject
+:                             :        :     :     :  +- CometSortMergeJoin
+:                             :        :     :     :     :- CometSort
+:                             :        :     :     :     :  +- CometExchange
+:                             :        :     :     :     :     +- CometProject
+:                             :        :     :     :     :        +- CometFilter
+:                             :        :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+:                             :        :     :     :     +- CometSort
+:                             :        :     :     :        +- CometExchange
+:                             :        :     :     :           +- CometProject
+:                             :        :     :     :              +- CometFilter
+:                             :        :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+:                             :        :     :     +- CometBroadcastExchange
+:                             :        :     :        +- CometProject
+:                             :        :     :           +- CometFilter
+:                             :        :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+:                             :        :     +- CometBroadcastExchange
+:                             :        :        +- CometProject
+:                             :        :           +- CometFilter
+:                             :        :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+:                             :        +- CometBroadcastExchange
+:                             :           +- CometProject
+:                             :              +- CometFilter
+:                             :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+:                             +- BroadcastExchange
+:                                +- CometNativeColumnarToRow
+:                                   +- CometProject
+:                                      +- CometFilter
+:                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
++- HashAggregate
+   +- Exchange
+      +- HashAggregate
+         +- HashAggregate
+            +- Exchange
+               +- HashAggregate
+                  +- Project
+                     +-  BroadcastHashJoin [COMET: Comet is not compatible with Spark for case conversion in locale-specific cases. Set spark.comet.caseConversion.enabled=true to enable it anyway.]
+                        :- CometNativeColumnarToRow
+                        :  +- CometProject
+                        :     +- CometBroadcastHashJoin
+                        :        :- CometProject
+                        :        :  +- CometBroadcastHashJoin
+                        :        :     :- CometProject
+                        :        :     :  +- CometBroadcastHashJoin
+                        :        :     :     :- CometProject
+                        :        :     :     :  +- CometSortMergeJoin
+                        :        :     :     :     :- CometSort
+                        :        :     :     :     :  +- CometExchange
+                        :        :     :     :     :     +- CometProject
+                        :        :     :     :     :        +- CometFilter
+                        :        :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                        :        :     :     :     +- CometSort
+                        :        :     :     :        +- CometExchange
+                        :        :     :     :           +- CometProject
+                        :        :     :     :              +- CometFilter
+                        :        :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+                        :        :     :     +- CometBroadcastExchange
+                        :        :     :        +- CometProject
+                        :        :     :           +- CometFilter
+                        :        :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                        :        :     +- CometBroadcastExchange
+                        :        :        +- CometProject
+                        :        :           +- CometFilter
+                        :        :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                        :        +- CometBroadcastExchange
+                        :           +- CometProject
+                        :              +- CometFilter
+                        :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                        +- BroadcastExchange
+                           +- CometNativeColumnarToRow
+                              +- CometProject
+                                 +- CometFilter
+                                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+
+Comet accelerated 66 out of 86 eligible operators (76%). Final plan contains 4 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q25.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q25.native_datafusion/extended.txt
@@ -1,0 +1,60 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometProject
+                  :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :- CometProject
+                  :     :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :     :- CometProject
+                  :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :     :     :- CometFilter
+                  :     :     :     :     :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                  :     :     :     :     :     :     :        +- CometSubqueryBroadcast
+                  :     :     :     :     :     :     :           +- CometBroadcastExchange
+                  :     :     :     :     :     :     :              +- CometProject
+                  :     :     :     :     :     :     :                 +- CometFilter
+                  :     :     :     :     :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :     :     :        +- CometFilter
+                  :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.store_returns
+                  :     :     :     :     :     :                 +- CometSubqueryBroadcast
+                  :     :     :     :     :     :                    +- CometBroadcastExchange
+                  :     :     :     :     :     :                       +- CometProject
+                  :     :     :     :     :     :                          +- CometFilter
+                  :     :     :     :     :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :     :        +- CometFilter
+                  :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                  :     :     :     :     :                 +- ReusedSubquery
+                  :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :        +- CometProject
+                  :     :     :     :           +- CometFilter
+                  :     :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometProject
+                  :     :     :           +- CometFilter
+                  :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometNativeScan parquet spark_catalog.default.store
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 54 out of 57 eligible operators (94%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q25.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q25.native_iceberg_compat/extended.txt
@@ -1,0 +1,62 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometProject
+                  :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :- CometProject
+                  :     :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :     :- CometProject
+                  :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :     :     :- CometFilter
+                  :     :     :     :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :     :     :     :     :     :     :        +- SubqueryBroadcast
+                  :     :     :     :     :     :     :           +- BroadcastExchange
+                  :     :     :     :     :     :     :              +- CometNativeColumnarToRow
+                  :     :     :     :     :     :     :                 +- CometProject
+                  :     :     :     :     :     :     :                    +- CometFilter
+                  :     :     :     :     :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :     :     :        +- CometFilter
+                  :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+                  :     :     :     :     :     :                 +- SubqueryBroadcast
+                  :     :     :     :     :     :                    +- BroadcastExchange
+                  :     :     :     :     :     :                       +- CometNativeColumnarToRow
+                  :     :     :     :     :     :                          +- CometProject
+                  :     :     :     :     :     :                             +- CometFilter
+                  :     :     :     :     :     :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :     :        +- CometFilter
+                  :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                  :     :     :     :     :                 +- ReusedSubquery
+                  :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :        +- CometProject
+                  :     :     :     :           +- CometFilter
+                  :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometProject
+                  :     :     :           +- CometFilter
+                  :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 52 out of 57 eligible operators (91%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q26.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q26.native_datafusion/extended.txt
@@ -1,0 +1,38 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometFilter
+                  :     :     :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                  :     :     :     :        +- CometSubqueryBroadcast
+                  :     :     :     :           +- CometBroadcastExchange
+                  :     :     :     :              +- CometProject
+                  :     :     :     :                 +- CometFilter
+                  :     :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometProject
+                  :     :     :           +- CometFilter
+                  :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometNativeScan parquet spark_catalog.default.item
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.promotion
+
+Comet accelerated 34 out of 35 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q26.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q26.native_iceberg_compat/extended.txt
@@ -1,0 +1,39 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometFilter
+                  :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                  :     :     :     :        +- SubqueryBroadcast
+                  :     :     :     :           +- BroadcastExchange
+                  :     :     :     :              +- CometNativeColumnarToRow
+                  :     :     :     :                 +- CometProject
+                  :     :     :     :                    +- CometFilter
+                  :     :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometProject
+                  :     :     :           +- CometFilter
+                  :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+
+Comet accelerated 33 out of 35 eligible operators (94%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q27.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q27.native_datafusion/extended.txt
@@ -1,0 +1,39 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometExpand
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometProject
+                     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :- CometFilter
+                     :     :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                     :     :     :     :        +- CometSubqueryBroadcast
+                     :     :     :     :           +- CometBroadcastExchange
+                     :     :     :     :              +- CometProject
+                     :     :     :     :                 +- CometFilter
+                     :     :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :     :     :     +- CometBroadcastExchange
+                     :     :     :        +- CometProject
+                     :     :     :           +- CometFilter
+                     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometProject
+                     :     :           +- CometFilter
+                     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              +- CometNativeScan parquet spark_catalog.default.store
+                     +- CometBroadcastExchange
+                        +- CometProject
+                           +- CometFilter
+                              +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 35 out of 36 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q27.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q27.native_iceberg_compat/extended.txt
@@ -1,0 +1,40 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometExpand
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometProject
+                     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :- CometFilter
+                     :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                     :     :     :     :        +- SubqueryBroadcast
+                     :     :     :     :           +- BroadcastExchange
+                     :     :     :     :              +- CometNativeColumnarToRow
+                     :     :     :     :                 +- CometProject
+                     :     :     :     :                    +- CometFilter
+                     :     :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :     :     :     +- CometBroadcastExchange
+                     :     :     :        +- CometProject
+                     :     :     :           +- CometFilter
+                     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometProject
+                     :     :           +- CometFilter
+                     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                     +- CometBroadcastExchange
+                        +- CometProject
+                           +- CometFilter
+                              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 34 out of 36 eligible operators (94%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q28.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q28.native_datafusion/extended.txt
@@ -1,0 +1,78 @@
+BroadcastNestedLoopJoin
+:- BroadcastNestedLoopJoin
+:  :- BroadcastNestedLoopJoin
+:  :  :- BroadcastNestedLoopJoin
+:  :  :  :-  BroadcastNestedLoopJoin [COMET: BroadcastNestedLoopJoin is not supported]
+:  :  :  :  :- CometNativeColumnarToRow
+:  :  :  :  :  +- CometHashAggregate
+:  :  :  :  :     +- CometColumnarExchange
+:  :  :  :  :        +- HashAggregate
+:  :  :  :  :           +-  HashAggregate [COMET: Unsupported aggregation mode PartialMerge]
+:  :  :  :  :              +- CometNativeColumnarToRow
+:  :  :  :  :                 +- CometExchange
+:  :  :  :  :                    +- CometHashAggregate
+:  :  :  :  :                       +- CometProject
+:  :  :  :  :                          +- CometFilter
+:  :  :  :  :                             +- CometNativeScan parquet spark_catalog.default.store_sales
+:  :  :  :  +- BroadcastExchange
+:  :  :  :     +- CometNativeColumnarToRow
+:  :  :  :        +- CometHashAggregate
+:  :  :  :           +- CometColumnarExchange
+:  :  :  :              +- HashAggregate
+:  :  :  :                 +-  HashAggregate [COMET: Unsupported aggregation mode PartialMerge]
+:  :  :  :                    +- CometNativeColumnarToRow
+:  :  :  :                       +- CometExchange
+:  :  :  :                          +- CometHashAggregate
+:  :  :  :                             +- CometProject
+:  :  :  :                                +- CometFilter
+:  :  :  :                                   +- CometNativeScan parquet spark_catalog.default.store_sales
+:  :  :  +- BroadcastExchange
+:  :  :     +- CometNativeColumnarToRow
+:  :  :        +- CometHashAggregate
+:  :  :           +- CometColumnarExchange
+:  :  :              +- HashAggregate
+:  :  :                 +-  HashAggregate [COMET: Unsupported aggregation mode PartialMerge]
+:  :  :                    +- CometNativeColumnarToRow
+:  :  :                       +- CometExchange
+:  :  :                          +- CometHashAggregate
+:  :  :                             +- CometProject
+:  :  :                                +- CometFilter
+:  :  :                                   +- CometNativeScan parquet spark_catalog.default.store_sales
+:  :  +- BroadcastExchange
+:  :     +- CometNativeColumnarToRow
+:  :        +- CometHashAggregate
+:  :           +- CometColumnarExchange
+:  :              +- HashAggregate
+:  :                 +-  HashAggregate [COMET: Unsupported aggregation mode PartialMerge]
+:  :                    +- CometNativeColumnarToRow
+:  :                       +- CometExchange
+:  :                          +- CometHashAggregate
+:  :                             +- CometProject
+:  :                                +- CometFilter
+:  :                                   +- CometNativeScan parquet spark_catalog.default.store_sales
+:  +- BroadcastExchange
+:     +- CometNativeColumnarToRow
+:        +- CometHashAggregate
+:           +- CometColumnarExchange
+:              +- HashAggregate
+:                 +-  HashAggregate [COMET: Unsupported aggregation mode PartialMerge]
+:                    +- CometNativeColumnarToRow
+:                       +- CometExchange
+:                          +- CometHashAggregate
+:                             +- CometProject
+:                                +- CometFilter
+:                                   +- CometNativeScan parquet spark_catalog.default.store_sales
++- BroadcastExchange
+   +- CometNativeColumnarToRow
+      +- CometHashAggregate
+         +- CometColumnarExchange
+            +- HashAggregate
+               +-  HashAggregate [COMET: Unsupported aggregation mode PartialMerge]
+                  +- CometNativeColumnarToRow
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometFilter
+                                 +- CometNativeScan parquet spark_catalog.default.store_sales
+
+Comet accelerated 42 out of 64 eligible operators (65%). Final plan contains 12 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q28.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q28.native_iceberg_compat/extended.txt
@@ -1,0 +1,78 @@
+BroadcastNestedLoopJoin
+:- BroadcastNestedLoopJoin
+:  :- BroadcastNestedLoopJoin
+:  :  :- BroadcastNestedLoopJoin
+:  :  :  :-  BroadcastNestedLoopJoin [COMET: BroadcastNestedLoopJoin is not supported]
+:  :  :  :  :- CometNativeColumnarToRow
+:  :  :  :  :  +- CometHashAggregate
+:  :  :  :  :     +- CometColumnarExchange
+:  :  :  :  :        +- HashAggregate
+:  :  :  :  :           +-  HashAggregate [COMET: Unsupported aggregation mode PartialMerge]
+:  :  :  :  :              +- CometNativeColumnarToRow
+:  :  :  :  :                 +- CometExchange
+:  :  :  :  :                    +- CometHashAggregate
+:  :  :  :  :                       +- CometProject
+:  :  :  :  :                          +- CometFilter
+:  :  :  :  :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+:  :  :  :  +- BroadcastExchange
+:  :  :  :     +- CometNativeColumnarToRow
+:  :  :  :        +- CometHashAggregate
+:  :  :  :           +- CometColumnarExchange
+:  :  :  :              +- HashAggregate
+:  :  :  :                 +-  HashAggregate [COMET: Unsupported aggregation mode PartialMerge]
+:  :  :  :                    +- CometNativeColumnarToRow
+:  :  :  :                       +- CometExchange
+:  :  :  :                          +- CometHashAggregate
+:  :  :  :                             +- CometProject
+:  :  :  :                                +- CometFilter
+:  :  :  :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+:  :  :  +- BroadcastExchange
+:  :  :     +- CometNativeColumnarToRow
+:  :  :        +- CometHashAggregate
+:  :  :           +- CometColumnarExchange
+:  :  :              +- HashAggregate
+:  :  :                 +-  HashAggregate [COMET: Unsupported aggregation mode PartialMerge]
+:  :  :                    +- CometNativeColumnarToRow
+:  :  :                       +- CometExchange
+:  :  :                          +- CometHashAggregate
+:  :  :                             +- CometProject
+:  :  :                                +- CometFilter
+:  :  :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+:  :  +- BroadcastExchange
+:  :     +- CometNativeColumnarToRow
+:  :        +- CometHashAggregate
+:  :           +- CometColumnarExchange
+:  :              +- HashAggregate
+:  :                 +-  HashAggregate [COMET: Unsupported aggregation mode PartialMerge]
+:  :                    +- CometNativeColumnarToRow
+:  :                       +- CometExchange
+:  :                          +- CometHashAggregate
+:  :                             +- CometProject
+:  :                                +- CometFilter
+:  :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+:  +- BroadcastExchange
+:     +- CometNativeColumnarToRow
+:        +- CometHashAggregate
+:           +- CometColumnarExchange
+:              +- HashAggregate
+:                 +-  HashAggregate [COMET: Unsupported aggregation mode PartialMerge]
+:                    +- CometNativeColumnarToRow
+:                       +- CometExchange
+:                          +- CometHashAggregate
+:                             +- CometProject
+:                                +- CometFilter
+:                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
++- BroadcastExchange
+   +- CometNativeColumnarToRow
+      +- CometHashAggregate
+         +- CometColumnarExchange
+            +- HashAggregate
+               +-  HashAggregate [COMET: Unsupported aggregation mode PartialMerge]
+                  +- CometNativeColumnarToRow
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometFilter
+                                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+
+Comet accelerated 42 out of 64 eligible operators (65%). Final plan contains 12 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q29.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q29.native_datafusion/extended.txt
@@ -1,0 +1,64 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometProject
+                  :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :- CometProject
+                  :     :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :     :- CometProject
+                  :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :     :     :- CometFilter
+                  :     :     :     :     :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                  :     :     :     :     :     :     :        +- CometSubqueryBroadcast
+                  :     :     :     :     :     :     :           +- CometBroadcastExchange
+                  :     :     :     :     :     :     :              +- CometProject
+                  :     :     :     :     :     :     :                 +- CometFilter
+                  :     :     :     :     :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :     :     :        +- CometFilter
+                  :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.store_returns
+                  :     :     :     :     :     :                 +- CometSubqueryBroadcast
+                  :     :     :     :     :     :                    +- CometBroadcastExchange
+                  :     :     :     :     :     :                       +- CometProject
+                  :     :     :     :     :     :                          +- CometFilter
+                  :     :     :     :     :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :     :        +- CometFilter
+                  :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                  :     :     :     :     :                 +- CometSubqueryBroadcast
+                  :     :     :     :     :                    +- CometBroadcastExchange
+                  :     :     :     :     :                       +- CometProject
+                  :     :     :     :     :                          +- CometFilter
+                  :     :     :     :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :        +- CometProject
+                  :     :     :     :           +- CometFilter
+                  :     :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometProject
+                  :     :     :           +- CometFilter
+                  :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometNativeScan parquet spark_catalog.default.store
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 58 out of 61 eligible operators (95%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q29.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q29.native_iceberg_compat/extended.txt
@@ -1,0 +1,67 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometProject
+                  :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :- CometProject
+                  :     :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :     :- CometProject
+                  :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :     :     :- CometFilter
+                  :     :     :     :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :     :     :     :     :     :     :        +- SubqueryBroadcast
+                  :     :     :     :     :     :     :           +- BroadcastExchange
+                  :     :     :     :     :     :     :              +- CometNativeColumnarToRow
+                  :     :     :     :     :     :     :                 +- CometProject
+                  :     :     :     :     :     :     :                    +- CometFilter
+                  :     :     :     :     :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :     :     :        +- CometFilter
+                  :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+                  :     :     :     :     :     :                 +- SubqueryBroadcast
+                  :     :     :     :     :     :                    +- BroadcastExchange
+                  :     :     :     :     :     :                       +- CometNativeColumnarToRow
+                  :     :     :     :     :     :                          +- CometProject
+                  :     :     :     :     :     :                             +- CometFilter
+                  :     :     :     :     :     :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :     :        +- CometFilter
+                  :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                  :     :     :     :     :                 +- SubqueryBroadcast
+                  :     :     :     :     :                    +- BroadcastExchange
+                  :     :     :     :     :                       +- CometNativeColumnarToRow
+                  :     :     :     :     :                          +- CometProject
+                  :     :     :     :     :                             +- CometFilter
+                  :     :     :     :     :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :        +- CometProject
+                  :     :     :     :           +- CometFilter
+                  :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometProject
+                  :     :     :           +- CometFilter
+                  :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 55 out of 61 eligible operators (90%). Final plan contains 4 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q3.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q3.native_datafusion/extended.txt
@@ -1,0 +1,21 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometFilter
+                  :     :     +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometFilter
+                  :           +- CometNativeScan parquet spark_catalog.default.store_sales
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 18 out of 18 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q3.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q3.native_iceberg_compat/extended.txt
@@ -1,0 +1,21 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometFilter
+                  :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometFilter
+                  :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 18 out of 18 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q30.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q30.native_datafusion/extended.txt
@@ -1,0 +1,64 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometProject
+         :     :  +- CometBroadcastHashJoin
+         :     :     :- CometFilter
+         :     :     :  +- CometHashAggregate
+         :     :     :     +- CometExchange
+         :     :     :        +- CometHashAggregate
+         :     :     :           +- CometProject
+         :     :     :              +- CometBroadcastHashJoin
+         :     :     :                 :- CometProject
+         :     :     :                 :  +- CometBroadcastHashJoin
+         :     :     :                 :     :- CometFilter
+         :     :     :                 :     :  +- CometNativeScan parquet spark_catalog.default.web_returns
+         :     :     :                 :     :        +- CometSubqueryBroadcast
+         :     :     :                 :     :           +- CometBroadcastExchange
+         :     :     :                 :     :              +- CometProject
+         :     :     :                 :     :                 +- CometFilter
+         :     :     :                 :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :     :                 :     +- CometBroadcastExchange
+         :     :     :                 :        +- CometProject
+         :     :     :                 :           +- CometFilter
+         :     :     :                 :              +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :     :                 +- CometBroadcastExchange
+         :     :     :                    +- CometProject
+         :     :     :                       +- CometFilter
+         :     :     :                          +- CometNativeScan parquet spark_catalog.default.customer_address
+         :     :     +- CometBroadcastExchange
+         :     :        +- CometFilter
+         :     :           +- CometHashAggregate
+         :     :              +- CometExchange
+         :     :                 +- CometHashAggregate
+         :     :                    +- CometHashAggregate
+         :     :                       +- CometExchange
+         :     :                          +- CometHashAggregate
+         :     :                             +- CometProject
+         :     :                                +- CometBroadcastHashJoin
+         :     :                                   :- CometProject
+         :     :                                   :  +- CometBroadcastHashJoin
+         :     :                                   :     :- CometFilter
+         :     :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_returns
+         :     :                                   :     :        +- ReusedSubquery
+         :     :                                   :     +- CometBroadcastExchange
+         :     :                                   :        +- CometProject
+         :     :                                   :           +- CometFilter
+         :     :                                   :              +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :                                   +- CometBroadcastExchange
+         :     :                                      +- CometProject
+         :     :                                         +- CometFilter
+         :     :                                            +- CometNativeScan parquet spark_catalog.default.customer_address
+         :     +- CometBroadcastExchange
+         :        +- CometProject
+         :           +- CometFilter
+         :              +- CometNativeScan parquet spark_catalog.default.customer
+         +- CometBroadcastExchange
+            +- CometProject
+               +- CometFilter
+                  +- CometNativeScan parquet spark_catalog.default.customer_address
+
+Comet accelerated 59 out of 61 eligible operators (96%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q30.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q30.native_iceberg_compat/extended.txt
@@ -1,0 +1,65 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometProject
+         :     :  +- CometBroadcastHashJoin
+         :     :     :- CometFilter
+         :     :     :  +- CometHashAggregate
+         :     :     :     +- CometExchange
+         :     :     :        +- CometHashAggregate
+         :     :     :           +- CometProject
+         :     :     :              +- CometBroadcastHashJoin
+         :     :     :                 :- CometProject
+         :     :     :                 :  +- CometBroadcastHashJoin
+         :     :     :                 :     :- CometFilter
+         :     :     :                 :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+         :     :     :                 :     :        +- SubqueryBroadcast
+         :     :     :                 :     :           +- BroadcastExchange
+         :     :     :                 :     :              +- CometNativeColumnarToRow
+         :     :     :                 :     :                 +- CometProject
+         :     :     :                 :     :                    +- CometFilter
+         :     :     :                 :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :     :                 :     +- CometBroadcastExchange
+         :     :     :                 :        +- CometProject
+         :     :     :                 :           +- CometFilter
+         :     :     :                 :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :     :                 +- CometBroadcastExchange
+         :     :     :                    +- CometProject
+         :     :     :                       +- CometFilter
+         :     :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+         :     :     +- CometBroadcastExchange
+         :     :        +- CometFilter
+         :     :           +- CometHashAggregate
+         :     :              +- CometExchange
+         :     :                 +- CometHashAggregate
+         :     :                    +- CometHashAggregate
+         :     :                       +- CometExchange
+         :     :                          +- CometHashAggregate
+         :     :                             +- CometProject
+         :     :                                +- CometBroadcastHashJoin
+         :     :                                   :- CometProject
+         :     :                                   :  +- CometBroadcastHashJoin
+         :     :                                   :     :- CometFilter
+         :     :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+         :     :                                   :     :        +- ReusedSubquery
+         :     :                                   :     +- CometBroadcastExchange
+         :     :                                   :        +- CometProject
+         :     :                                   :           +- CometFilter
+         :     :                                   :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :                                   +- CometBroadcastExchange
+         :     :                                      +- CometProject
+         :     :                                         +- CometFilter
+         :     :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+         :     +- CometBroadcastExchange
+         :        +- CometProject
+         :           +- CometFilter
+         :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         +- CometBroadcastExchange
+            +- CometProject
+               +- CometFilter
+                  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+
+Comet accelerated 58 out of 61 eligible operators (95%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q31.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q31.native_datafusion/extended.txt
@@ -1,0 +1,123 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometProject
+         +- CometBroadcastHashJoin
+            :- CometProject
+            :  +- CometBroadcastHashJoin
+            :     :- CometBroadcastHashJoin
+            :     :  :- CometProject
+            :     :  :  +- CometBroadcastHashJoin
+            :     :  :     :- CometBroadcastHashJoin
+            :     :  :     :  :- CometHashAggregate
+            :     :  :     :  :  +- CometExchange
+            :     :  :     :  :     +- CometHashAggregate
+            :     :  :     :  :        +- CometProject
+            :     :  :     :  :           +- CometBroadcastHashJoin
+            :     :  :     :  :              :- CometProject
+            :     :  :     :  :              :  +- CometBroadcastHashJoin
+            :     :  :     :  :              :     :- CometFilter
+            :     :  :     :  :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+            :     :  :     :  :              :     :        +- CometSubqueryBroadcast
+            :     :  :     :  :              :     :           +- CometBroadcastExchange
+            :     :  :     :  :              :     :              +- CometFilter
+            :     :  :     :  :              :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+            :     :  :     :  :              :     +- CometBroadcastExchange
+            :     :  :     :  :              :        +- CometFilter
+            :     :  :     :  :              :           +- CometNativeScan parquet spark_catalog.default.date_dim
+            :     :  :     :  :              +- CometBroadcastExchange
+            :     :  :     :  :                 +- CometFilter
+            :     :  :     :  :                    +- CometNativeScan parquet spark_catalog.default.customer_address
+            :     :  :     :  +- CometBroadcastExchange
+            :     :  :     :     +- CometHashAggregate
+            :     :  :     :        +- CometExchange
+            :     :  :     :           +- CometHashAggregate
+            :     :  :     :              +- CometProject
+            :     :  :     :                 +- CometBroadcastHashJoin
+            :     :  :     :                    :- CometProject
+            :     :  :     :                    :  +- CometBroadcastHashJoin
+            :     :  :     :                    :     :- CometFilter
+            :     :  :     :                    :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+            :     :  :     :                    :     :        +- CometSubqueryBroadcast
+            :     :  :     :                    :     :           +- CometBroadcastExchange
+            :     :  :     :                    :     :              +- CometFilter
+            :     :  :     :                    :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+            :     :  :     :                    :     +- CometBroadcastExchange
+            :     :  :     :                    :        +- CometFilter
+            :     :  :     :                    :           +- CometNativeScan parquet spark_catalog.default.date_dim
+            :     :  :     :                    +- CometBroadcastExchange
+            :     :  :     :                       +- CometFilter
+            :     :  :     :                          +- CometNativeScan parquet spark_catalog.default.customer_address
+            :     :  :     +- CometBroadcastExchange
+            :     :  :        +- CometHashAggregate
+            :     :  :           +- CometExchange
+            :     :  :              +- CometHashAggregate
+            :     :  :                 +- CometProject
+            :     :  :                    +- CometBroadcastHashJoin
+            :     :  :                       :- CometProject
+            :     :  :                       :  +- CometBroadcastHashJoin
+            :     :  :                       :     :- CometFilter
+            :     :  :                       :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+            :     :  :                       :     :        +- CometSubqueryBroadcast
+            :     :  :                       :     :           +- CometBroadcastExchange
+            :     :  :                       :     :              +- CometFilter
+            :     :  :                       :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+            :     :  :                       :     +- CometBroadcastExchange
+            :     :  :                       :        +- CometFilter
+            :     :  :                       :           +- CometNativeScan parquet spark_catalog.default.date_dim
+            :     :  :                       +- CometBroadcastExchange
+            :     :  :                          +- CometFilter
+            :     :  :                             +- CometNativeScan parquet spark_catalog.default.customer_address
+            :     :  +- CometBroadcastExchange
+            :     :     +- CometHashAggregate
+            :     :        +- CometExchange
+            :     :           +- CometHashAggregate
+            :     :              +- CometProject
+            :     :                 +- CometBroadcastHashJoin
+            :     :                    :- CometProject
+            :     :                    :  +- CometBroadcastHashJoin
+            :     :                    :     :- CometFilter
+            :     :                    :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+            :     :                    :     :        +- ReusedSubquery
+            :     :                    :     +- CometBroadcastExchange
+            :     :                    :        +- CometFilter
+            :     :                    :           +- CometNativeScan parquet spark_catalog.default.date_dim
+            :     :                    +- CometBroadcastExchange
+            :     :                       +- CometFilter
+            :     :                          +- CometNativeScan parquet spark_catalog.default.customer_address
+            :     +- CometBroadcastExchange
+            :        +- CometHashAggregate
+            :           +- CometExchange
+            :              +- CometHashAggregate
+            :                 +- CometProject
+            :                    +- CometBroadcastHashJoin
+            :                       :- CometProject
+            :                       :  +- CometBroadcastHashJoin
+            :                       :     :- CometFilter
+            :                       :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+            :                       :     :        +- ReusedSubquery
+            :                       :     +- CometBroadcastExchange
+            :                       :        +- CometFilter
+            :                       :           +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                       +- CometBroadcastExchange
+            :                          +- CometFilter
+            :                             +- CometNativeScan parquet spark_catalog.default.customer_address
+            +- CometBroadcastExchange
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometBroadcastHashJoin
+                              :     :- CometFilter
+                              :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                              :     :        +- ReusedSubquery
+                              :     +- CometBroadcastExchange
+                              :        +- CometFilter
+                              :           +- CometNativeScan parquet spark_catalog.default.date_dim
+                              +- CometBroadcastExchange
+                                 +- CometFilter
+                                    +- CometNativeScan parquet spark_catalog.default.customer_address
+
+Comet accelerated 114 out of 120 eligible operators (95%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q31.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q31.native_iceberg_compat/extended.txt
@@ -1,0 +1,126 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometProject
+         +- CometBroadcastHashJoin
+            :- CometProject
+            :  +- CometBroadcastHashJoin
+            :     :- CometBroadcastHashJoin
+            :     :  :- CometProject
+            :     :  :  +- CometBroadcastHashJoin
+            :     :  :     :- CometBroadcastHashJoin
+            :     :  :     :  :- CometHashAggregate
+            :     :  :     :  :  +- CometExchange
+            :     :  :     :  :     +- CometHashAggregate
+            :     :  :     :  :        +- CometProject
+            :     :  :     :  :           +- CometBroadcastHashJoin
+            :     :  :     :  :              :- CometProject
+            :     :  :     :  :              :  +- CometBroadcastHashJoin
+            :     :  :     :  :              :     :- CometFilter
+            :     :  :     :  :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+            :     :  :     :  :              :     :        +- SubqueryBroadcast
+            :     :  :     :  :              :     :           +- BroadcastExchange
+            :     :  :     :  :              :     :              +- CometNativeColumnarToRow
+            :     :  :     :  :              :     :                 +- CometFilter
+            :     :  :     :  :              :     :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :     :  :     :  :              :     +- CometBroadcastExchange
+            :     :  :     :  :              :        +- CometFilter
+            :     :  :     :  :              :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :     :  :     :  :              +- CometBroadcastExchange
+            :     :  :     :  :                 +- CometFilter
+            :     :  :     :  :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+            :     :  :     :  +- CometBroadcastExchange
+            :     :  :     :     +- CometHashAggregate
+            :     :  :     :        +- CometExchange
+            :     :  :     :           +- CometHashAggregate
+            :     :  :     :              +- CometProject
+            :     :  :     :                 +- CometBroadcastHashJoin
+            :     :  :     :                    :- CometProject
+            :     :  :     :                    :  +- CometBroadcastHashJoin
+            :     :  :     :                    :     :- CometFilter
+            :     :  :     :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+            :     :  :     :                    :     :        +- SubqueryBroadcast
+            :     :  :     :                    :     :           +- BroadcastExchange
+            :     :  :     :                    :     :              +- CometNativeColumnarToRow
+            :     :  :     :                    :     :                 +- CometFilter
+            :     :  :     :                    :     :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :     :  :     :                    :     +- CometBroadcastExchange
+            :     :  :     :                    :        +- CometFilter
+            :     :  :     :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :     :  :     :                    +- CometBroadcastExchange
+            :     :  :     :                       +- CometFilter
+            :     :  :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+            :     :  :     +- CometBroadcastExchange
+            :     :  :        +- CometHashAggregate
+            :     :  :           +- CometExchange
+            :     :  :              +- CometHashAggregate
+            :     :  :                 +- CometProject
+            :     :  :                    +- CometBroadcastHashJoin
+            :     :  :                       :- CometProject
+            :     :  :                       :  +- CometBroadcastHashJoin
+            :     :  :                       :     :- CometFilter
+            :     :  :                       :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+            :     :  :                       :     :        +- SubqueryBroadcast
+            :     :  :                       :     :           +- BroadcastExchange
+            :     :  :                       :     :              +- CometNativeColumnarToRow
+            :     :  :                       :     :                 +- CometFilter
+            :     :  :                       :     :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :     :  :                       :     +- CometBroadcastExchange
+            :     :  :                       :        +- CometFilter
+            :     :  :                       :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :     :  :                       +- CometBroadcastExchange
+            :     :  :                          +- CometFilter
+            :     :  :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+            :     :  +- CometBroadcastExchange
+            :     :     +- CometHashAggregate
+            :     :        +- CometExchange
+            :     :           +- CometHashAggregate
+            :     :              +- CometProject
+            :     :                 +- CometBroadcastHashJoin
+            :     :                    :- CometProject
+            :     :                    :  +- CometBroadcastHashJoin
+            :     :                    :     :- CometFilter
+            :     :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+            :     :                    :     :        +- ReusedSubquery
+            :     :                    :     +- CometBroadcastExchange
+            :     :                    :        +- CometFilter
+            :     :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :     :                    +- CometBroadcastExchange
+            :     :                       +- CometFilter
+            :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+            :     +- CometBroadcastExchange
+            :        +- CometHashAggregate
+            :           +- CometExchange
+            :              +- CometHashAggregate
+            :                 +- CometProject
+            :                    +- CometBroadcastHashJoin
+            :                       :- CometProject
+            :                       :  +- CometBroadcastHashJoin
+            :                       :     :- CometFilter
+            :                       :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+            :                       :     :        +- ReusedSubquery
+            :                       :     +- CometBroadcastExchange
+            :                       :        +- CometFilter
+            :                       :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :                       +- CometBroadcastExchange
+            :                          +- CometFilter
+            :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+            +- CometBroadcastExchange
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometBroadcastHashJoin
+                              :     :- CometFilter
+                              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                              :     :        +- ReusedSubquery
+                              :     +- CometBroadcastExchange
+                              :        +- CometFilter
+                              :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              +- CometBroadcastExchange
+                                 +- CometFilter
+                                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+
+Comet accelerated 111 out of 120 eligible operators (92%). Final plan contains 4 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q32.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q32.native_datafusion/extended.txt
@@ -1,0 +1,41 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometProject
+            +- CometBroadcastHashJoin
+               :- CometProject
+               :  +- CometBroadcastHashJoin
+               :     :- CometProject
+               :     :  +- CometBroadcastHashJoin
+               :     :     :- CometFilter
+               :     :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :     :     :        +- CometSubqueryBroadcast
+               :     :     :           +- CometBroadcastExchange
+               :     :     :              +- CometProject
+               :     :     :                 +- CometFilter
+               :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     :     +- CometBroadcastExchange
+               :     :        +- CometProject
+               :     :           +- CometFilter
+               :     :              +- CometNativeScan parquet spark_catalog.default.item
+               :     +- CometBroadcastExchange
+               :        +- CometFilter
+               :           +- CometHashAggregate
+               :              +- CometExchange
+               :                 +- CometHashAggregate
+               :                    +- CometProject
+               :                       +- CometBroadcastHashJoin
+               :                          :- CometFilter
+               :                          :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                          :        +- ReusedSubquery
+               :                          +- CometBroadcastExchange
+               :                             +- CometProject
+               :                                +- CometFilter
+               :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+               +- CometBroadcastExchange
+                  +- CometProject
+                     +- CometFilter
+                        +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 36 out of 38 eligible operators (94%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q32.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q32.native_iceberg_compat/extended.txt
@@ -1,0 +1,42 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometProject
+            +- CometBroadcastHashJoin
+               :- CometProject
+               :  +- CometBroadcastHashJoin
+               :     :- CometProject
+               :     :  +- CometBroadcastHashJoin
+               :     :     :- CometFilter
+               :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :     :     :        +- SubqueryBroadcast
+               :     :     :           +- BroadcastExchange
+               :     :     :              +- CometNativeColumnarToRow
+               :     :     :                 +- CometProject
+               :     :     :                    +- CometFilter
+               :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     :     +- CometBroadcastExchange
+               :     :        +- CometProject
+               :     :           +- CometFilter
+               :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :     +- CometBroadcastExchange
+               :        +- CometFilter
+               :           +- CometHashAggregate
+               :              +- CometExchange
+               :                 +- CometHashAggregate
+               :                    +- CometProject
+               :                       +- CometBroadcastHashJoin
+               :                          :- CometFilter
+               :                          :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                          :        +- ReusedSubquery
+               :                          +- CometBroadcastExchange
+               :                             +- CometProject
+               :                                +- CometFilter
+               :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               +- CometBroadcastExchange
+                  +- CometProject
+                     +- CometFilter
+                        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 35 out of 38 eligible operators (92%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q33.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q33.native_datafusion/extended.txt
@@ -1,0 +1,95 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometHashAggregate
+         +- CometUnion
+            :- CometHashAggregate
+            :  +- CometExchange
+            :     +- CometHashAggregate
+            :        +- CometProject
+            :           +- CometBroadcastHashJoin
+            :              :- CometProject
+            :              :  +- CometBroadcastHashJoin
+            :              :     :- CometProject
+            :              :     :  +- CometBroadcastHashJoin
+            :              :     :     :- CometFilter
+            :              :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+            :              :     :     :        +- CometSubqueryBroadcast
+            :              :     :     :           +- CometBroadcastExchange
+            :              :     :     :              +- CometProject
+            :              :     :     :                 +- CometFilter
+            :              :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+            :              :     :     +- CometBroadcastExchange
+            :              :     :        +- CometProject
+            :              :     :           +- CometFilter
+            :              :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+            :              :     +- CometBroadcastExchange
+            :              :        +- CometProject
+            :              :           +- CometFilter
+            :              :              +- CometNativeScan parquet spark_catalog.default.customer_address
+            :              +- CometBroadcastExchange
+            :                 +- CometBroadcastHashJoin
+            :                    :- CometFilter
+            :                    :  +- CometNativeScan parquet spark_catalog.default.item
+            :                    +- CometBroadcastExchange
+            :                       +- CometProject
+            :                          +- CometFilter
+            :                             +- CometNativeScan parquet spark_catalog.default.item
+            :- CometHashAggregate
+            :  +- CometExchange
+            :     +- CometHashAggregate
+            :        +- CometProject
+            :           +- CometBroadcastHashJoin
+            :              :- CometProject
+            :              :  +- CometBroadcastHashJoin
+            :              :     :- CometProject
+            :              :     :  +- CometBroadcastHashJoin
+            :              :     :     :- CometFilter
+            :              :     :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+            :              :     :     :        +- ReusedSubquery
+            :              :     :     +- CometBroadcastExchange
+            :              :     :        +- CometProject
+            :              :     :           +- CometFilter
+            :              :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+            :              :     +- CometBroadcastExchange
+            :              :        +- CometProject
+            :              :           +- CometFilter
+            :              :              +- CometNativeScan parquet spark_catalog.default.customer_address
+            :              +- CometBroadcastExchange
+            :                 +- CometBroadcastHashJoin
+            :                    :- CometFilter
+            :                    :  +- CometNativeScan parquet spark_catalog.default.item
+            :                    +- CometBroadcastExchange
+            :                       +- CometProject
+            :                          +- CometFilter
+            :                             +- CometNativeScan parquet spark_catalog.default.item
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometBroadcastHashJoin
+                           :     :     :- CometFilter
+                           :     :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                           :     :     :        +- ReusedSubquery
+                           :     :     +- CometBroadcastExchange
+                           :     :        +- CometProject
+                           :     :           +- CometFilter
+                           :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     +- CometBroadcastExchange
+                           :        +- CometProject
+                           :           +- CometFilter
+                           :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                           +- CometBroadcastExchange
+                              +- CometBroadcastHashJoin
+                                 :- CometFilter
+                                 :  +- CometNativeScan parquet spark_catalog.default.item
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 89 out of 92 eligible operators (96%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q33.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q33.native_iceberg_compat/extended.txt
@@ -1,0 +1,96 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometHashAggregate
+         +- CometUnion
+            :- CometHashAggregate
+            :  +- CometExchange
+            :     +- CometHashAggregate
+            :        +- CometProject
+            :           +- CometBroadcastHashJoin
+            :              :- CometProject
+            :              :  +- CometBroadcastHashJoin
+            :              :     :- CometProject
+            :              :     :  +- CometBroadcastHashJoin
+            :              :     :     :- CometFilter
+            :              :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+            :              :     :     :        +- SubqueryBroadcast
+            :              :     :     :           +- BroadcastExchange
+            :              :     :     :              +- CometNativeColumnarToRow
+            :              :     :     :                 +- CometProject
+            :              :     :     :                    +- CometFilter
+            :              :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :              :     :     +- CometBroadcastExchange
+            :              :     :        +- CometProject
+            :              :     :           +- CometFilter
+            :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :              :     +- CometBroadcastExchange
+            :              :        +- CometProject
+            :              :           +- CometFilter
+            :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+            :              +- CometBroadcastExchange
+            :                 +- CometBroadcastHashJoin
+            :                    :- CometFilter
+            :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+            :                    +- CometBroadcastExchange
+            :                       +- CometProject
+            :                          +- CometFilter
+            :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+            :- CometHashAggregate
+            :  +- CometExchange
+            :     +- CometHashAggregate
+            :        +- CometProject
+            :           +- CometBroadcastHashJoin
+            :              :- CometProject
+            :              :  +- CometBroadcastHashJoin
+            :              :     :- CometProject
+            :              :     :  +- CometBroadcastHashJoin
+            :              :     :     :- CometFilter
+            :              :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+            :              :     :     :        +- ReusedSubquery
+            :              :     :     +- CometBroadcastExchange
+            :              :     :        +- CometProject
+            :              :     :           +- CometFilter
+            :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :              :     +- CometBroadcastExchange
+            :              :        +- CometProject
+            :              :           +- CometFilter
+            :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+            :              +- CometBroadcastExchange
+            :                 +- CometBroadcastHashJoin
+            :                    :- CometFilter
+            :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+            :                    +- CometBroadcastExchange
+            :                       +- CometProject
+            :                          +- CometFilter
+            :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometBroadcastHashJoin
+                           :     :     :- CometFilter
+                           :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                           :     :     :        +- ReusedSubquery
+                           :     :     +- CometBroadcastExchange
+                           :     :        +- CometProject
+                           :     :           +- CometFilter
+                           :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     +- CometBroadcastExchange
+                           :        +- CometProject
+                           :           +- CometFilter
+                           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                           +- CometBroadcastExchange
+                              +- CometBroadcastHashJoin
+                                 :- CometFilter
+                                 :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 88 out of 92 eligible operators (95%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q34.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q34.native_datafusion/extended.txt
@@ -1,0 +1,40 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometProject
+         +- CometBroadcastHashJoin
+            :- CometFilter
+            :  +- CometHashAggregate
+            :     +- CometExchange
+            :        +- CometHashAggregate
+            :           +- CometProject
+            :              +- CometBroadcastHashJoin
+            :                 :- CometProject
+            :                 :  +- CometBroadcastHashJoin
+            :                 :     :- CometProject
+            :                 :     :  +- CometBroadcastHashJoin
+            :                 :     :     :- CometFilter
+            :                 :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+            :                 :     :     :        +- CometSubqueryBroadcast
+            :                 :     :     :           +- CometBroadcastExchange
+            :                 :     :     :              +- CometProject
+            :                 :     :     :                 +- CometFilter
+            :                 :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     +- CometBroadcastExchange
+            :                 :     :        +- CometProject
+            :                 :     :           +- CometFilter
+            :                 :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     +- CometBroadcastExchange
+            :                 :        +- CometProject
+            :                 :           +- CometFilter
+            :                 :              +- CometNativeScan parquet spark_catalog.default.store
+            :                 +- CometBroadcastExchange
+            :                    +- CometProject
+            :                       +- CometFilter
+            :                          +- CometNativeScan parquet spark_catalog.default.household_demographics
+            +- CometBroadcastExchange
+               +- CometProject
+                  +- CometFilter
+                     +- CometNativeScan parquet spark_catalog.default.customer
+
+Comet accelerated 36 out of 37 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q34.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q34.native_iceberg_compat/extended.txt
@@ -1,0 +1,41 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometProject
+         +- CometBroadcastHashJoin
+            :- CometFilter
+            :  +- CometHashAggregate
+            :     +- CometExchange
+            :        +- CometHashAggregate
+            :           +- CometProject
+            :              +- CometBroadcastHashJoin
+            :                 :- CometProject
+            :                 :  +- CometBroadcastHashJoin
+            :                 :     :- CometProject
+            :                 :     :  +- CometBroadcastHashJoin
+            :                 :     :     :- CometFilter
+            :                 :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+            :                 :     :     :        +- SubqueryBroadcast
+            :                 :     :     :           +- BroadcastExchange
+            :                 :     :     :              +- CometNativeColumnarToRow
+            :                 :     :     :                 +- CometProject
+            :                 :     :     :                    +- CometFilter
+            :                 :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :                 :     :     +- CometBroadcastExchange
+            :                 :     :        +- CometProject
+            :                 :     :           +- CometFilter
+            :                 :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :                 :     +- CometBroadcastExchange
+            :                 :        +- CometProject
+            :                 :           +- CometFilter
+            :                 :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+            :                 +- CometBroadcastExchange
+            :                    +- CometProject
+            :                       +- CometFilter
+            :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+            +- CometBroadcastExchange
+               +- CometProject
+                  +- CometFilter
+                     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+
+Comet accelerated 35 out of 37 eligible operators (94%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q35.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q35.native_datafusion/extended.txt
@@ -1,0 +1,61 @@
+TakeOrderedAndProject
++- HashAggregate
+   +- Exchange
+      +- HashAggregate
+         +- Project
+            +- BroadcastHashJoin
+               :- Project
+               :  +- BroadcastHashJoin
+               :     :- Project
+               :     :  +- Filter
+               :     :     +- BroadcastHashJoin
+               :     :        :-  BroadcastHashJoin [COMET: Unsupported join type ExistenceJoin(exists#1)]
+               :     :        :  :- CometNativeColumnarToRow
+               :     :        :  :  +- CometBroadcastHashJoin
+               :     :        :  :     :- CometFilter
+               :     :        :  :     :  +- CometNativeScan parquet spark_catalog.default.customer
+               :     :        :  :     +- CometBroadcastExchange
+               :     :        :  :        +- CometProject
+               :     :        :  :           +- CometBroadcastHashJoin
+               :     :        :  :              :- CometNativeScan parquet spark_catalog.default.store_sales
+               :     :        :  :              :     +- CometSubqueryBroadcast
+               :     :        :  :              :        +- CometBroadcastExchange
+               :     :        :  :              :           +- CometProject
+               :     :        :  :              :              +- CometFilter
+               :     :        :  :              :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     :        :  :              +- CometBroadcastExchange
+               :     :        :  :                 +- CometProject
+               :     :        :  :                    +- CometFilter
+               :     :        :  :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     :        :  +- BroadcastExchange
+               :     :        :     +- CometNativeColumnarToRow
+               :     :        :        +- CometProject
+               :     :        :           +- CometBroadcastHashJoin
+               :     :        :              :- CometNativeScan parquet spark_catalog.default.web_sales
+               :     :        :              :     +- ReusedSubquery
+               :     :        :              +- CometBroadcastExchange
+               :     :        :                 +- CometProject
+               :     :        :                    +- CometFilter
+               :     :        :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     :        +- BroadcastExchange
+               :     :           +- CometNativeColumnarToRow
+               :     :              +- CometProject
+               :     :                 +- CometBroadcastHashJoin
+               :     :                    :- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :     :                    :     +- ReusedSubquery
+               :     :                    +- CometBroadcastExchange
+               :     :                       +- CometProject
+               :     :                          +- CometFilter
+               :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     +- BroadcastExchange
+               :        +- CometNativeColumnarToRow
+               :           +- CometProject
+               :              +- CometFilter
+               :                 +- CometNativeScan parquet spark_catalog.default.customer_address
+               +- BroadcastExchange
+                  +- CometNativeColumnarToRow
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.customer_demographics
+
+Comet accelerated 35 out of 54 eligible operators (64%). Final plan contains 5 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q35.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q35.native_iceberg_compat/extended.txt
@@ -1,0 +1,62 @@
+TakeOrderedAndProject
++- HashAggregate
+   +- Exchange
+      +- HashAggregate
+         +- Project
+            +- BroadcastHashJoin
+               :- Project
+               :  +- BroadcastHashJoin
+               :     :- Project
+               :     :  +- Filter
+               :     :     +- BroadcastHashJoin
+               :     :        :-  BroadcastHashJoin [COMET: Unsupported join type ExistenceJoin(exists#1)]
+               :     :        :  :- CometNativeColumnarToRow
+               :     :        :  :  +- CometBroadcastHashJoin
+               :     :        :  :     :- CometFilter
+               :     :        :  :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+               :     :        :  :     +- CometBroadcastExchange
+               :     :        :  :        +- CometProject
+               :     :        :  :           +- CometBroadcastHashJoin
+               :     :        :  :              :- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :     :        :  :              :     +- SubqueryBroadcast
+               :     :        :  :              :        +- BroadcastExchange
+               :     :        :  :              :           +- CometNativeColumnarToRow
+               :     :        :  :              :              +- CometProject
+               :     :        :  :              :                 +- CometFilter
+               :     :        :  :              :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     :        :  :              +- CometBroadcastExchange
+               :     :        :  :                 +- CometProject
+               :     :        :  :                    +- CometFilter
+               :     :        :  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     :        :  +- BroadcastExchange
+               :     :        :     +- CometNativeColumnarToRow
+               :     :        :        +- CometProject
+               :     :        :           +- CometBroadcastHashJoin
+               :     :        :              :- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :     :        :              :     +- ReusedSubquery
+               :     :        :              +- CometBroadcastExchange
+               :     :        :                 +- CometProject
+               :     :        :                    +- CometFilter
+               :     :        :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     :        +- BroadcastExchange
+               :     :           +- CometNativeColumnarToRow
+               :     :              +- CometProject
+               :     :                 +- CometBroadcastHashJoin
+               :     :                    :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :     :                    :     +- ReusedSubquery
+               :     :                    +- CometBroadcastExchange
+               :     :                       +- CometProject
+               :     :                          +- CometFilter
+               :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     +- BroadcastExchange
+               :        +- CometNativeColumnarToRow
+               :           +- CometProject
+               :              +- CometFilter
+               :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+               +- BroadcastExchange
+                  +- CometNativeColumnarToRow
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+
+Comet accelerated 34 out of 54 eligible operators (62%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q36.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q36.native_datafusion/extended.txt
@@ -1,0 +1,37 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometExpand
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometProject
+                                 :     :  +- CometBroadcastHashJoin
+                                 :     :     :- CometFilter
+                                 :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                 :     :     :        +- CometSubqueryBroadcast
+                                 :     :     :           +- CometBroadcastExchange
+                                 :     :     :              +- CometProject
+                                 :     :     :                 +- CometFilter
+                                 :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :     :     +- CometBroadcastExchange
+                                 :     :        +- CometProject
+                                 :     :           +- CometFilter
+                                 :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometProject
+                                 :           +- CometFilter
+                                 :              +- CometNativeScan parquet spark_catalog.default.item
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometNativeScan parquet spark_catalog.default.store
+
+Comet accelerated 30 out of 34 eligible operators (88%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q36.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q36.native_iceberg_compat/extended.txt
@@ -1,0 +1,38 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometExpand
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometProject
+                                 :     :  +- CometBroadcastHashJoin
+                                 :     :     :- CometFilter
+                                 :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                 :     :     :        +- SubqueryBroadcast
+                                 :     :     :           +- BroadcastExchange
+                                 :     :     :              +- CometNativeColumnarToRow
+                                 :     :     :                 +- CometProject
+                                 :     :     :                    +- CometFilter
+                                 :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :     :     +- CometBroadcastExchange
+                                 :     :        +- CometProject
+                                 :     :           +- CometFilter
+                                 :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometProject
+                                 :           +- CometFilter
+                                 :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+
+Comet accelerated 29 out of 34 eligible operators (85%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q37.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q37.native_datafusion/extended.txt
@@ -1,0 +1,33 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometBroadcastExchange
+                  :  +- CometProject
+                  :     +- CometBroadcastHashJoin
+                  :        :- CometProject
+                  :        :  +- CometBroadcastHashJoin
+                  :        :     :- CometProject
+                  :        :     :  +- CometFilter
+                  :        :     :     +- CometNativeScan parquet spark_catalog.default.item
+                  :        :     +- CometBroadcastExchange
+                  :        :        +- CometProject
+                  :        :           +- CometFilter
+                  :        :              +- CometNativeScan parquet spark_catalog.default.inventory
+                  :        :                    +- CometSubqueryBroadcast
+                  :        :                       +- CometBroadcastExchange
+                  :        :                          +- CometProject
+                  :        :                             +- CometFilter
+                  :        :                                +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :        +- CometBroadcastExchange
+                  :           +- CometProject
+                  :              +- CometFilter
+                  :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                  +- CometProject
+                     +- CometFilter
+                        +- CometNativeScan parquet spark_catalog.default.catalog_sales
+
+Comet accelerated 29 out of 30 eligible operators (96%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q37.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q37.native_iceberg_compat/extended.txt
@@ -1,0 +1,34 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometBroadcastExchange
+                  :  +- CometProject
+                  :     +- CometBroadcastHashJoin
+                  :        :- CometProject
+                  :        :  +- CometBroadcastHashJoin
+                  :        :     :- CometProject
+                  :        :     :  +- CometFilter
+                  :        :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :        :     +- CometBroadcastExchange
+                  :        :        +- CometProject
+                  :        :           +- CometFilter
+                  :        :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.inventory
+                  :        :                    +- SubqueryBroadcast
+                  :        :                       +- BroadcastExchange
+                  :        :                          +- CometNativeColumnarToRow
+                  :        :                             +- CometProject
+                  :        :                                +- CometFilter
+                  :        :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :        +- CometBroadcastExchange
+                  :           +- CometProject
+                  :              +- CometFilter
+                  :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  +- CometProject
+                     +- CometFilter
+                        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+
+Comet accelerated 28 out of 30 eligible operators (93%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q38.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q38.native_datafusion/extended.txt
@@ -1,0 +1,69 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometProject
+            +- CometBroadcastHashJoin
+               :- CometBroadcastHashJoin
+               :  :- CometHashAggregate
+               :  :  +- CometExchange
+               :  :     +- CometHashAggregate
+               :  :        +- CometProject
+               :  :           +- CometBroadcastHashJoin
+               :  :              :- CometProject
+               :  :              :  +- CometBroadcastHashJoin
+               :  :              :     :- CometFilter
+               :  :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :  :              :     :        +- CometSubqueryBroadcast
+               :  :              :     :           +- CometBroadcastExchange
+               :  :              :     :              +- CometProject
+               :  :              :     :                 +- CometFilter
+               :  :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :  :              :     +- CometBroadcastExchange
+               :  :              :        +- CometProject
+               :  :              :           +- CometFilter
+               :  :              :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :  :              +- CometBroadcastExchange
+               :  :                 +- CometProject
+               :  :                    +- CometFilter
+               :  :                       +- CometNativeScan parquet spark_catalog.default.customer
+               :  +- CometBroadcastExchange
+               :     +- CometHashAggregate
+               :        +- CometExchange
+               :           +- CometHashAggregate
+               :              +- CometProject
+               :                 +- CometBroadcastHashJoin
+               :                    :- CometProject
+               :                    :  +- CometBroadcastHashJoin
+               :                    :     :- CometFilter
+               :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                    :     :        +- ReusedSubquery
+               :                    :     +- CometBroadcastExchange
+               :                    :        +- CometProject
+               :                    :           +- CometFilter
+               :                    :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                    +- CometBroadcastExchange
+               :                       +- CometProject
+               :                          +- CometFilter
+               :                             +- CometNativeScan parquet spark_catalog.default.customer
+               +- CometBroadcastExchange
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometFilter
+                                 :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                                 :     :        +- ReusedSubquery
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometProject
+                                 :           +- CometFilter
+                                 :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometNativeScan parquet spark_catalog.default.customer
+
+Comet accelerated 63 out of 66 eligible operators (95%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q38.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q38.native_iceberg_compat/extended.txt
@@ -1,0 +1,70 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometProject
+            +- CometBroadcastHashJoin
+               :- CometBroadcastHashJoin
+               :  :- CometHashAggregate
+               :  :  +- CometExchange
+               :  :     +- CometHashAggregate
+               :  :        +- CometProject
+               :  :           +- CometBroadcastHashJoin
+               :  :              :- CometProject
+               :  :              :  +- CometBroadcastHashJoin
+               :  :              :     :- CometFilter
+               :  :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :  :              :     :        +- SubqueryBroadcast
+               :  :              :     :           +- BroadcastExchange
+               :  :              :     :              +- CometNativeColumnarToRow
+               :  :              :     :                 +- CometProject
+               :  :              :     :                    +- CometFilter
+               :  :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :  :              :     +- CometBroadcastExchange
+               :  :              :        +- CometProject
+               :  :              :           +- CometFilter
+               :  :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :  :              +- CometBroadcastExchange
+               :  :                 +- CometProject
+               :  :                    +- CometFilter
+               :  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+               :  +- CometBroadcastExchange
+               :     +- CometHashAggregate
+               :        +- CometExchange
+               :           +- CometHashAggregate
+               :              +- CometProject
+               :                 +- CometBroadcastHashJoin
+               :                    :- CometProject
+               :                    :  +- CometBroadcastHashJoin
+               :                    :     :- CometFilter
+               :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                    :     :        +- ReusedSubquery
+               :                    :     +- CometBroadcastExchange
+               :                    :        +- CometProject
+               :                    :           +- CometFilter
+               :                    :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                    +- CometBroadcastExchange
+               :                       +- CometProject
+               :                          +- CometFilter
+               :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+               +- CometBroadcastExchange
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometFilter
+                                 :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                 :     :        +- ReusedSubquery
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometProject
+                                 :           +- CometFilter
+                                 :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+
+Comet accelerated 62 out of 66 eligible operators (93%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q39a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q39a.native_datafusion/extended.txt
@@ -1,0 +1,63 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometFilter
+         :     +- CometHashAggregate
+         :        +- CometExchange
+         :           +- CometHashAggregate
+         :              +- CometProject
+         :                 +- CometBroadcastHashJoin
+         :                    :- CometProject
+         :                    :  +- CometBroadcastHashJoin
+         :                    :     :- CometProject
+         :                    :     :  +- CometBroadcastHashJoin
+         :                    :     :     :- CometFilter
+         :                    :     :     :  +- CometNativeScan parquet spark_catalog.default.inventory
+         :                    :     :     :        +- CometSubqueryBroadcast
+         :                    :     :     :           +- CometBroadcastExchange
+         :                    :     :     :              +- CometProject
+         :                    :     :     :                 +- CometFilter
+         :                    :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+         :                    :     :     +- CometBroadcastExchange
+         :                    :     :        +- CometFilter
+         :                    :     :           +- CometNativeScan parquet spark_catalog.default.item
+         :                    :     +- CometBroadcastExchange
+         :                    :        +- CometFilter
+         :                    :           +- CometNativeScan parquet spark_catalog.default.warehouse
+         :                    +- CometBroadcastExchange
+         :                       +- CometProject
+         :                          +- CometFilter
+         :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometProject
+               +- CometFilter
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometProject
+                                 :     :  +- CometBroadcastHashJoin
+                                 :     :     :- CometFilter
+                                 :     :     :  +- CometNativeScan parquet spark_catalog.default.inventory
+                                 :     :     :        +- CometSubqueryBroadcast
+                                 :     :     :           +- CometBroadcastExchange
+                                 :     :     :              +- CometProject
+                                 :     :     :                 +- CometFilter
+                                 :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :     :     +- CometBroadcastExchange
+                                 :     :        +- CometFilter
+                                 :     :           +- CometNativeScan parquet spark_catalog.default.item
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometFilter
+                                 :           +- CometNativeScan parquet spark_catalog.default.warehouse
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 58 out of 60 eligible operators (96%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q39a.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q39a.native_iceberg_compat/extended.txt
@@ -1,0 +1,65 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometFilter
+         :     +- CometHashAggregate
+         :        +- CometExchange
+         :           +- CometHashAggregate
+         :              +- CometProject
+         :                 +- CometBroadcastHashJoin
+         :                    :- CometProject
+         :                    :  +- CometBroadcastHashJoin
+         :                    :     :- CometProject
+         :                    :     :  +- CometBroadcastHashJoin
+         :                    :     :     :- CometFilter
+         :                    :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.inventory
+         :                    :     :     :        +- SubqueryBroadcast
+         :                    :     :     :           +- BroadcastExchange
+         :                    :     :     :              +- CometNativeColumnarToRow
+         :                    :     :     :                 +- CometProject
+         :                    :     :     :                    +- CometFilter
+         :                    :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :                    :     :     +- CometBroadcastExchange
+         :                    :     :        +- CometFilter
+         :                    :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+         :                    :     +- CometBroadcastExchange
+         :                    :        +- CometFilter
+         :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.warehouse
+         :                    +- CometBroadcastExchange
+         :                       +- CometProject
+         :                          +- CometFilter
+         :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometProject
+               +- CometFilter
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometProject
+                                 :     :  +- CometBroadcastHashJoin
+                                 :     :     :- CometFilter
+                                 :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.inventory
+                                 :     :     :        +- SubqueryBroadcast
+                                 :     :     :           +- BroadcastExchange
+                                 :     :     :              +- CometNativeColumnarToRow
+                                 :     :     :                 +- CometProject
+                                 :     :     :                    +- CometFilter
+                                 :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :     :     +- CometBroadcastExchange
+                                 :     :        +- CometFilter
+                                 :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometFilter
+                                 :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.warehouse
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 56 out of 60 eligible operators (93%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q39b.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q39b.native_datafusion/extended.txt
@@ -1,0 +1,63 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometFilter
+         :     +- CometHashAggregate
+         :        +- CometExchange
+         :           +- CometHashAggregate
+         :              +- CometProject
+         :                 +- CometBroadcastHashJoin
+         :                    :- CometProject
+         :                    :  +- CometBroadcastHashJoin
+         :                    :     :- CometProject
+         :                    :     :  +- CometBroadcastHashJoin
+         :                    :     :     :- CometFilter
+         :                    :     :     :  +- CometNativeScan parquet spark_catalog.default.inventory
+         :                    :     :     :        +- CometSubqueryBroadcast
+         :                    :     :     :           +- CometBroadcastExchange
+         :                    :     :     :              +- CometProject
+         :                    :     :     :                 +- CometFilter
+         :                    :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+         :                    :     :     +- CometBroadcastExchange
+         :                    :     :        +- CometFilter
+         :                    :     :           +- CometNativeScan parquet spark_catalog.default.item
+         :                    :     +- CometBroadcastExchange
+         :                    :        +- CometFilter
+         :                    :           +- CometNativeScan parquet spark_catalog.default.warehouse
+         :                    +- CometBroadcastExchange
+         :                       +- CometProject
+         :                          +- CometFilter
+         :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometProject
+               +- CometFilter
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometProject
+                                 :     :  +- CometBroadcastHashJoin
+                                 :     :     :- CometFilter
+                                 :     :     :  +- CometNativeScan parquet spark_catalog.default.inventory
+                                 :     :     :        +- CometSubqueryBroadcast
+                                 :     :     :           +- CometBroadcastExchange
+                                 :     :     :              +- CometProject
+                                 :     :     :                 +- CometFilter
+                                 :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :     :     +- CometBroadcastExchange
+                                 :     :        +- CometFilter
+                                 :     :           +- CometNativeScan parquet spark_catalog.default.item
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometFilter
+                                 :           +- CometNativeScan parquet spark_catalog.default.warehouse
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 58 out of 60 eligible operators (96%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q39b.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q39b.native_iceberg_compat/extended.txt
@@ -1,0 +1,65 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometFilter
+         :     +- CometHashAggregate
+         :        +- CometExchange
+         :           +- CometHashAggregate
+         :              +- CometProject
+         :                 +- CometBroadcastHashJoin
+         :                    :- CometProject
+         :                    :  +- CometBroadcastHashJoin
+         :                    :     :- CometProject
+         :                    :     :  +- CometBroadcastHashJoin
+         :                    :     :     :- CometFilter
+         :                    :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.inventory
+         :                    :     :     :        +- SubqueryBroadcast
+         :                    :     :     :           +- BroadcastExchange
+         :                    :     :     :              +- CometNativeColumnarToRow
+         :                    :     :     :                 +- CometProject
+         :                    :     :     :                    +- CometFilter
+         :                    :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :                    :     :     +- CometBroadcastExchange
+         :                    :     :        +- CometFilter
+         :                    :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+         :                    :     +- CometBroadcastExchange
+         :                    :        +- CometFilter
+         :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.warehouse
+         :                    +- CometBroadcastExchange
+         :                       +- CometProject
+         :                          +- CometFilter
+         :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometProject
+               +- CometFilter
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometProject
+                                 :     :  +- CometBroadcastHashJoin
+                                 :     :     :- CometFilter
+                                 :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.inventory
+                                 :     :     :        +- SubqueryBroadcast
+                                 :     :     :           +- BroadcastExchange
+                                 :     :     :              +- CometNativeColumnarToRow
+                                 :     :     :                 +- CometProject
+                                 :     :     :                    +- CometFilter
+                                 :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :     :     +- CometBroadcastExchange
+                                 :     :        +- CometFilter
+                                 :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometFilter
+                                 :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.warehouse
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 56 out of 60 eligible operators (93%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q4.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q4.native_datafusion/extended.txt
@@ -1,0 +1,129 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometProject
+         :     :  +- CometBroadcastHashJoin
+         :     :     :- CometProject
+         :     :     :  +- CometBroadcastHashJoin
+         :     :     :     :- CometBroadcastHashJoin
+         :     :     :     :  :- CometFilter
+         :     :     :     :  :  +- CometHashAggregate
+         :     :     :     :  :     +- CometExchange
+         :     :     :     :  :        +- CometHashAggregate
+         :     :     :     :  :           +- CometProject
+         :     :     :     :  :              +- CometBroadcastHashJoin
+         :     :     :     :  :                 :- CometProject
+         :     :     :     :  :                 :  +- CometBroadcastHashJoin
+         :     :     :     :  :                 :     :- CometProject
+         :     :     :     :  :                 :     :  +- CometFilter
+         :     :     :     :  :                 :     :     +- CometNativeScan parquet spark_catalog.default.customer
+         :     :     :     :  :                 :     +- CometBroadcastExchange
+         :     :     :     :  :                 :        +- CometFilter
+         :     :     :     :  :                 :           +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     :     :     :  :                 :                 +- CometSubqueryBroadcast
+         :     :     :     :  :                 :                    +- CometBroadcastExchange
+         :     :     :     :  :                 :                       +- CometFilter
+         :     :     :     :  :                 :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :     :     :  :                 +- CometBroadcastExchange
+         :     :     :     :  :                    +- CometFilter
+         :     :     :     :  :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :     :     :  +- CometBroadcastExchange
+         :     :     :     :     +- CometHashAggregate
+         :     :     :     :        +- CometExchange
+         :     :     :     :           +- CometHashAggregate
+         :     :     :     :              +- CometProject
+         :     :     :     :                 +- CometBroadcastHashJoin
+         :     :     :     :                    :- CometProject
+         :     :     :     :                    :  +- CometBroadcastHashJoin
+         :     :     :     :                    :     :- CometProject
+         :     :     :     :                    :     :  +- CometFilter
+         :     :     :     :                    :     :     +- CometNativeScan parquet spark_catalog.default.customer
+         :     :     :     :                    :     +- CometBroadcastExchange
+         :     :     :     :                    :        +- CometFilter
+         :     :     :     :                    :           +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     :     :     :                    :                 +- CometSubqueryBroadcast
+         :     :     :     :                    :                    +- CometBroadcastExchange
+         :     :     :     :                    :                       +- CometFilter
+         :     :     :     :                    :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :     :     :                    +- CometBroadcastExchange
+         :     :     :     :                       +- CometFilter
+         :     :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :     :     +- CometBroadcastExchange
+         :     :     :        +- CometFilter
+         :     :     :           +- CometHashAggregate
+         :     :     :              +- CometExchange
+         :     :     :                 +- CometHashAggregate
+         :     :     :                    +- CometProject
+         :     :     :                       +- CometBroadcastHashJoin
+         :     :     :                          :- CometProject
+         :     :     :                          :  +- CometBroadcastHashJoin
+         :     :     :                          :     :- CometProject
+         :     :     :                          :     :  +- CometFilter
+         :     :     :                          :     :     +- CometNativeScan parquet spark_catalog.default.customer
+         :     :     :                          :     +- CometBroadcastExchange
+         :     :     :                          :        +- CometFilter
+         :     :     :                          :           +- CometNativeScan parquet spark_catalog.default.catalog_sales
+         :     :     :                          :                 +- ReusedSubquery
+         :     :     :                          +- CometBroadcastExchange
+         :     :     :                             +- CometFilter
+         :     :     :                                +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :     +- CometBroadcastExchange
+         :     :        +- CometHashAggregate
+         :     :           +- CometExchange
+         :     :              +- CometHashAggregate
+         :     :                 +- CometProject
+         :     :                    +- CometBroadcastHashJoin
+         :     :                       :- CometProject
+         :     :                       :  +- CometBroadcastHashJoin
+         :     :                       :     :- CometProject
+         :     :                       :     :  +- CometFilter
+         :     :                       :     :     +- CometNativeScan parquet spark_catalog.default.customer
+         :     :                       :     +- CometBroadcastExchange
+         :     :                       :        +- CometFilter
+         :     :                       :           +- CometNativeScan parquet spark_catalog.default.catalog_sales
+         :     :                       :                 +- ReusedSubquery
+         :     :                       +- CometBroadcastExchange
+         :     :                          +- CometFilter
+         :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     +- CometBroadcastExchange
+         :        +- CometFilter
+         :           +- CometHashAggregate
+         :              +- CometExchange
+         :                 +- CometHashAggregate
+         :                    +- CometProject
+         :                       +- CometBroadcastHashJoin
+         :                          :- CometProject
+         :                          :  +- CometBroadcastHashJoin
+         :                          :     :- CometProject
+         :                          :     :  +- CometFilter
+         :                          :     :     +- CometNativeScan parquet spark_catalog.default.customer
+         :                          :     +- CometBroadcastExchange
+         :                          :        +- CometFilter
+         :                          :           +- CometNativeScan parquet spark_catalog.default.web_sales
+         :                          :                 +- ReusedSubquery
+         :                          +- CometBroadcastExchange
+         :                             +- CometFilter
+         :                                +- CometNativeScan parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometFilter
+                           :     :     +- CometNativeScan parquet spark_catalog.default.customer
+                           :     +- CometBroadcastExchange
+                           :        +- CometFilter
+                           :           +- CometNativeScan parquet spark_catalog.default.web_sales
+                           :                 +- ReusedSubquery
+                           +- CometBroadcastExchange
+                              +- CometFilter
+                                 +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 120 out of 126 eligible operators (95%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q4.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q4.native_iceberg_compat/extended.txt
@@ -1,0 +1,131 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometProject
+         :     :  +- CometBroadcastHashJoin
+         :     :     :- CometProject
+         :     :     :  +- CometBroadcastHashJoin
+         :     :     :     :- CometBroadcastHashJoin
+         :     :     :     :  :- CometFilter
+         :     :     :     :  :  +- CometHashAggregate
+         :     :     :     :  :     +- CometExchange
+         :     :     :     :  :        +- CometHashAggregate
+         :     :     :     :  :           +- CometProject
+         :     :     :     :  :              +- CometBroadcastHashJoin
+         :     :     :     :  :                 :- CometProject
+         :     :     :     :  :                 :  +- CometBroadcastHashJoin
+         :     :     :     :  :                 :     :- CometProject
+         :     :     :     :  :                 :     :  +- CometFilter
+         :     :     :     :  :                 :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         :     :     :     :  :                 :     +- CometBroadcastExchange
+         :     :     :     :  :                 :        +- CometFilter
+         :     :     :     :  :                 :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     :     :     :  :                 :                 +- SubqueryBroadcast
+         :     :     :     :  :                 :                    +- BroadcastExchange
+         :     :     :     :  :                 :                       +- CometNativeColumnarToRow
+         :     :     :     :  :                 :                          +- CometFilter
+         :     :     :     :  :                 :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :     :     :  :                 +- CometBroadcastExchange
+         :     :     :     :  :                    +- CometFilter
+         :     :     :     :  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :     :     :  +- CometBroadcastExchange
+         :     :     :     :     +- CometHashAggregate
+         :     :     :     :        +- CometExchange
+         :     :     :     :           +- CometHashAggregate
+         :     :     :     :              +- CometProject
+         :     :     :     :                 +- CometBroadcastHashJoin
+         :     :     :     :                    :- CometProject
+         :     :     :     :                    :  +- CometBroadcastHashJoin
+         :     :     :     :                    :     :- CometProject
+         :     :     :     :                    :     :  +- CometFilter
+         :     :     :     :                    :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         :     :     :     :                    :     +- CometBroadcastExchange
+         :     :     :     :                    :        +- CometFilter
+         :     :     :     :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     :     :     :                    :                 +- SubqueryBroadcast
+         :     :     :     :                    :                    +- BroadcastExchange
+         :     :     :     :                    :                       +- CometNativeColumnarToRow
+         :     :     :     :                    :                          +- CometFilter
+         :     :     :     :                    :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :     :     :                    +- CometBroadcastExchange
+         :     :     :     :                       +- CometFilter
+         :     :     :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :     :     +- CometBroadcastExchange
+         :     :     :        +- CometFilter
+         :     :     :           +- CometHashAggregate
+         :     :     :              +- CometExchange
+         :     :     :                 +- CometHashAggregate
+         :     :     :                    +- CometProject
+         :     :     :                       +- CometBroadcastHashJoin
+         :     :     :                          :- CometProject
+         :     :     :                          :  +- CometBroadcastHashJoin
+         :     :     :                          :     :- CometProject
+         :     :     :                          :     :  +- CometFilter
+         :     :     :                          :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         :     :     :                          :     +- CometBroadcastExchange
+         :     :     :                          :        +- CometFilter
+         :     :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+         :     :     :                          :                 +- ReusedSubquery
+         :     :     :                          +- CometBroadcastExchange
+         :     :     :                             +- CometFilter
+         :     :     :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :     +- CometBroadcastExchange
+         :     :        +- CometHashAggregate
+         :     :           +- CometExchange
+         :     :              +- CometHashAggregate
+         :     :                 +- CometProject
+         :     :                    +- CometBroadcastHashJoin
+         :     :                       :- CometProject
+         :     :                       :  +- CometBroadcastHashJoin
+         :     :                       :     :- CometProject
+         :     :                       :     :  +- CometFilter
+         :     :                       :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         :     :                       :     +- CometBroadcastExchange
+         :     :                       :        +- CometFilter
+         :     :                       :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+         :     :                       :                 +- ReusedSubquery
+         :     :                       +- CometBroadcastExchange
+         :     :                          +- CometFilter
+         :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     +- CometBroadcastExchange
+         :        +- CometFilter
+         :           +- CometHashAggregate
+         :              +- CometExchange
+         :                 +- CometHashAggregate
+         :                    +- CometProject
+         :                       +- CometBroadcastHashJoin
+         :                          :- CometProject
+         :                          :  +- CometBroadcastHashJoin
+         :                          :     :- CometProject
+         :                          :     :  +- CometFilter
+         :                          :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         :                          :     +- CometBroadcastExchange
+         :                          :        +- CometFilter
+         :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+         :                          :                 +- ReusedSubquery
+         :                          +- CometBroadcastExchange
+         :                             +- CometFilter
+         :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometFilter
+                           :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                           :     +- CometBroadcastExchange
+                           :        +- CometFilter
+                           :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                           :                 +- ReusedSubquery
+                           +- CometBroadcastExchange
+                              +- CometFilter
+                                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 118 out of 126 eligible operators (93%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q40.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q40.native_datafusion/extended.txt
@@ -1,0 +1,39 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometSortMergeJoin
+                  :     :     :     :- CometSort
+                  :     :     :     :  +- CometExchange
+                  :     :     :     :     +- CometFilter
+                  :     :     :     :        +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                  :     :     :     :              +- CometSubqueryBroadcast
+                  :     :     :     :                 +- CometBroadcastExchange
+                  :     :     :     :                    +- CometFilter
+                  :     :     :     :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     :     +- CometSort
+                  :     :     :        +- CometExchange
+                  :     :     :           +- CometProject
+                  :     :     :              +- CometFilter
+                  :     :     :                 +- CometNativeScan parquet spark_catalog.default.catalog_returns
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometNativeScan parquet spark_catalog.default.warehouse
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometNativeScan parquet spark_catalog.default.item
+                  +- CometBroadcastExchange
+                     +- CometFilter
+                        +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 35 out of 36 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q40.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q40.native_iceberg_compat/extended.txt
@@ -1,0 +1,40 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometSortMergeJoin
+                  :     :     :     :- CometSort
+                  :     :     :     :  +- CometExchange
+                  :     :     :     :     +- CometFilter
+                  :     :     :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                  :     :     :     :              +- SubqueryBroadcast
+                  :     :     :     :                 +- BroadcastExchange
+                  :     :     :     :                    +- CometNativeColumnarToRow
+                  :     :     :     :                       +- CometFilter
+                  :     :     :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     :     +- CometSort
+                  :     :     :        +- CometExchange
+                  :     :     :           +- CometProject
+                  :     :     :              +- CometFilter
+                  :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.warehouse
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  +- CometBroadcastExchange
+                     +- CometFilter
+                        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 34 out of 36 eligible operators (94%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q41.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q41.native_datafusion/extended.txt
@@ -1,0 +1,21 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometFilter
+                  :     +- CometNativeScan parquet spark_catalog.default.item
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometHashAggregate
+                              +- CometExchange
+                                 +- CometHashAggregate
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 18 out of 18 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q41.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q41.native_iceberg_compat/extended.txt
@@ -1,0 +1,21 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometFilter
+                  :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometHashAggregate
+                              +- CometExchange
+                                 +- CometHashAggregate
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 18 out of 18 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q42.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q42.native_datafusion/extended.txt
@@ -1,0 +1,21 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometFilter
+                  :     :     +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometFilter
+                  :           +- CometNativeScan parquet spark_catalog.default.store_sales
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 18 out of 18 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q42.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q42.native_iceberg_compat/extended.txt
@@ -1,0 +1,21 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometFilter
+                  :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometFilter
+                  :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 18 out of 18 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q43.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q43.native_datafusion/extended.txt
@@ -1,0 +1,21 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometFilter
+                  :     :     +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometFilter
+                  :           +- CometNativeScan parquet spark_catalog.default.store_sales
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.store
+
+Comet accelerated 18 out of 18 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q43.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q43.native_iceberg_compat/extended.txt
@@ -1,0 +1,21 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometFilter
+                  :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometFilter
+                  :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+
+Comet accelerated 18 out of 18 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q44.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q44.native_datafusion/extended.txt
@@ -1,0 +1,65 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometProject
+         :     :  +- CometSortMergeJoin
+         :     :     :- CometSort
+         :     :     :  +- CometColumnarExchange
+         :     :     :     +- Project
+         :     :     :        +- Filter
+         :     :     :           +- Window
+         :     :     :              +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+         :     :     :                 +- CometNativeColumnarToRow
+         :     :     :                    +- CometSort
+         :     :     :                       +- CometColumnarExchange
+         :     :     :                          +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+         :     :     :                             +- CometNativeColumnarToRow
+         :     :     :                                +- CometSort
+         :     :     :                                   +- CometFilter
+         :     :     :                                      :  +- Subquery
+         :     :     :                                      :     +- CometNativeColumnarToRow
+         :     :     :                                      :        +- CometHashAggregate
+         :     :     :                                      :           +- CometExchange
+         :     :     :                                      :              +- CometHashAggregate
+         :     :     :                                      :                 +- CometProject
+         :     :     :                                      :                    +- CometFilter
+         :     :     :                                      :                       +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     :     :                                      +- CometHashAggregate
+         :     :     :                                         +- CometExchange
+         :     :     :                                            +- CometHashAggregate
+         :     :     :                                               +- CometProject
+         :     :     :                                                  +- CometFilter
+         :     :     :                                                     +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     :     +- CometSort
+         :     :        +- CometColumnarExchange
+         :     :           +- Project
+         :     :              +- Filter
+         :     :                 +- Window
+         :     :                    +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+         :     :                       +- CometNativeColumnarToRow
+         :     :                          +- CometSort
+         :     :                             +- CometColumnarExchange
+         :     :                                +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+         :     :                                   +- CometNativeColumnarToRow
+         :     :                                      +- CometSort
+         :     :                                         +- CometFilter
+         :     :                                            :  +- ReusedSubquery
+         :     :                                            +- CometHashAggregate
+         :     :                                               +- CometExchange
+         :     :                                                  +- CometHashAggregate
+         :     :                                                     +- CometProject
+         :     :                                                        +- CometFilter
+         :     :                                                           +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     +- CometBroadcastExchange
+         :        +- CometProject
+         :           +- CometFilter
+         :              +- CometNativeScan parquet spark_catalog.default.item
+         +- CometBroadcastExchange
+            +- CometProject
+               +- CometFilter
+                  +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 45 out of 57 eligible operators (78%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q44.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q44.native_iceberg_compat/extended.txt
@@ -1,0 +1,65 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometProject
+         :     :  +- CometSortMergeJoin
+         :     :     :- CometSort
+         :     :     :  +- CometColumnarExchange
+         :     :     :     +- Project
+         :     :     :        +- Filter
+         :     :     :           +- Window
+         :     :     :              +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+         :     :     :                 +- CometNativeColumnarToRow
+         :     :     :                    +- CometSort
+         :     :     :                       +- CometColumnarExchange
+         :     :     :                          +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+         :     :     :                             +- CometNativeColumnarToRow
+         :     :     :                                +- CometSort
+         :     :     :                                   +- CometFilter
+         :     :     :                                      :  +- Subquery
+         :     :     :                                      :     +- CometNativeColumnarToRow
+         :     :     :                                      :        +- CometHashAggregate
+         :     :     :                                      :           +- CometExchange
+         :     :     :                                      :              +- CometHashAggregate
+         :     :     :                                      :                 +- CometProject
+         :     :     :                                      :                    +- CometFilter
+         :     :     :                                      :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     :     :                                      +- CometHashAggregate
+         :     :     :                                         +- CometExchange
+         :     :     :                                            +- CometHashAggregate
+         :     :     :                                               +- CometProject
+         :     :     :                                                  +- CometFilter
+         :     :     :                                                     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     :     +- CometSort
+         :     :        +- CometColumnarExchange
+         :     :           +- Project
+         :     :              +- Filter
+         :     :                 +- Window
+         :     :                    +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+         :     :                       +- CometNativeColumnarToRow
+         :     :                          +- CometSort
+         :     :                             +- CometColumnarExchange
+         :     :                                +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+         :     :                                   +- CometNativeColumnarToRow
+         :     :                                      +- CometSort
+         :     :                                         +- CometFilter
+         :     :                                            :  +- ReusedSubquery
+         :     :                                            +- CometHashAggregate
+         :     :                                               +- CometExchange
+         :     :                                                  +- CometHashAggregate
+         :     :                                                     +- CometProject
+         :     :                                                        +- CometFilter
+         :     :                                                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     +- CometBroadcastExchange
+         :        +- CometProject
+         :           +- CometFilter
+         :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+         +- CometBroadcastExchange
+            +- CometProject
+               +- CometFilter
+                  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 45 out of 57 eligible operators (78%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q45.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q45.native_datafusion/extended.txt
@@ -1,0 +1,45 @@
+TakeOrderedAndProject
++- HashAggregate
+   +- Exchange
+      +- HashAggregate
+         +- Project
+            +- Filter
+               +-  BroadcastHashJoin [COMET: Unsupported join type ExistenceJoin(exists#1)]
+                  :- CometNativeColumnarToRow
+                  :  +- CometProject
+                  :     +- CometBroadcastHashJoin
+                  :        :- CometProject
+                  :        :  +- CometBroadcastHashJoin
+                  :        :     :- CometProject
+                  :        :     :  +- CometBroadcastHashJoin
+                  :        :     :     :- CometProject
+                  :        :     :     :  +- CometBroadcastHashJoin
+                  :        :     :     :     :- CometFilter
+                  :        :     :     :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                  :        :     :     :     :        +- CometSubqueryBroadcast
+                  :        :     :     :     :           +- CometBroadcastExchange
+                  :        :     :     :     :              +- CometProject
+                  :        :     :     :     :                 +- CometFilter
+                  :        :     :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :        :     :     :     +- CometBroadcastExchange
+                  :        :     :     :        +- CometFilter
+                  :        :     :     :           +- CometNativeScan parquet spark_catalog.default.customer
+                  :        :     :     +- CometBroadcastExchange
+                  :        :     :        +- CometProject
+                  :        :     :           +- CometFilter
+                  :        :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                  :        :     +- CometBroadcastExchange
+                  :        :        +- CometProject
+                  :        :           +- CometFilter
+                  :        :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :        +- CometBroadcastExchange
+                  :           +- CometProject
+                  :              +- CometFilter
+                  :                 +- CometNativeScan parquet spark_catalog.default.item
+                  +- BroadcastExchange
+                     +- CometNativeColumnarToRow
+                        +- CometProject
+                           +- CometFilter
+                              +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 32 out of 41 eligible operators (78%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q45.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q45.native_iceberg_compat/extended.txt
@@ -1,0 +1,46 @@
+TakeOrderedAndProject
++- HashAggregate
+   +- Exchange
+      +- HashAggregate
+         +- Project
+            +- Filter
+               +-  BroadcastHashJoin [COMET: Unsupported join type ExistenceJoin(exists#1)]
+                  :- CometNativeColumnarToRow
+                  :  +- CometProject
+                  :     +- CometBroadcastHashJoin
+                  :        :- CometProject
+                  :        :  +- CometBroadcastHashJoin
+                  :        :     :- CometProject
+                  :        :     :  +- CometBroadcastHashJoin
+                  :        :     :     :- CometProject
+                  :        :     :     :  +- CometBroadcastHashJoin
+                  :        :     :     :     :- CometFilter
+                  :        :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                  :        :     :     :     :        +- SubqueryBroadcast
+                  :        :     :     :     :           +- BroadcastExchange
+                  :        :     :     :     :              +- CometNativeColumnarToRow
+                  :        :     :     :     :                 +- CometProject
+                  :        :     :     :     :                    +- CometFilter
+                  :        :     :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :        :     :     :     +- CometBroadcastExchange
+                  :        :     :     :        +- CometFilter
+                  :        :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                  :        :     :     +- CometBroadcastExchange
+                  :        :     :        +- CometProject
+                  :        :     :           +- CometFilter
+                  :        :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                  :        :     +- CometBroadcastExchange
+                  :        :        +- CometProject
+                  :        :           +- CometFilter
+                  :        :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :        +- CometBroadcastExchange
+                  :           +- CometProject
+                  :              +- CometFilter
+                  :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  +- BroadcastExchange
+                     +- CometNativeColumnarToRow
+                        +- CometProject
+                           +- CometFilter
+                              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 31 out of 41 eligible operators (75%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q46.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q46.native_datafusion/extended.txt
@@ -1,0 +1,48 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometHashAggregate
+         :     :  +- CometExchange
+         :     :     +- CometHashAggregate
+         :     :        +- CometProject
+         :     :           +- CometBroadcastHashJoin
+         :     :              :- CometProject
+         :     :              :  +- CometBroadcastHashJoin
+         :     :              :     :- CometProject
+         :     :              :     :  +- CometBroadcastHashJoin
+         :     :              :     :     :- CometProject
+         :     :              :     :     :  +- CometBroadcastHashJoin
+         :     :              :     :     :     :- CometFilter
+         :     :              :     :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     :              :     :     :     :        +- CometSubqueryBroadcast
+         :     :              :     :     :     :           +- CometBroadcastExchange
+         :     :              :     :     :     :              +- CometProject
+         :     :              :     :     :     :                 +- CometFilter
+         :     :              :     :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :              :     :     :     +- CometBroadcastExchange
+         :     :              :     :     :        +- CometProject
+         :     :              :     :     :           +- CometFilter
+         :     :              :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :              :     :     +- CometBroadcastExchange
+         :     :              :     :        +- CometProject
+         :     :              :     :           +- CometFilter
+         :     :              :     :              +- CometNativeScan parquet spark_catalog.default.store
+         :     :              :     +- CometBroadcastExchange
+         :     :              :        +- CometProject
+         :     :              :           +- CometFilter
+         :     :              :              +- CometNativeScan parquet spark_catalog.default.household_demographics
+         :     :              +- CometBroadcastExchange
+         :     :                 +- CometFilter
+         :     :                    +- CometNativeScan parquet spark_catalog.default.customer_address
+         :     +- CometBroadcastExchange
+         :        +- CometProject
+         :           +- CometFilter
+         :              +- CometNativeScan parquet spark_catalog.default.customer
+         +- CometBroadcastExchange
+            +- CometFilter
+               +- CometNativeScan parquet spark_catalog.default.customer_address
+
+Comet accelerated 44 out of 45 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q46.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q46.native_iceberg_compat/extended.txt
@@ -1,0 +1,49 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometHashAggregate
+         :     :  +- CometExchange
+         :     :     +- CometHashAggregate
+         :     :        +- CometProject
+         :     :           +- CometBroadcastHashJoin
+         :     :              :- CometProject
+         :     :              :  +- CometBroadcastHashJoin
+         :     :              :     :- CometProject
+         :     :              :     :  +- CometBroadcastHashJoin
+         :     :              :     :     :- CometProject
+         :     :              :     :     :  +- CometBroadcastHashJoin
+         :     :              :     :     :     :- CometFilter
+         :     :              :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     :              :     :     :     :        +- SubqueryBroadcast
+         :     :              :     :     :     :           +- BroadcastExchange
+         :     :              :     :     :     :              +- CometNativeColumnarToRow
+         :     :              :     :     :     :                 +- CometProject
+         :     :              :     :     :     :                    +- CometFilter
+         :     :              :     :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :              :     :     :     +- CometBroadcastExchange
+         :     :              :     :     :        +- CometProject
+         :     :              :     :     :           +- CometFilter
+         :     :              :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :              :     :     +- CometBroadcastExchange
+         :     :              :     :        +- CometProject
+         :     :              :     :           +- CometFilter
+         :     :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+         :     :              :     +- CometBroadcastExchange
+         :     :              :        +- CometProject
+         :     :              :           +- CometFilter
+         :     :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+         :     :              +- CometBroadcastExchange
+         :     :                 +- CometFilter
+         :     :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+         :     +- CometBroadcastExchange
+         :        +- CometProject
+         :           +- CometFilter
+         :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         +- CometBroadcastExchange
+            +- CometFilter
+               +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+
+Comet accelerated 43 out of 45 eligible operators (95%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q47.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q47.native_datafusion/extended.txt
@@ -1,0 +1,102 @@
+TakeOrderedAndProject
++- Project
+   +- BroadcastHashJoin
+      :- Project
+      :  +- BroadcastHashJoin
+      :     :- Project
+      :     :  +- Filter
+      :     :     +- Window
+      :     :        +- Filter
+      :     :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      :     :              +- CometNativeColumnarToRow
+      :     :                 +- CometSort
+      :     :                    +- CometExchange
+      :     :                       +- CometHashAggregate
+      :     :                          +- CometExchange
+      :     :                             +- CometHashAggregate
+      :     :                                +- CometProject
+      :     :                                   +- CometBroadcastHashJoin
+      :     :                                      :- CometProject
+      :     :                                      :  +- CometBroadcastHashJoin
+      :     :                                      :     :- CometProject
+      :     :                                      :     :  +- CometBroadcastHashJoin
+      :     :                                      :     :     :- CometProject
+      :     :                                      :     :     :  +- CometFilter
+      :     :                                      :     :     :     +- CometNativeScan parquet spark_catalog.default.item
+      :     :                                      :     :     +- CometBroadcastExchange
+      :     :                                      :     :        +- CometFilter
+      :     :                                      :     :           +- CometNativeScan parquet spark_catalog.default.store_sales
+      :     :                                      :     :                 +- CometSubqueryBroadcast
+      :     :                                      :     :                    +- CometBroadcastExchange
+      :     :                                      :     :                       +- CometFilter
+      :     :                                      :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+      :     :                                      :     +- CometBroadcastExchange
+      :     :                                      :        +- CometFilter
+      :     :                                      :           +- CometNativeScan parquet spark_catalog.default.date_dim
+      :     :                                      +- CometBroadcastExchange
+      :     :                                         +- CometFilter
+      :     :                                            +- CometNativeScan parquet spark_catalog.default.store
+      :     +- BroadcastExchange
+      :        +- Project
+      :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      :              +- CometNativeColumnarToRow
+      :                 +- CometSort
+      :                    +- CometExchange
+      :                       +- CometHashAggregate
+      :                          +- CometExchange
+      :                             +- CometHashAggregate
+      :                                +- CometProject
+      :                                   +- CometBroadcastHashJoin
+      :                                      :- CometProject
+      :                                      :  +- CometBroadcastHashJoin
+      :                                      :     :- CometProject
+      :                                      :     :  +- CometBroadcastHashJoin
+      :                                      :     :     :- CometProject
+      :                                      :     :     :  +- CometFilter
+      :                                      :     :     :     +- CometNativeScan parquet spark_catalog.default.item
+      :                                      :     :     +- CometBroadcastExchange
+      :                                      :     :        +- CometFilter
+      :                                      :     :           +- CometNativeScan parquet spark_catalog.default.store_sales
+      :                                      :     :                 +- CometSubqueryBroadcast
+      :                                      :     :                    +- CometBroadcastExchange
+      :                                      :     :                       +- CometFilter
+      :                                      :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                                      :     +- CometBroadcastExchange
+      :                                      :        +- CometFilter
+      :                                      :           +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                                      +- CometBroadcastExchange
+      :                                         +- CometFilter
+      :                                            +- CometNativeScan parquet spark_catalog.default.store
+      +- BroadcastExchange
+         +- Project
+            +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               +- CometNativeColumnarToRow
+                  +- CometSort
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometExchange
+                              +- CometHashAggregate
+                                 +- CometProject
+                                    +- CometBroadcastHashJoin
+                                       :- CometProject
+                                       :  +- CometBroadcastHashJoin
+                                       :     :- CometProject
+                                       :     :  +- CometBroadcastHashJoin
+                                       :     :     :- CometProject
+                                       :     :     :  +- CometFilter
+                                       :     :     :     +- CometNativeScan parquet spark_catalog.default.item
+                                       :     :     +- CometBroadcastExchange
+                                       :     :        +- CometFilter
+                                       :     :           +- CometNativeScan parquet spark_catalog.default.store_sales
+                                       :     :                 +- CometSubqueryBroadcast
+                                       :     :                    +- CometBroadcastExchange
+                                       :     :                       +- CometFilter
+                                       :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       :     +- CometBroadcastExchange
+                                       :        +- CometFilter
+                                       :           +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       +- CometBroadcastExchange
+                                          +- CometFilter
+                                             +- CometNativeScan parquet spark_catalog.default.store
+
+Comet accelerated 78 out of 97 eligible operators (80%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q47.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q47.native_iceberg_compat/extended.txt
@@ -1,0 +1,105 @@
+TakeOrderedAndProject
++- Project
+   +- BroadcastHashJoin
+      :- Project
+      :  +- BroadcastHashJoin
+      :     :- Project
+      :     :  +- Filter
+      :     :     +- Window
+      :     :        +- Filter
+      :     :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      :     :              +- CometNativeColumnarToRow
+      :     :                 +- CometSort
+      :     :                    +- CometExchange
+      :     :                       +- CometHashAggregate
+      :     :                          +- CometExchange
+      :     :                             +- CometHashAggregate
+      :     :                                +- CometProject
+      :     :                                   +- CometBroadcastHashJoin
+      :     :                                      :- CometProject
+      :     :                                      :  +- CometBroadcastHashJoin
+      :     :                                      :     :- CometProject
+      :     :                                      :     :  +- CometBroadcastHashJoin
+      :     :                                      :     :     :- CometProject
+      :     :                                      :     :     :  +- CometFilter
+      :     :                                      :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :     :                                      :     :     +- CometBroadcastExchange
+      :     :                                      :     :        +- CometFilter
+      :     :                                      :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+      :     :                                      :     :                 +- SubqueryBroadcast
+      :     :                                      :     :                    +- BroadcastExchange
+      :     :                                      :     :                       +- CometNativeColumnarToRow
+      :     :                                      :     :                          +- CometFilter
+      :     :                                      :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :     :                                      :     +- CometBroadcastExchange
+      :     :                                      :        +- CometFilter
+      :     :                                      :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :     :                                      +- CometBroadcastExchange
+      :     :                                         +- CometFilter
+      :     :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+      :     +- BroadcastExchange
+      :        +- Project
+      :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      :              +- CometNativeColumnarToRow
+      :                 +- CometSort
+      :                    +- CometExchange
+      :                       +- CometHashAggregate
+      :                          +- CometExchange
+      :                             +- CometHashAggregate
+      :                                +- CometProject
+      :                                   +- CometBroadcastHashJoin
+      :                                      :- CometProject
+      :                                      :  +- CometBroadcastHashJoin
+      :                                      :     :- CometProject
+      :                                      :     :  +- CometBroadcastHashJoin
+      :                                      :     :     :- CometProject
+      :                                      :     :     :  +- CometFilter
+      :                                      :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                                      :     :     +- CometBroadcastExchange
+      :                                      :     :        +- CometFilter
+      :                                      :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+      :                                      :     :                 +- SubqueryBroadcast
+      :                                      :     :                    +- BroadcastExchange
+      :                                      :     :                       +- CometNativeColumnarToRow
+      :                                      :     :                          +- CometFilter
+      :                                      :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                                      :     +- CometBroadcastExchange
+      :                                      :        +- CometFilter
+      :                                      :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                                      +- CometBroadcastExchange
+      :                                         +- CometFilter
+      :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+      +- BroadcastExchange
+         +- Project
+            +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               +- CometNativeColumnarToRow
+                  +- CometSort
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometExchange
+                              +- CometHashAggregate
+                                 +- CometProject
+                                    +- CometBroadcastHashJoin
+                                       :- CometProject
+                                       :  +- CometBroadcastHashJoin
+                                       :     :- CometProject
+                                       :     :  +- CometBroadcastHashJoin
+                                       :     :     :- CometProject
+                                       :     :     :  +- CometFilter
+                                       :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                       :     :     +- CometBroadcastExchange
+                                       :     :        +- CometFilter
+                                       :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                       :     :                 +- SubqueryBroadcast
+                                       :     :                    +- BroadcastExchange
+                                       :     :                       +- CometNativeColumnarToRow
+                                       :     :                          +- CometFilter
+                                       :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       :     +- CometBroadcastExchange
+                                       :        +- CometFilter
+                                       :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       +- CometBroadcastExchange
+                                          +- CometFilter
+                                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+
+Comet accelerated 75 out of 97 eligible operators (77%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q48.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q48.native_datafusion/extended.txt
@@ -1,0 +1,36 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometProject
+            +- CometBroadcastHashJoin
+               :- CometProject
+               :  +- CometBroadcastHashJoin
+               :     :- CometProject
+               :     :  +- CometBroadcastHashJoin
+               :     :     :- CometProject
+               :     :     :  +- CometBroadcastHashJoin
+               :     :     :     :- CometFilter
+               :     :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :     :     :     :        +- CometSubqueryBroadcast
+               :     :     :     :           +- CometBroadcastExchange
+               :     :     :     :              +- CometProject
+               :     :     :     :                 +- CometFilter
+               :     :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     :     :     +- CometBroadcastExchange
+               :     :     :        +- CometFilter
+               :     :     :           +- CometNativeScan parquet spark_catalog.default.store
+               :     :     +- CometBroadcastExchange
+               :     :        +- CometProject
+               :     :           +- CometFilter
+               :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+               :     +- CometBroadcastExchange
+               :        +- CometProject
+               :           +- CometFilter
+               :              +- CometNativeScan parquet spark_catalog.default.customer_address
+               +- CometBroadcastExchange
+                  +- CometProject
+                     +- CometFilter
+                        +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 32 out of 33 eligible operators (96%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q48.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q48.native_iceberg_compat/extended.txt
@@ -1,0 +1,37 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometProject
+            +- CometBroadcastHashJoin
+               :- CometProject
+               :  +- CometBroadcastHashJoin
+               :     :- CometProject
+               :     :  +- CometBroadcastHashJoin
+               :     :     :- CometProject
+               :     :     :  +- CometBroadcastHashJoin
+               :     :     :     :- CometFilter
+               :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :     :     :     :        +- SubqueryBroadcast
+               :     :     :     :           +- BroadcastExchange
+               :     :     :     :              +- CometNativeColumnarToRow
+               :     :     :     :                 +- CometProject
+               :     :     :     :                    +- CometFilter
+               :     :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     :     :     +- CometBroadcastExchange
+               :     :     :        +- CometFilter
+               :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+               :     :     +- CometBroadcastExchange
+               :     :        +- CometProject
+               :     :           +- CometFilter
+               :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+               :     +- CometBroadcastExchange
+               :        +- CometProject
+               :           +- CometFilter
+               :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+               +- CometBroadcastExchange
+                  +- CometProject
+                     +- CometFilter
+                        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 31 out of 33 eligible operators (93%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q49.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q49.native_datafusion/extended.txt
@@ -1,0 +1,91 @@
+TakeOrderedAndProject
++- HashAggregate
+   +- HashAggregate
+      +- Union
+         :- Project
+         :  +- Filter
+         :     +- Window
+         :        +- Sort
+         :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+         :              +- CometNativeColumnarToRow
+         :                 +- CometSort
+         :                    +- CometExchange
+         :                       +- CometHashAggregate
+         :                          +- CometExchange
+         :                             +- CometHashAggregate
+         :                                +- CometProject
+         :                                   +- CometBroadcastHashJoin
+         :                                      :- CometProject
+         :                                      :  +- CometBroadcastHashJoin
+         :                                      :     :- CometBroadcastExchange
+         :                                      :     :  +- CometProject
+         :                                      :     :     +- CometFilter
+         :                                      :     :        +- CometNativeScan parquet spark_catalog.default.web_sales
+         :                                      :     :              +- CometSubqueryBroadcast
+         :                                      :     :                 +- CometBroadcastExchange
+         :                                      :     :                    +- CometProject
+         :                                      :     :                       +- CometFilter
+         :                                      :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+         :                                      :     +- CometProject
+         :                                      :        +- CometFilter
+         :                                      :           +- CometNativeScan parquet spark_catalog.default.web_returns
+         :                                      +- CometBroadcastExchange
+         :                                         +- CometProject
+         :                                            +- CometFilter
+         :                                               +- CometNativeScan parquet spark_catalog.default.date_dim
+         :- Project
+         :  +- Filter
+         :     +- Window
+         :        +- Sort
+         :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+         :              +- CometNativeColumnarToRow
+         :                 +- CometSort
+         :                    +- CometExchange
+         :                       +- CometHashAggregate
+         :                          +- CometExchange
+         :                             +- CometHashAggregate
+         :                                +- CometProject
+         :                                   +- CometBroadcastHashJoin
+         :                                      :- CometProject
+         :                                      :  +- CometBroadcastHashJoin
+         :                                      :     :- CometBroadcastExchange
+         :                                      :     :  +- CometProject
+         :                                      :     :     +- CometFilter
+         :                                      :     :        +- CometNativeScan parquet spark_catalog.default.catalog_sales
+         :                                      :     :              +- ReusedSubquery
+         :                                      :     +- CometProject
+         :                                      :        +- CometFilter
+         :                                      :           +- CometNativeScan parquet spark_catalog.default.catalog_returns
+         :                                      +- CometBroadcastExchange
+         :                                         +- CometProject
+         :                                            +- CometFilter
+         :                                               +- CometNativeScan parquet spark_catalog.default.date_dim
+         +- Project
+            +- Filter
+               +- Window
+                  +- Sort
+                     +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+                        +- CometNativeColumnarToRow
+                           +- CometSort
+                              +- CometExchange
+                                 +- CometHashAggregate
+                                    +- CometExchange
+                                       +- CometHashAggregate
+                                          +- CometProject
+                                             +- CometBroadcastHashJoin
+                                                :- CometProject
+                                                :  +- CometBroadcastHashJoin
+                                                :     :- CometBroadcastExchange
+                                                :     :  +- CometProject
+                                                :     :     +- CometFilter
+                                                :     :        +- CometNativeScan parquet spark_catalog.default.store_sales
+                                                :     :              +- ReusedSubquery
+                                                :     +- CometProject
+                                                :        +- CometFilter
+                                                :           +- CometNativeScan parquet spark_catalog.default.store_returns
+                                                +- CometBroadcastExchange
+                                                   +- CometProject
+                                                      +- CometFilter
+                                                         +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 64 out of 86 eligible operators (74%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q49.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q49.native_iceberg_compat/extended.txt
@@ -1,0 +1,92 @@
+TakeOrderedAndProject
++- HashAggregate
+   +- HashAggregate
+      +- Union
+         :- Project
+         :  +- Filter
+         :     +- Window
+         :        +- Sort
+         :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+         :              +- CometNativeColumnarToRow
+         :                 +- CometSort
+         :                    +- CometExchange
+         :                       +- CometHashAggregate
+         :                          +- CometExchange
+         :                             +- CometHashAggregate
+         :                                +- CometProject
+         :                                   +- CometBroadcastHashJoin
+         :                                      :- CometProject
+         :                                      :  +- CometBroadcastHashJoin
+         :                                      :     :- CometBroadcastExchange
+         :                                      :     :  +- CometProject
+         :                                      :     :     +- CometFilter
+         :                                      :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+         :                                      :     :              +- SubqueryBroadcast
+         :                                      :     :                 +- BroadcastExchange
+         :                                      :     :                    +- CometNativeColumnarToRow
+         :                                      :     :                       +- CometProject
+         :                                      :     :                          +- CometFilter
+         :                                      :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :                                      :     +- CometProject
+         :                                      :        +- CometFilter
+         :                                      :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+         :                                      +- CometBroadcastExchange
+         :                                         +- CometProject
+         :                                            +- CometFilter
+         :                                               +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :- Project
+         :  +- Filter
+         :     +- Window
+         :        +- Sort
+         :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+         :              +- CometNativeColumnarToRow
+         :                 +- CometSort
+         :                    +- CometExchange
+         :                       +- CometHashAggregate
+         :                          +- CometExchange
+         :                             +- CometHashAggregate
+         :                                +- CometProject
+         :                                   +- CometBroadcastHashJoin
+         :                                      :- CometProject
+         :                                      :  +- CometBroadcastHashJoin
+         :                                      :     :- CometBroadcastExchange
+         :                                      :     :  +- CometProject
+         :                                      :     :     +- CometFilter
+         :                                      :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+         :                                      :     :              +- ReusedSubquery
+         :                                      :     +- CometProject
+         :                                      :        +- CometFilter
+         :                                      :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+         :                                      +- CometBroadcastExchange
+         :                                         +- CometProject
+         :                                            +- CometFilter
+         :                                               +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         +- Project
+            +- Filter
+               +- Window
+                  +- Sort
+                     +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+                        +- CometNativeColumnarToRow
+                           +- CometSort
+                              +- CometExchange
+                                 +- CometHashAggregate
+                                    +- CometExchange
+                                       +- CometHashAggregate
+                                          +- CometProject
+                                             +- CometBroadcastHashJoin
+                                                :- CometProject
+                                                :  +- CometBroadcastHashJoin
+                                                :     :- CometBroadcastExchange
+                                                :     :  +- CometProject
+                                                :     :     +- CometFilter
+                                                :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                                :     :              +- ReusedSubquery
+                                                :     +- CometProject
+                                                :        +- CometFilter
+                                                :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+                                                +- CometBroadcastExchange
+                                                   +- CometProject
+                                                      +- CometFilter
+                                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 63 out of 86 eligible operators (73%). Final plan contains 4 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q5.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q5.native_datafusion/extended.txt
@@ -1,0 +1,107 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometExpand
+               +- CometUnion
+                  :- CometHashAggregate
+                  :  +- CometExchange
+                  :     +- CometHashAggregate
+                  :        +- CometProject
+                  :           +- CometBroadcastHashJoin
+                  :              :- CometUnion
+                  :              :  :- CometProject
+                  :              :  :  +- CometBroadcastHashJoin
+                  :              :  :     :- CometProject
+                  :              :  :     :  +- CometFilter
+                  :              :  :     :     +- CometNativeScan parquet spark_catalog.default.store_sales
+                  :              :  :     :           +- CometSubqueryBroadcast
+                  :              :  :     :              +- CometBroadcastExchange
+                  :              :  :     :                 +- CometProject
+                  :              :  :     :                    +- CometFilter
+                  :              :  :     :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :              :  :     +- CometBroadcastExchange
+                  :              :  :        +- CometProject
+                  :              :  :           +- CometFilter
+                  :              :  :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :              :  +- CometProject
+                  :              :     +- CometBroadcastHashJoin
+                  :              :        :- CometProject
+                  :              :        :  +- CometFilter
+                  :              :        :     +- CometNativeScan parquet spark_catalog.default.store_returns
+                  :              :        :           +- ReusedSubquery
+                  :              :        +- CometBroadcastExchange
+                  :              :           +- CometProject
+                  :              :              +- CometFilter
+                  :              :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :              +- CometBroadcastExchange
+                  :                 +- CometProject
+                  :                    +- CometFilter
+                  :                       +- CometNativeScan parquet spark_catalog.default.store
+                  :- CometHashAggregate
+                  :  +- CometExchange
+                  :     +- CometHashAggregate
+                  :        +- CometProject
+                  :           +- CometBroadcastHashJoin
+                  :              :- CometUnion
+                  :              :  :- CometProject
+                  :              :  :  +- CometBroadcastHashJoin
+                  :              :  :     :- CometProject
+                  :              :  :     :  +- CometFilter
+                  :              :  :     :     +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                  :              :  :     :           +- ReusedSubquery
+                  :              :  :     +- CometBroadcastExchange
+                  :              :  :        +- CometProject
+                  :              :  :           +- CometFilter
+                  :              :  :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :              :  +- CometProject
+                  :              :     +- CometBroadcastHashJoin
+                  :              :        :- CometProject
+                  :              :        :  +- CometFilter
+                  :              :        :     +- CometNativeScan parquet spark_catalog.default.catalog_returns
+                  :              :        :           +- ReusedSubquery
+                  :              :        +- CometBroadcastExchange
+                  :              :           +- CometProject
+                  :              :              +- CometFilter
+                  :              :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :              +- CometBroadcastExchange
+                  :                 +- CometProject
+                  :                    +- CometFilter
+                  :                       +- CometNativeScan parquet spark_catalog.default.catalog_page
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometUnion
+                                 :  :- CometProject
+                                 :  :  +- CometBroadcastHashJoin
+                                 :  :     :- CometProject
+                                 :  :     :  +- CometFilter
+                                 :  :     :     +- CometNativeScan parquet spark_catalog.default.web_sales
+                                 :  :     :           +- ReusedSubquery
+                                 :  :     +- CometBroadcastExchange
+                                 :  :        +- CometProject
+                                 :  :           +- CometFilter
+                                 :  :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :  +- CometProject
+                                 :     +- CometBroadcastHashJoin
+                                 :        :- CometProject
+                                 :        :  +- CometBroadcastHashJoin
+                                 :        :     :- CometBroadcastExchange
+                                 :        :     :  +- CometNativeScan parquet spark_catalog.default.web_returns
+                                 :        :     :        +- ReusedSubquery
+                                 :        :     +- CometProject
+                                 :        :        +- CometFilter
+                                 :        :           +- CometNativeScan parquet spark_catalog.default.web_sales
+                                 :        +- CometBroadcastExchange
+                                 :           +- CometProject
+                                 :              +- CometFilter
+                                 :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometNativeScan parquet spark_catalog.default.web_site
+
+Comet accelerated 98 out of 104 eligible operators (94%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q5.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q5.native_iceberg_compat/extended.txt
@@ -1,0 +1,108 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometExpand
+               +- CometUnion
+                  :- CometHashAggregate
+                  :  +- CometExchange
+                  :     +- CometHashAggregate
+                  :        +- CometProject
+                  :           +- CometBroadcastHashJoin
+                  :              :- CometUnion
+                  :              :  :- CometProject
+                  :              :  :  +- CometBroadcastHashJoin
+                  :              :  :     :- CometProject
+                  :              :  :     :  +- CometFilter
+                  :              :  :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :              :  :     :           +- SubqueryBroadcast
+                  :              :  :     :              +- BroadcastExchange
+                  :              :  :     :                 +- CometNativeColumnarToRow
+                  :              :  :     :                    +- CometProject
+                  :              :  :     :                       +- CometFilter
+                  :              :  :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :              :  :     +- CometBroadcastExchange
+                  :              :  :        +- CometProject
+                  :              :  :           +- CometFilter
+                  :              :  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :              :  +- CometProject
+                  :              :     +- CometBroadcastHashJoin
+                  :              :        :- CometProject
+                  :              :        :  +- CometFilter
+                  :              :        :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+                  :              :        :           +- ReusedSubquery
+                  :              :        +- CometBroadcastExchange
+                  :              :           +- CometProject
+                  :              :              +- CometFilter
+                  :              :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :              +- CometBroadcastExchange
+                  :                 +- CometProject
+                  :                    +- CometFilter
+                  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                  :- CometHashAggregate
+                  :  +- CometExchange
+                  :     +- CometHashAggregate
+                  :        +- CometProject
+                  :           +- CometBroadcastHashJoin
+                  :              :- CometUnion
+                  :              :  :- CometProject
+                  :              :  :  +- CometBroadcastHashJoin
+                  :              :  :     :- CometProject
+                  :              :  :     :  +- CometFilter
+                  :              :  :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                  :              :  :     :           +- ReusedSubquery
+                  :              :  :     +- CometBroadcastExchange
+                  :              :  :        +- CometProject
+                  :              :  :           +- CometFilter
+                  :              :  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :              :  +- CometProject
+                  :              :     +- CometBroadcastHashJoin
+                  :              :        :- CometProject
+                  :              :        :  +- CometFilter
+                  :              :        :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+                  :              :        :           +- ReusedSubquery
+                  :              :        +- CometBroadcastExchange
+                  :              :           +- CometProject
+                  :              :              +- CometFilter
+                  :              :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :              +- CometBroadcastExchange
+                  :                 +- CometProject
+                  :                    +- CometFilter
+                  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_page
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometUnion
+                                 :  :- CometProject
+                                 :  :  +- CometBroadcastHashJoin
+                                 :  :     :- CometProject
+                                 :  :     :  +- CometFilter
+                                 :  :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                 :  :     :           +- ReusedSubquery
+                                 :  :     +- CometBroadcastExchange
+                                 :  :        +- CometProject
+                                 :  :           +- CometFilter
+                                 :  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :  +- CometProject
+                                 :     +- CometBroadcastHashJoin
+                                 :        :- CometProject
+                                 :        :  +- CometBroadcastHashJoin
+                                 :        :     :- CometBroadcastExchange
+                                 :        :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+                                 :        :     :        +- ReusedSubquery
+                                 :        :     +- CometProject
+                                 :        :        +- CometFilter
+                                 :        :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                 :        +- CometBroadcastExchange
+                                 :           +- CometProject
+                                 :              +- CometFilter
+                                 :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_site
+
+Comet accelerated 97 out of 104 eligible operators (93%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q50.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q50.native_datafusion/extended.txt
@@ -1,0 +1,36 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometFilter
+                  :     :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometFilter
+                  :     :     :           +- CometNativeScan parquet spark_catalog.default.store_returns
+                  :     :     :                 +- CometSubqueryBroadcast
+                  :     :     :                    +- CometBroadcastExchange
+                  :     :     :                       +- CometProject
+                  :     :     :                          +- CometFilter
+                  :     :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometNativeScan parquet spark_catalog.default.store
+                  :     +- CometBroadcastExchange
+                  :        +- CometFilter
+                  :           +- CometNativeScan parquet spark_catalog.default.date_dim
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 32 out of 33 eligible operators (96%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q50.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q50.native_iceberg_compat/extended.txt
@@ -1,0 +1,37 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometFilter
+                  :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometFilter
+                  :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+                  :     :     :                 +- SubqueryBroadcast
+                  :     :     :                    +- BroadcastExchange
+                  :     :     :                       +- CometNativeColumnarToRow
+                  :     :     :                          +- CometProject
+                  :     :     :                             +- CometFilter
+                  :     :     :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                  :     +- CometBroadcastExchange
+                  :        +- CometFilter
+                  :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 31 out of 33 eligible operators (93%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q51.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q51.native_datafusion/extended.txt
@@ -1,0 +1,52 @@
+TakeOrderedAndProject
++- Filter
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometProject
+                  +- CometSortMergeJoin
+                     :- CometSort
+                     :  +- CometColumnarExchange
+                     :     +- Project
+                     :        +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+                     :           +- CometNativeColumnarToRow
+                     :              +- CometSort
+                     :                 +- CometExchange
+                     :                    +- CometHashAggregate
+                     :                       +- CometExchange
+                     :                          +- CometHashAggregate
+                     :                             +- CometProject
+                     :                                +- CometBroadcastHashJoin
+                     :                                   :- CometFilter
+                     :                                   :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                     :                                   :        +- CometSubqueryBroadcast
+                     :                                   :           +- CometBroadcastExchange
+                     :                                   :              +- CometProject
+                     :                                   :                 +- CometFilter
+                     :                                   :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :                                   +- CometBroadcastExchange
+                     :                                      +- CometProject
+                     :                                         +- CometFilter
+                     :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+                     +- CometSort
+                        +- CometColumnarExchange
+                           +- Project
+                              +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+                                 +- CometNativeColumnarToRow
+                                    +- CometSort
+                                       +- CometExchange
+                                          +- CometHashAggregate
+                                             +- CometExchange
+                                                +- CometHashAggregate
+                                                   +- CometProject
+                                                      +- CometBroadcastHashJoin
+                                                         :- CometFilter
+                                                         :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                                         :        +- ReusedSubquery
+                                                         +- CometBroadcastExchange
+                                                            +- CometProject
+                                                               +- CometFilter
+                                                                  +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 38 out of 47 eligible operators (80%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q51.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q51.native_iceberg_compat/extended.txt
@@ -1,0 +1,53 @@
+TakeOrderedAndProject
++- Filter
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometProject
+                  +- CometSortMergeJoin
+                     :- CometSort
+                     :  +- CometColumnarExchange
+                     :     +- Project
+                     :        +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+                     :           +- CometNativeColumnarToRow
+                     :              +- CometSort
+                     :                 +- CometExchange
+                     :                    +- CometHashAggregate
+                     :                       +- CometExchange
+                     :                          +- CometHashAggregate
+                     :                             +- CometProject
+                     :                                +- CometBroadcastHashJoin
+                     :                                   :- CometFilter
+                     :                                   :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                     :                                   :        +- SubqueryBroadcast
+                     :                                   :           +- BroadcastExchange
+                     :                                   :              +- CometNativeColumnarToRow
+                     :                                   :                 +- CometProject
+                     :                                   :                    +- CometFilter
+                     :                                   :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :                                   +- CometBroadcastExchange
+                     :                                      +- CometProject
+                     :                                         +- CometFilter
+                     :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     +- CometSort
+                        +- CometColumnarExchange
+                           +- Project
+                              +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+                                 +- CometNativeColumnarToRow
+                                    +- CometSort
+                                       +- CometExchange
+                                          +- CometHashAggregate
+                                             +- CometExchange
+                                                +- CometHashAggregate
+                                                   +- CometProject
+                                                      +- CometBroadcastHashJoin
+                                                         :- CometFilter
+                                                         :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                                         :        +- ReusedSubquery
+                                                         +- CometBroadcastExchange
+                                                            +- CometProject
+                                                               +- CometFilter
+                                                                  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 37 out of 47 eligible operators (78%). Final plan contains 4 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q52.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q52.native_datafusion/extended.txt
@@ -1,0 +1,21 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometFilter
+                  :     :     +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometFilter
+                  :           +- CometNativeScan parquet spark_catalog.default.store_sales
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 18 out of 18 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q52.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q52.native_iceberg_compat/extended.txt
@@ -1,0 +1,21 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometFilter
+                  :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometFilter
+                  :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 18 out of 18 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q53.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q53.native_datafusion/extended.txt
@@ -1,0 +1,36 @@
+TakeOrderedAndProject
++- Project
+   +- Filter
+      +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+         +- CometNativeColumnarToRow
+            +- CometSort
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometProject
+                                 :     :  +- CometBroadcastHashJoin
+                                 :     :     :- CometProject
+                                 :     :     :  +- CometFilter
+                                 :     :     :     +- CometNativeScan parquet spark_catalog.default.item
+                                 :     :     +- CometBroadcastExchange
+                                 :     :        +- CometFilter
+                                 :     :           +- CometNativeScan parquet spark_catalog.default.store_sales
+                                 :     :                 +- CometSubqueryBroadcast
+                                 :     :                    +- CometBroadcastExchange
+                                 :     :                       +- CometProject
+                                 :     :                          +- CometFilter
+                                 :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometProject
+                                 :           +- CometFilter
+                                 :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 +- CometBroadcastExchange
+                                    +- CometFilter
+                                       +- CometNativeScan parquet spark_catalog.default.store
+
+Comet accelerated 28 out of 33 eligible operators (84%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q53.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q53.native_iceberg_compat/extended.txt
@@ -1,0 +1,37 @@
+TakeOrderedAndProject
++- Project
+   +- Filter
+      +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+         +- CometNativeColumnarToRow
+            +- CometSort
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometProject
+                                 :     :  +- CometBroadcastHashJoin
+                                 :     :     :- CometProject
+                                 :     :     :  +- CometFilter
+                                 :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :     :     +- CometBroadcastExchange
+                                 :     :        +- CometFilter
+                                 :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                 :     :                 +- SubqueryBroadcast
+                                 :     :                    +- BroadcastExchange
+                                 :     :                       +- CometNativeColumnarToRow
+                                 :     :                          +- CometProject
+                                 :     :                             +- CometFilter
+                                 :     :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometProject
+                                 :           +- CometFilter
+                                 :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 +- CometBroadcastExchange
+                                    +- CometFilter
+                                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+
+Comet accelerated 27 out of 33 eligible operators (81%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q54.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q54.native_datafusion/extended.txt
@@ -1,0 +1,113 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometBroadcastHashJoin
+                           :     :     :- CometProject
+                           :     :     :  +- CometBroadcastHashJoin
+                           :     :     :     :- CometHashAggregate
+                           :     :     :     :  +- CometExchange
+                           :     :     :     :     +- CometHashAggregate
+                           :     :     :     :        +- CometProject
+                           :     :     :     :           +- CometBroadcastHashJoin
+                           :     :     :     :              :- CometProject
+                           :     :     :     :              :  +- CometBroadcastHashJoin
+                           :     :     :     :              :     :- CometUnion
+                           :     :     :     :              :     :  :- CometProject
+                           :     :     :     :              :     :  :  +- CometBroadcastHashJoin
+                           :     :     :     :              :     :  :     :- CometProject
+                           :     :     :     :              :     :  :     :  +- CometFilter
+                           :     :     :     :              :     :  :     :     +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                           :     :     :     :              :     :  :     :           +- CometSubqueryBroadcast
+                           :     :     :     :              :     :  :     :              +- CometBroadcastExchange
+                           :     :     :     :              :     :  :     :                 +- CometProject
+                           :     :     :     :              :     :  :     :                    +- CometFilter
+                           :     :     :     :              :     :  :     :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     :     :     :              :     :  :     +- CometBroadcastExchange
+                           :     :     :     :              :     :  :        +- CometProject
+                           :     :     :     :              :     :  :           +- CometFilter
+                           :     :     :     :              :     :  :              +- CometNativeScan parquet spark_catalog.default.item
+                           :     :     :     :              :     :  +- CometProject
+                           :     :     :     :              :     :     +- CometBroadcastHashJoin
+                           :     :     :     :              :     :        :- CometProject
+                           :     :     :     :              :     :        :  +- CometFilter
+                           :     :     :     :              :     :        :     +- CometNativeScan parquet spark_catalog.default.web_sales
+                           :     :     :     :              :     :        :           +- ReusedSubquery
+                           :     :     :     :              :     :        +- CometBroadcastExchange
+                           :     :     :     :              :     :           +- CometProject
+                           :     :     :     :              :     :              +- CometFilter
+                           :     :     :     :              :     :                 +- CometNativeScan parquet spark_catalog.default.item
+                           :     :     :     :              :     +- CometBroadcastExchange
+                           :     :     :     :              :        +- CometProject
+                           :     :     :     :              :           +- CometFilter
+                           :     :     :     :              :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     :     :     :              +- CometBroadcastExchange
+                           :     :     :     :                 +- CometFilter
+                           :     :     :     :                    +- CometNativeScan parquet spark_catalog.default.customer
+                           :     :     :     +- CometBroadcastExchange
+                           :     :     :        +- CometFilter
+                           :     :     :           +- CometNativeScan parquet spark_catalog.default.store_sales
+                           :     :     :                 +- CometSubqueryBroadcast
+                           :     :     :                    +- CometBroadcastExchange
+                           :     :     :                       +- CometProject
+                           :     :     :                          +- CometFilter
+                           :     :     :                             :  :- ReusedSubquery
+                           :     :     :                             :  +- ReusedSubquery
+                           :     :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     :     :                                   :- Subquery
+                           :     :     :                                   :  +- CometNativeColumnarToRow
+                           :     :     :                                   :     +- CometHashAggregate
+                           :     :     :                                   :        +- CometExchange
+                           :     :     :                                   :           +- CometHashAggregate
+                           :     :     :                                   :              +- CometProject
+                           :     :     :                                   :                 +- CometFilter
+                           :     :     :                                   :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     :     :                                   +- Subquery
+                           :     :     :                                      +- CometNativeColumnarToRow
+                           :     :     :                                         +- CometHashAggregate
+                           :     :     :                                            +- CometExchange
+                           :     :     :                                               +- CometHashAggregate
+                           :     :     :                                                  +- CometProject
+                           :     :     :                                                     +- CometFilter
+                           :     :     :                                                        +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     :     +- CometBroadcastExchange
+                           :     :        +- CometProject
+                           :     :           +- CometFilter
+                           :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                           :     +- CometBroadcastExchange
+                           :        +- CometProject
+                           :           +- CometFilter
+                           :              +- CometNativeScan parquet spark_catalog.default.store
+                           +- CometBroadcastExchange
+                              +- CometProject
+                                 +- CometFilter
+                                    :  :- ReusedSubquery
+                                    :  +- ReusedSubquery
+                                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                          :- Subquery
+                                          :  +- CometNativeColumnarToRow
+                                          :     +- CometHashAggregate
+                                          :        +- CometExchange
+                                          :           +- CometHashAggregate
+                                          :              +- CometProject
+                                          :                 +- CometFilter
+                                          :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                          +- Subquery
+                                             +- CometNativeColumnarToRow
+                                                +- CometHashAggregate
+                                                   +- CometExchange
+                                                      +- CometHashAggregate
+                                                         +- CometProject
+                                                            +- CometFilter
+                                                               +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 95 out of 106 eligible operators (89%). Final plan contains 5 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q54.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q54.native_iceberg_compat/extended.txt
@@ -1,0 +1,101 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometBroadcastHashJoin
+                           :     :     :- CometProject
+                           :     :     :  +- CometBroadcastHashJoin
+                           :     :     :     :- CometHashAggregate
+                           :     :     :     :  +- CometExchange
+                           :     :     :     :     +- CometHashAggregate
+                           :     :     :     :        +- CometProject
+                           :     :     :     :           +- CometBroadcastHashJoin
+                           :     :     :     :              :- CometProject
+                           :     :     :     :              :  +- CometBroadcastHashJoin
+                           :     :     :     :              :     :- CometUnion
+                           :     :     :     :              :     :  :- CometProject
+                           :     :     :     :              :     :  :  +- CometBroadcastHashJoin
+                           :     :     :     :              :     :  :     :- CometProject
+                           :     :     :     :              :     :  :     :  +- CometFilter
+                           :     :     :     :              :     :  :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                           :     :     :     :              :     :  :     :           +- SubqueryBroadcast
+                           :     :     :     :              :     :  :     :              +- BroadcastExchange
+                           :     :     :     :              :     :  :     :                 +- CometNativeColumnarToRow
+                           :     :     :     :              :     :  :     :                    +- CometProject
+                           :     :     :     :              :     :  :     :                       +- CometFilter
+                           :     :     :     :              :     :  :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     :     :     :              :     :  :     +- CometBroadcastExchange
+                           :     :     :     :              :     :  :        +- CometProject
+                           :     :     :     :              :     :  :           +- CometFilter
+                           :     :     :     :              :     :  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :     :     :     :              :     :  +- CometProject
+                           :     :     :     :              :     :     +- CometBroadcastHashJoin
+                           :     :     :     :              :     :        :- CometProject
+                           :     :     :     :              :     :        :  +- CometFilter
+                           :     :     :     :              :     :        :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                           :     :     :     :              :     :        :           +- ReusedSubquery
+                           :     :     :     :              :     :        +- CometBroadcastExchange
+                           :     :     :     :              :     :           +- CometProject
+                           :     :     :     :              :     :              +- CometFilter
+                           :     :     :     :              :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :     :     :     :              :     +- CometBroadcastExchange
+                           :     :     :     :              :        +- CometProject
+                           :     :     :     :              :           +- CometFilter
+                           :     :     :     :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     :     :     :              +- CometBroadcastExchange
+                           :     :     :     :                 +- CometFilter
+                           :     :     :     :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                           :     :     :     +- CometBroadcastExchange
+                           :     :     :        +- CometFilter
+                           :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                           :     :     :                 +- SubqueryBroadcast
+                           :     :     :                    +- BroadcastExchange
+                           :     :     :                       +- CometNativeColumnarToRow
+                           :     :     :                          +- CometProject
+                           :     :     :                             +- CometFilter
+                           :     :     :                                :  :- ReusedSubquery
+                           :     :     :                                :  +- ReusedSubquery
+                           :     :     :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     :     :                                      :- Subquery
+                           :     :     :                                      :  +- CometNativeColumnarToRow
+                           :     :     :                                      :     +- CometHashAggregate
+                           :     :     :                                      :        +- CometExchange
+                           :     :     :                                      :           +- CometHashAggregate
+                           :     :     :                                      :              +- CometProject
+                           :     :     :                                      :                 +- CometFilter
+                           :     :     :                                      :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     :     :                                      +- Subquery
+                           :     :     :                                         +- CometNativeColumnarToRow
+                           :     :     :                                            +- CometHashAggregate
+                           :     :     :                                               +- CometExchange
+                           :     :     :                                                  +- CometHashAggregate
+                           :     :     :                                                     +- CometProject
+                           :     :     :                                                        +- CometFilter
+                           :     :     :                                                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     :     +- CometBroadcastExchange
+                           :     :        +- CometProject
+                           :     :           +- CometFilter
+                           :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                           :     +- CometBroadcastExchange
+                           :        +- CometProject
+                           :           +- CometFilter
+                           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                           +- CometBroadcastExchange
+                              +- CometProject
+                                 +- CometFilter
+                                    :  :- ReusedSubquery
+                                    :  +- ReusedSubquery
+                                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                          :- ReusedSubquery
+                                          +- ReusedSubquery
+
+Comet accelerated 81 out of 94 eligible operators (86%). Final plan contains 5 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q55.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q55.native_datafusion/extended.txt
@@ -1,0 +1,21 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometFilter
+                  :     :     +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometFilter
+                  :           +- CometNativeScan parquet spark_catalog.default.store_sales
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 18 out of 18 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q55.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q55.native_iceberg_compat/extended.txt
@@ -1,0 +1,21 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometFilter
+                  :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometFilter
+                  :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 18 out of 18 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q56.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q56.native_datafusion/extended.txt
@@ -1,0 +1,98 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometHashAggregate
+         +- CometUnion
+            :- CometHashAggregate
+            :  +- CometExchange
+            :     +- CometHashAggregate
+            :        +- CometProject
+            :           +- CometBroadcastHashJoin
+            :              :- CometProject
+            :              :  +- CometBroadcastHashJoin
+            :              :     :- CometProject
+            :              :     :  +- CometBroadcastHashJoin
+            :              :     :     :- CometFilter
+            :              :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+            :              :     :     :        +- CometSubqueryBroadcast
+            :              :     :     :           +- CometBroadcastExchange
+            :              :     :     :              +- CometProject
+            :              :     :     :                 +- CometFilter
+            :              :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+            :              :     :     +- CometBroadcastExchange
+            :              :     :        +- CometProject
+            :              :     :           +- CometFilter
+            :              :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+            :              :     +- CometBroadcastExchange
+            :              :        +- CometProject
+            :              :           +- CometFilter
+            :              :              +- CometNativeScan parquet spark_catalog.default.customer_address
+            :              +- CometBroadcastExchange
+            :                 +- CometProject
+            :                    +- CometBroadcastHashJoin
+            :                       :- CometFilter
+            :                       :  +- CometNativeScan parquet spark_catalog.default.item
+            :                       +- CometBroadcastExchange
+            :                          +- CometProject
+            :                             +- CometFilter
+            :                                +- CometNativeScan parquet spark_catalog.default.item
+            :- CometHashAggregate
+            :  +- CometExchange
+            :     +- CometHashAggregate
+            :        +- CometProject
+            :           +- CometBroadcastHashJoin
+            :              :- CometProject
+            :              :  +- CometBroadcastHashJoin
+            :              :     :- CometProject
+            :              :     :  +- CometBroadcastHashJoin
+            :              :     :     :- CometFilter
+            :              :     :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+            :              :     :     :        +- ReusedSubquery
+            :              :     :     +- CometBroadcastExchange
+            :              :     :        +- CometProject
+            :              :     :           +- CometFilter
+            :              :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+            :              :     +- CometBroadcastExchange
+            :              :        +- CometProject
+            :              :           +- CometFilter
+            :              :              +- CometNativeScan parquet spark_catalog.default.customer_address
+            :              +- CometBroadcastExchange
+            :                 +- CometProject
+            :                    +- CometBroadcastHashJoin
+            :                       :- CometFilter
+            :                       :  +- CometNativeScan parquet spark_catalog.default.item
+            :                       +- CometBroadcastExchange
+            :                          +- CometProject
+            :                             +- CometFilter
+            :                                +- CometNativeScan parquet spark_catalog.default.item
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometBroadcastHashJoin
+                           :     :     :- CometFilter
+                           :     :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                           :     :     :        +- ReusedSubquery
+                           :     :     +- CometBroadcastExchange
+                           :     :        +- CometProject
+                           :     :           +- CometFilter
+                           :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     +- CometBroadcastExchange
+                           :        +- CometProject
+                           :           +- CometFilter
+                           :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                           +- CometBroadcastExchange
+                              +- CometProject
+                                 +- CometBroadcastHashJoin
+                                    :- CometFilter
+                                    :  +- CometNativeScan parquet spark_catalog.default.item
+                                    +- CometBroadcastExchange
+                                       +- CometProject
+                                          +- CometFilter
+                                             +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 92 out of 95 eligible operators (96%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q56.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q56.native_iceberg_compat/extended.txt
@@ -1,0 +1,99 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometHashAggregate
+         +- CometUnion
+            :- CometHashAggregate
+            :  +- CometExchange
+            :     +- CometHashAggregate
+            :        +- CometProject
+            :           +- CometBroadcastHashJoin
+            :              :- CometProject
+            :              :  +- CometBroadcastHashJoin
+            :              :     :- CometProject
+            :              :     :  +- CometBroadcastHashJoin
+            :              :     :     :- CometFilter
+            :              :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+            :              :     :     :        +- SubqueryBroadcast
+            :              :     :     :           +- BroadcastExchange
+            :              :     :     :              +- CometNativeColumnarToRow
+            :              :     :     :                 +- CometProject
+            :              :     :     :                    +- CometFilter
+            :              :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :              :     :     +- CometBroadcastExchange
+            :              :     :        +- CometProject
+            :              :     :           +- CometFilter
+            :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :              :     +- CometBroadcastExchange
+            :              :        +- CometProject
+            :              :           +- CometFilter
+            :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+            :              +- CometBroadcastExchange
+            :                 +- CometProject
+            :                    +- CometBroadcastHashJoin
+            :                       :- CometFilter
+            :                       :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+            :                       +- CometBroadcastExchange
+            :                          +- CometProject
+            :                             +- CometFilter
+            :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+            :- CometHashAggregate
+            :  +- CometExchange
+            :     +- CometHashAggregate
+            :        +- CometProject
+            :           +- CometBroadcastHashJoin
+            :              :- CometProject
+            :              :  +- CometBroadcastHashJoin
+            :              :     :- CometProject
+            :              :     :  +- CometBroadcastHashJoin
+            :              :     :     :- CometFilter
+            :              :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+            :              :     :     :        +- ReusedSubquery
+            :              :     :     +- CometBroadcastExchange
+            :              :     :        +- CometProject
+            :              :     :           +- CometFilter
+            :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :              :     +- CometBroadcastExchange
+            :              :        +- CometProject
+            :              :           +- CometFilter
+            :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+            :              +- CometBroadcastExchange
+            :                 +- CometProject
+            :                    +- CometBroadcastHashJoin
+            :                       :- CometFilter
+            :                       :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+            :                       +- CometBroadcastExchange
+            :                          +- CometProject
+            :                             +- CometFilter
+            :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometBroadcastHashJoin
+                           :     :     :- CometFilter
+                           :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                           :     :     :        +- ReusedSubquery
+                           :     :     +- CometBroadcastExchange
+                           :     :        +- CometProject
+                           :     :           +- CometFilter
+                           :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     +- CometBroadcastExchange
+                           :        +- CometProject
+                           :           +- CometFilter
+                           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                           +- CometBroadcastExchange
+                              +- CometProject
+                                 +- CometBroadcastHashJoin
+                                    :- CometFilter
+                                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                    +- CometBroadcastExchange
+                                       +- CometProject
+                                          +- CometFilter
+                                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 91 out of 95 eligible operators (95%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q57.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q57.native_datafusion/extended.txt
@@ -1,0 +1,102 @@
+TakeOrderedAndProject
++- Project
+   +- BroadcastHashJoin
+      :- Project
+      :  +- BroadcastHashJoin
+      :     :- Project
+      :     :  +- Filter
+      :     :     +- Window
+      :     :        +- Filter
+      :     :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      :     :              +- CometNativeColumnarToRow
+      :     :                 +- CometSort
+      :     :                    +- CometExchange
+      :     :                       +- CometHashAggregate
+      :     :                          +- CometExchange
+      :     :                             +- CometHashAggregate
+      :     :                                +- CometProject
+      :     :                                   +- CometBroadcastHashJoin
+      :     :                                      :- CometProject
+      :     :                                      :  +- CometBroadcastHashJoin
+      :     :                                      :     :- CometProject
+      :     :                                      :     :  +- CometBroadcastHashJoin
+      :     :                                      :     :     :- CometProject
+      :     :                                      :     :     :  +- CometFilter
+      :     :                                      :     :     :     +- CometNativeScan parquet spark_catalog.default.item
+      :     :                                      :     :     +- CometBroadcastExchange
+      :     :                                      :     :        +- CometFilter
+      :     :                                      :     :           +- CometNativeScan parquet spark_catalog.default.catalog_sales
+      :     :                                      :     :                 +- CometSubqueryBroadcast
+      :     :                                      :     :                    +- CometBroadcastExchange
+      :     :                                      :     :                       +- CometFilter
+      :     :                                      :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+      :     :                                      :     +- CometBroadcastExchange
+      :     :                                      :        +- CometFilter
+      :     :                                      :           +- CometNativeScan parquet spark_catalog.default.date_dim
+      :     :                                      +- CometBroadcastExchange
+      :     :                                         +- CometFilter
+      :     :                                            +- CometNativeScan parquet spark_catalog.default.call_center
+      :     +- BroadcastExchange
+      :        +- Project
+      :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      :              +- CometNativeColumnarToRow
+      :                 +- CometSort
+      :                    +- CometExchange
+      :                       +- CometHashAggregate
+      :                          +- CometExchange
+      :                             +- CometHashAggregate
+      :                                +- CometProject
+      :                                   +- CometBroadcastHashJoin
+      :                                      :- CometProject
+      :                                      :  +- CometBroadcastHashJoin
+      :                                      :     :- CometProject
+      :                                      :     :  +- CometBroadcastHashJoin
+      :                                      :     :     :- CometProject
+      :                                      :     :     :  +- CometFilter
+      :                                      :     :     :     +- CometNativeScan parquet spark_catalog.default.item
+      :                                      :     :     +- CometBroadcastExchange
+      :                                      :     :        +- CometFilter
+      :                                      :     :           +- CometNativeScan parquet spark_catalog.default.catalog_sales
+      :                                      :     :                 +- CometSubqueryBroadcast
+      :                                      :     :                    +- CometBroadcastExchange
+      :                                      :     :                       +- CometFilter
+      :                                      :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                                      :     +- CometBroadcastExchange
+      :                                      :        +- CometFilter
+      :                                      :           +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                                      +- CometBroadcastExchange
+      :                                         +- CometFilter
+      :                                            +- CometNativeScan parquet spark_catalog.default.call_center
+      +- BroadcastExchange
+         +- Project
+            +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               +- CometNativeColumnarToRow
+                  +- CometSort
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometExchange
+                              +- CometHashAggregate
+                                 +- CometProject
+                                    +- CometBroadcastHashJoin
+                                       :- CometProject
+                                       :  +- CometBroadcastHashJoin
+                                       :     :- CometProject
+                                       :     :  +- CometBroadcastHashJoin
+                                       :     :     :- CometProject
+                                       :     :     :  +- CometFilter
+                                       :     :     :     +- CometNativeScan parquet spark_catalog.default.item
+                                       :     :     +- CometBroadcastExchange
+                                       :     :        +- CometFilter
+                                       :     :           +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                                       :     :                 +- CometSubqueryBroadcast
+                                       :     :                    +- CometBroadcastExchange
+                                       :     :                       +- CometFilter
+                                       :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       :     +- CometBroadcastExchange
+                                       :        +- CometFilter
+                                       :           +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       +- CometBroadcastExchange
+                                          +- CometFilter
+                                             +- CometNativeScan parquet spark_catalog.default.call_center
+
+Comet accelerated 78 out of 97 eligible operators (80%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q57.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q57.native_iceberg_compat/extended.txt
@@ -1,0 +1,105 @@
+TakeOrderedAndProject
++- Project
+   +- BroadcastHashJoin
+      :- Project
+      :  +- BroadcastHashJoin
+      :     :- Project
+      :     :  +- Filter
+      :     :     +- Window
+      :     :        +- Filter
+      :     :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      :     :              +- CometNativeColumnarToRow
+      :     :                 +- CometSort
+      :     :                    +- CometExchange
+      :     :                       +- CometHashAggregate
+      :     :                          +- CometExchange
+      :     :                             +- CometHashAggregate
+      :     :                                +- CometProject
+      :     :                                   +- CometBroadcastHashJoin
+      :     :                                      :- CometProject
+      :     :                                      :  +- CometBroadcastHashJoin
+      :     :                                      :     :- CometProject
+      :     :                                      :     :  +- CometBroadcastHashJoin
+      :     :                                      :     :     :- CometProject
+      :     :                                      :     :     :  +- CometFilter
+      :     :                                      :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :     :                                      :     :     +- CometBroadcastExchange
+      :     :                                      :     :        +- CometFilter
+      :     :                                      :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+      :     :                                      :     :                 +- SubqueryBroadcast
+      :     :                                      :     :                    +- BroadcastExchange
+      :     :                                      :     :                       +- CometNativeColumnarToRow
+      :     :                                      :     :                          +- CometFilter
+      :     :                                      :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :     :                                      :     +- CometBroadcastExchange
+      :     :                                      :        +- CometFilter
+      :     :                                      :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :     :                                      +- CometBroadcastExchange
+      :     :                                         +- CometFilter
+      :     :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.call_center
+      :     +- BroadcastExchange
+      :        +- Project
+      :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      :              +- CometNativeColumnarToRow
+      :                 +- CometSort
+      :                    +- CometExchange
+      :                       +- CometHashAggregate
+      :                          +- CometExchange
+      :                             +- CometHashAggregate
+      :                                +- CometProject
+      :                                   +- CometBroadcastHashJoin
+      :                                      :- CometProject
+      :                                      :  +- CometBroadcastHashJoin
+      :                                      :     :- CometProject
+      :                                      :     :  +- CometBroadcastHashJoin
+      :                                      :     :     :- CometProject
+      :                                      :     :     :  +- CometFilter
+      :                                      :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                                      :     :     +- CometBroadcastExchange
+      :                                      :     :        +- CometFilter
+      :                                      :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+      :                                      :     :                 +- SubqueryBroadcast
+      :                                      :     :                    +- BroadcastExchange
+      :                                      :     :                       +- CometNativeColumnarToRow
+      :                                      :     :                          +- CometFilter
+      :                                      :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                                      :     +- CometBroadcastExchange
+      :                                      :        +- CometFilter
+      :                                      :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                                      +- CometBroadcastExchange
+      :                                         +- CometFilter
+      :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.call_center
+      +- BroadcastExchange
+         +- Project
+            +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               +- CometNativeColumnarToRow
+                  +- CometSort
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometExchange
+                              +- CometHashAggregate
+                                 +- CometProject
+                                    +- CometBroadcastHashJoin
+                                       :- CometProject
+                                       :  +- CometBroadcastHashJoin
+                                       :     :- CometProject
+                                       :     :  +- CometBroadcastHashJoin
+                                       :     :     :- CometProject
+                                       :     :     :  +- CometFilter
+                                       :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                       :     :     +- CometBroadcastExchange
+                                       :     :        +- CometFilter
+                                       :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                                       :     :                 +- SubqueryBroadcast
+                                       :     :                    +- BroadcastExchange
+                                       :     :                       +- CometNativeColumnarToRow
+                                       :     :                          +- CometFilter
+                                       :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       :     +- CometBroadcastExchange
+                                       :        +- CometFilter
+                                       :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       +- CometBroadcastExchange
+                                          +- CometFilter
+                                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.call_center
+
+Comet accelerated 75 out of 97 eligible operators (77%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q58.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q58.native_datafusion/extended.txt
@@ -1,0 +1,115 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometFilter
+         :     :  +- CometHashAggregate
+         :     :     +- CometExchange
+         :     :        +- CometHashAggregate
+         :     :           +- CometProject
+         :     :              +- CometBroadcastHashJoin
+         :     :                 :- CometProject
+         :     :                 :  +- CometBroadcastHashJoin
+         :     :                 :     :- CometFilter
+         :     :                 :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     :                 :     :        +- CometSubqueryBroadcast
+         :     :                 :     :           +- CometBroadcastExchange
+         :     :                 :     :              +- CometProject
+         :     :                 :     :                 +- CometBroadcastHashJoin
+         :     :                 :     :                    :- CometFilter
+         :     :                 :     :                    :  +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :                 :     :                    +- CometBroadcastExchange
+         :     :                 :     :                       +- CometProject
+         :     :                 :     :                          +- CometFilter
+         :     :                 :     :                             :  +- ReusedSubquery
+         :     :                 :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :                 :     :                                   +- Subquery
+         :     :                 :     :                                      +- CometNativeColumnarToRow
+         :     :                 :     :                                         +- CometProject
+         :     :                 :     :                                            +- CometFilter
+         :     :                 :     :                                               +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :                 :     +- CometBroadcastExchange
+         :     :                 :        +- CometProject
+         :     :                 :           +- CometFilter
+         :     :                 :              +- CometNativeScan parquet spark_catalog.default.item
+         :     :                 +- CometBroadcastExchange
+         :     :                    +- CometProject
+         :     :                       +- CometBroadcastHashJoin
+         :     :                          :- CometFilter
+         :     :                          :  +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :                          +- CometBroadcastExchange
+         :     :                             +- CometProject
+         :     :                                +- CometFilter
+         :     :                                   :  +- ReusedSubquery
+         :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :                                         +- Subquery
+         :     :                                            +- CometNativeColumnarToRow
+         :     :                                               +- CometProject
+         :     :                                                  +- CometFilter
+         :     :                                                     +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     +- CometBroadcastExchange
+         :        +- CometFilter
+         :           +- CometHashAggregate
+         :              +- CometExchange
+         :                 +- CometHashAggregate
+         :                    +- CometProject
+         :                       +- CometBroadcastHashJoin
+         :                          :- CometProject
+         :                          :  +- CometBroadcastHashJoin
+         :                          :     :- CometFilter
+         :                          :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+         :                          :     :        +- ReusedSubquery
+         :                          :     +- CometBroadcastExchange
+         :                          :        +- CometProject
+         :                          :           +- CometFilter
+         :                          :              +- CometNativeScan parquet spark_catalog.default.item
+         :                          +- CometBroadcastExchange
+         :                             +- CometProject
+         :                                +- CometBroadcastHashJoin
+         :                                   :- CometFilter
+         :                                   :  +- CometNativeScan parquet spark_catalog.default.date_dim
+         :                                   +- CometBroadcastExchange
+         :                                      +- CometProject
+         :                                         +- CometFilter
+         :                                            :  +- ReusedSubquery
+         :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+         :                                                  +- Subquery
+         :                                                     +- CometNativeColumnarToRow
+         :                                                        +- CometProject
+         :                                                           +- CometFilter
+         :                                                              +- CometNativeScan parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometFilter
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometBroadcastHashJoin
+                              :     :- CometFilter
+                              :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                              :     :        +- ReusedSubquery
+                              :     +- CometBroadcastExchange
+                              :        +- CometProject
+                              :           +- CometFilter
+                              :              +- CometNativeScan parquet spark_catalog.default.item
+                              +- CometBroadcastExchange
+                                 +- CometProject
+                                    +- CometBroadcastHashJoin
+                                       :- CometFilter
+                                       :  +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       +- CometBroadcastExchange
+                                          +- CometProject
+                                             +- CometFilter
+                                                :  +- ReusedSubquery
+                                                +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                      +- Subquery
+                                                         +- CometNativeColumnarToRow
+                                                            +- CometProject
+                                                               +- CometFilter
+                                                                  +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 97 out of 108 eligible operators (89%). Final plan contains 5 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q58.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q58.native_iceberg_compat/extended.txt
@@ -1,0 +1,116 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometFilter
+         :     :  +- CometHashAggregate
+         :     :     +- CometExchange
+         :     :        +- CometHashAggregate
+         :     :           +- CometProject
+         :     :              +- CometBroadcastHashJoin
+         :     :                 :- CometProject
+         :     :                 :  +- CometBroadcastHashJoin
+         :     :                 :     :- CometFilter
+         :     :                 :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     :                 :     :        +- SubqueryBroadcast
+         :     :                 :     :           +- BroadcastExchange
+         :     :                 :     :              +- CometNativeColumnarToRow
+         :     :                 :     :                 +- CometProject
+         :     :                 :     :                    +- CometBroadcastHashJoin
+         :     :                 :     :                       :- CometFilter
+         :     :                 :     :                       :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :                 :     :                       +- CometBroadcastExchange
+         :     :                 :     :                          +- CometProject
+         :     :                 :     :                             +- CometFilter
+         :     :                 :     :                                :  +- ReusedSubquery
+         :     :                 :     :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :                 :     :                                      +- Subquery
+         :     :                 :     :                                         +- CometNativeColumnarToRow
+         :     :                 :     :                                            +- CometProject
+         :     :                 :     :                                               +- CometFilter
+         :     :                 :     :                                                  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :                 :     +- CometBroadcastExchange
+         :     :                 :        +- CometProject
+         :     :                 :           +- CometFilter
+         :     :                 :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+         :     :                 +- CometBroadcastExchange
+         :     :                    +- CometProject
+         :     :                       +- CometBroadcastHashJoin
+         :     :                          :- CometFilter
+         :     :                          :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :                          +- CometBroadcastExchange
+         :     :                             +- CometProject
+         :     :                                +- CometFilter
+         :     :                                   :  +- ReusedSubquery
+         :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :                                         +- Subquery
+         :     :                                            +- CometNativeColumnarToRow
+         :     :                                               +- CometProject
+         :     :                                                  +- CometFilter
+         :     :                                                     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     +- CometBroadcastExchange
+         :        +- CometFilter
+         :           +- CometHashAggregate
+         :              +- CometExchange
+         :                 +- CometHashAggregate
+         :                    +- CometProject
+         :                       +- CometBroadcastHashJoin
+         :                          :- CometProject
+         :                          :  +- CometBroadcastHashJoin
+         :                          :     :- CometFilter
+         :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+         :                          :     :        +- ReusedSubquery
+         :                          :     +- CometBroadcastExchange
+         :                          :        +- CometProject
+         :                          :           +- CometFilter
+         :                          :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+         :                          +- CometBroadcastExchange
+         :                             +- CometProject
+         :                                +- CometBroadcastHashJoin
+         :                                   :- CometFilter
+         :                                   :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :                                   +- CometBroadcastExchange
+         :                                      +- CometProject
+         :                                         +- CometFilter
+         :                                            :  +- ReusedSubquery
+         :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :                                                  +- Subquery
+         :                                                     +- CometNativeColumnarToRow
+         :                                                        +- CometProject
+         :                                                           +- CometFilter
+         :                                                              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometFilter
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometBroadcastHashJoin
+                              :     :- CometFilter
+                              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                              :     :        +- ReusedSubquery
+                              :     +- CometBroadcastExchange
+                              :        +- CometProject
+                              :           +- CometFilter
+                              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                              +- CometBroadcastExchange
+                                 +- CometProject
+                                    +- CometBroadcastHashJoin
+                                       :- CometFilter
+                                       :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       +- CometBroadcastExchange
+                                          +- CometProject
+                                             +- CometFilter
+                                                :  +- ReusedSubquery
+                                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                      +- Subquery
+                                                         +- CometNativeColumnarToRow
+                                                            +- CometProject
+                                                               +- CometFilter
+                                                                  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 96 out of 108 eligible operators (88%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q59.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q59.native_datafusion/extended.txt
@@ -1,0 +1,53 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometProject
+         :     :  +- CometBroadcastHashJoin
+         :     :     :- CometHashAggregate
+         :     :     :  +- CometExchange
+         :     :     :     +- CometHashAggregate
+         :     :     :        +- CometProject
+         :     :     :           +- CometBroadcastHashJoin
+         :     :     :              :- CometFilter
+         :     :     :              :  +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     :     :              +- CometBroadcastExchange
+         :     :     :                 +- CometProject
+         :     :     :                    +- CometFilter
+         :     :     :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :     +- CometBroadcastExchange
+         :     :        +- CometProject
+         :     :           +- CometFilter
+         :     :              +- CometNativeScan parquet spark_catalog.default.store
+         :     +- CometBroadcastExchange
+         :        +- CometProject
+         :           +- CometFilter
+         :              +- CometNativeScan parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometHashAggregate
+                  :     :  +- CometExchange
+                  :     :     +- CometHashAggregate
+                  :     :        +- CometProject
+                  :     :           +- CometBroadcastHashJoin
+                  :     :              :- CometFilter
+                  :     :              :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                  :     :              +- CometBroadcastExchange
+                  :     :                 +- CometProject
+                  :     :                    +- CometFilter
+                  :     :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometNativeScan parquet spark_catalog.default.store
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 50 out of 50 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q59.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q59.native_iceberg_compat/extended.txt
@@ -1,0 +1,53 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometProject
+         :     :  +- CometBroadcastHashJoin
+         :     :     :- CometHashAggregate
+         :     :     :  +- CometExchange
+         :     :     :     +- CometHashAggregate
+         :     :     :        +- CometProject
+         :     :     :           +- CometBroadcastHashJoin
+         :     :     :              :- CometFilter
+         :     :     :              :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     :     :              +- CometBroadcastExchange
+         :     :     :                 +- CometProject
+         :     :     :                    +- CometFilter
+         :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :     +- CometBroadcastExchange
+         :     :        +- CometProject
+         :     :           +- CometFilter
+         :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+         :     +- CometBroadcastExchange
+         :        +- CometProject
+         :           +- CometFilter
+         :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometHashAggregate
+                  :     :  +- CometExchange
+                  :     :     +- CometHashAggregate
+                  :     :        +- CometProject
+                  :     :           +- CometBroadcastHashJoin
+                  :     :              :- CometFilter
+                  :     :              :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :     :              +- CometBroadcastExchange
+                  :     :                 +- CometProject
+                  :     :                    +- CometFilter
+                  :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 50 out of 50 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q6.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q6.native_datafusion/extended.txt
@@ -1,0 +1,65 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometFilter
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometProject
+                     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :- CometProject
+                     :     :     :     :  +- CometFilter
+                     :     :     :     :     +- CometNativeScan parquet spark_catalog.default.customer_address
+                     :     :     :     +- CometBroadcastExchange
+                     :     :     :        +- CometFilter
+                     :     :     :           +- CometNativeScan parquet spark_catalog.default.customer
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometFilter
+                     :     :           +- CometNativeScan parquet spark_catalog.default.store_sales
+                     :     :                 +- CometSubqueryBroadcast
+                     :     :                    +- CometBroadcastExchange
+                     :     :                       +- CometProject
+                     :     :                          +- CometFilter
+                     :     :                             :  +- ReusedSubquery
+                     :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :     :                                   +- Subquery
+                     :     :                                      +- CometNativeColumnarToRow
+                     :     :                                         +- CometHashAggregate
+                     :     :                                            +- CometExchange
+                     :     :                                               +- CometHashAggregate
+                     :     :                                                  +- CometProject
+                     :     :                                                     +- CometFilter
+                     :     :                                                        +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              :  +- ReusedSubquery
+                     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :                    +- Subquery
+                     :                       +- CometNativeColumnarToRow
+                     :                          +- CometHashAggregate
+                     :                             +- CometExchange
+                     :                                +- CometHashAggregate
+                     :                                   +- CometProject
+                     :                                      +- CometFilter
+                     :                                         +- CometNativeScan parquet spark_catalog.default.date_dim
+                     +- CometBroadcastExchange
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometFilter
+                              :  +- CometNativeScan parquet spark_catalog.default.item
+                              +- CometBroadcastExchange
+                                 +- CometFilter
+                                    +- CometHashAggregate
+                                       +- CometExchange
+                                          +- CometHashAggregate
+                                             +- CometProject
+                                                +- CometFilter
+                                                   +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 55 out of 60 eligible operators (91%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q6.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q6.native_iceberg_compat/extended.txt
@@ -1,0 +1,59 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometFilter
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometProject
+                     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :- CometProject
+                     :     :     :     :  +- CometFilter
+                     :     :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                     :     :     :     +- CometBroadcastExchange
+                     :     :     :        +- CometFilter
+                     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometFilter
+                     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                     :     :                 +- SubqueryBroadcast
+                     :     :                    +- BroadcastExchange
+                     :     :                       +- CometNativeColumnarToRow
+                     :     :                          +- CometProject
+                     :     :                             +- CometFilter
+                     :     :                                :  +- ReusedSubquery
+                     :     :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :     :                                      +- Subquery
+                     :     :                                         +- CometNativeColumnarToRow
+                     :     :                                            +- CometHashAggregate
+                     :     :                                               +- CometExchange
+                     :     :                                                  +- CometHashAggregate
+                     :     :                                                     +- CometProject
+                     :     :                                                        +- CometFilter
+                     :     :                                                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              :  +- ReusedSubquery
+                     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :                    +- ReusedSubquery
+                     +- CometBroadcastExchange
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometFilter
+                              :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                              +- CometBroadcastExchange
+                                 +- CometFilter
+                                    +- CometHashAggregate
+                                       +- CometExchange
+                                          +- CometHashAggregate
+                                             +- CometProject
+                                                +- CometFilter
+                                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 48 out of 54 eligible operators (88%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q60.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q60.native_datafusion/extended.txt
@@ -1,0 +1,98 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometHashAggregate
+         +- CometUnion
+            :- CometHashAggregate
+            :  +- CometExchange
+            :     +- CometHashAggregate
+            :        +- CometProject
+            :           +- CometBroadcastHashJoin
+            :              :- CometProject
+            :              :  +- CometBroadcastHashJoin
+            :              :     :- CometProject
+            :              :     :  +- CometBroadcastHashJoin
+            :              :     :     :- CometFilter
+            :              :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+            :              :     :     :        +- CometSubqueryBroadcast
+            :              :     :     :           +- CometBroadcastExchange
+            :              :     :     :              +- CometProject
+            :              :     :     :                 +- CometFilter
+            :              :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+            :              :     :     +- CometBroadcastExchange
+            :              :     :        +- CometProject
+            :              :     :           +- CometFilter
+            :              :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+            :              :     +- CometBroadcastExchange
+            :              :        +- CometProject
+            :              :           +- CometFilter
+            :              :              +- CometNativeScan parquet spark_catalog.default.customer_address
+            :              +- CometBroadcastExchange
+            :                 +- CometProject
+            :                    +- CometBroadcastHashJoin
+            :                       :- CometFilter
+            :                       :  +- CometNativeScan parquet spark_catalog.default.item
+            :                       +- CometBroadcastExchange
+            :                          +- CometProject
+            :                             +- CometFilter
+            :                                +- CometNativeScan parquet spark_catalog.default.item
+            :- CometHashAggregate
+            :  +- CometExchange
+            :     +- CometHashAggregate
+            :        +- CometProject
+            :           +- CometBroadcastHashJoin
+            :              :- CometProject
+            :              :  +- CometBroadcastHashJoin
+            :              :     :- CometProject
+            :              :     :  +- CometBroadcastHashJoin
+            :              :     :     :- CometFilter
+            :              :     :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+            :              :     :     :        +- ReusedSubquery
+            :              :     :     +- CometBroadcastExchange
+            :              :     :        +- CometProject
+            :              :     :           +- CometFilter
+            :              :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+            :              :     +- CometBroadcastExchange
+            :              :        +- CometProject
+            :              :           +- CometFilter
+            :              :              +- CometNativeScan parquet spark_catalog.default.customer_address
+            :              +- CometBroadcastExchange
+            :                 +- CometProject
+            :                    +- CometBroadcastHashJoin
+            :                       :- CometFilter
+            :                       :  +- CometNativeScan parquet spark_catalog.default.item
+            :                       +- CometBroadcastExchange
+            :                          +- CometProject
+            :                             +- CometFilter
+            :                                +- CometNativeScan parquet spark_catalog.default.item
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometBroadcastHashJoin
+                           :     :     :- CometFilter
+                           :     :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                           :     :     :        +- ReusedSubquery
+                           :     :     +- CometBroadcastExchange
+                           :     :        +- CometProject
+                           :     :           +- CometFilter
+                           :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     +- CometBroadcastExchange
+                           :        +- CometProject
+                           :           +- CometFilter
+                           :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                           +- CometBroadcastExchange
+                              +- CometProject
+                                 +- CometBroadcastHashJoin
+                                    :- CometFilter
+                                    :  +- CometNativeScan parquet spark_catalog.default.item
+                                    +- CometBroadcastExchange
+                                       +- CometProject
+                                          +- CometFilter
+                                             +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 92 out of 95 eligible operators (96%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q60.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q60.native_iceberg_compat/extended.txt
@@ -1,0 +1,99 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometHashAggregate
+         +- CometUnion
+            :- CometHashAggregate
+            :  +- CometExchange
+            :     +- CometHashAggregate
+            :        +- CometProject
+            :           +- CometBroadcastHashJoin
+            :              :- CometProject
+            :              :  +- CometBroadcastHashJoin
+            :              :     :- CometProject
+            :              :     :  +- CometBroadcastHashJoin
+            :              :     :     :- CometFilter
+            :              :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+            :              :     :     :        +- SubqueryBroadcast
+            :              :     :     :           +- BroadcastExchange
+            :              :     :     :              +- CometNativeColumnarToRow
+            :              :     :     :                 +- CometProject
+            :              :     :     :                    +- CometFilter
+            :              :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :              :     :     +- CometBroadcastExchange
+            :              :     :        +- CometProject
+            :              :     :           +- CometFilter
+            :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :              :     +- CometBroadcastExchange
+            :              :        +- CometProject
+            :              :           +- CometFilter
+            :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+            :              +- CometBroadcastExchange
+            :                 +- CometProject
+            :                    +- CometBroadcastHashJoin
+            :                       :- CometFilter
+            :                       :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+            :                       +- CometBroadcastExchange
+            :                          +- CometProject
+            :                             +- CometFilter
+            :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+            :- CometHashAggregate
+            :  +- CometExchange
+            :     +- CometHashAggregate
+            :        +- CometProject
+            :           +- CometBroadcastHashJoin
+            :              :- CometProject
+            :              :  +- CometBroadcastHashJoin
+            :              :     :- CometProject
+            :              :     :  +- CometBroadcastHashJoin
+            :              :     :     :- CometFilter
+            :              :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+            :              :     :     :        +- ReusedSubquery
+            :              :     :     +- CometBroadcastExchange
+            :              :     :        +- CometProject
+            :              :     :           +- CometFilter
+            :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :              :     +- CometBroadcastExchange
+            :              :        +- CometProject
+            :              :           +- CometFilter
+            :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+            :              +- CometBroadcastExchange
+            :                 +- CometProject
+            :                    +- CometBroadcastHashJoin
+            :                       :- CometFilter
+            :                       :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+            :                       +- CometBroadcastExchange
+            :                          +- CometProject
+            :                             +- CometFilter
+            :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometBroadcastHashJoin
+                           :     :     :- CometFilter
+                           :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                           :     :     :        +- ReusedSubquery
+                           :     :     +- CometBroadcastExchange
+                           :     :        +- CometProject
+                           :     :           +- CometFilter
+                           :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     +- CometBroadcastExchange
+                           :        +- CometProject
+                           :           +- CometFilter
+                           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                           +- CometBroadcastExchange
+                              +- CometProject
+                                 +- CometBroadcastHashJoin
+                                    :- CometFilter
+                                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                    +- CometBroadcastExchange
+                                       +- CometProject
+                                          +- CometFilter
+                                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 91 out of 95 eligible operators (95%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q61.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q61.native_datafusion/extended.txt
@@ -1,0 +1,87 @@
+Project
++-  BroadcastNestedLoopJoin [COMET: BroadcastNestedLoopJoin is not supported]
+   :- CometNativeColumnarToRow
+   :  +- CometHashAggregate
+   :     +- CometExchange
+   :        +- CometHashAggregate
+   :           +- CometProject
+   :              +- CometBroadcastHashJoin
+   :                 :- CometProject
+   :                 :  +- CometBroadcastHashJoin
+   :                 :     :- CometProject
+   :                 :     :  +- CometBroadcastHashJoin
+   :                 :     :     :- CometProject
+   :                 :     :     :  +- CometBroadcastHashJoin
+   :                 :     :     :     :- CometProject
+   :                 :     :     :     :  +- CometBroadcastHashJoin
+   :                 :     :     :     :     :- CometProject
+   :                 :     :     :     :     :  +- CometBroadcastHashJoin
+   :                 :     :     :     :     :     :- CometFilter
+   :                 :     :     :     :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+   :                 :     :     :     :     :     :        +- CometSubqueryBroadcast
+   :                 :     :     :     :     :     :           +- CometBroadcastExchange
+   :                 :     :     :     :     :     :              +- CometProject
+   :                 :     :     :     :     :     :                 +- CometFilter
+   :                 :     :     :     :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+   :                 :     :     :     :     :     +- CometBroadcastExchange
+   :                 :     :     :     :     :        +- CometProject
+   :                 :     :     :     :     :           +- CometFilter
+   :                 :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.store
+   :                 :     :     :     :     +- CometBroadcastExchange
+   :                 :     :     :     :        +- CometProject
+   :                 :     :     :     :           +- CometFilter
+   :                 :     :     :     :              +- CometNativeScan parquet spark_catalog.default.promotion
+   :                 :     :     :     +- CometBroadcastExchange
+   :                 :     :     :        +- CometProject
+   :                 :     :     :           +- CometFilter
+   :                 :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+   :                 :     :     +- CometBroadcastExchange
+   :                 :     :        +- CometFilter
+   :                 :     :           +- CometNativeScan parquet spark_catalog.default.customer
+   :                 :     +- CometBroadcastExchange
+   :                 :        +- CometProject
+   :                 :           +- CometFilter
+   :                 :              +- CometNativeScan parquet spark_catalog.default.customer_address
+   :                 +- CometBroadcastExchange
+   :                    +- CometProject
+   :                       +- CometFilter
+   :                          +- CometNativeScan parquet spark_catalog.default.item
+   +- BroadcastExchange
+      +- CometNativeColumnarToRow
+         +- CometHashAggregate
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometProject
+                     +- CometBroadcastHashJoin
+                        :- CometProject
+                        :  +- CometBroadcastHashJoin
+                        :     :- CometProject
+                        :     :  +- CometBroadcastHashJoin
+                        :     :     :- CometProject
+                        :     :     :  +- CometBroadcastHashJoin
+                        :     :     :     :- CometProject
+                        :     :     :     :  +- CometBroadcastHashJoin
+                        :     :     :     :     :- CometFilter
+                        :     :     :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                        :     :     :     :     :        +- ReusedSubquery
+                        :     :     :     :     +- CometBroadcastExchange
+                        :     :     :     :        +- CometProject
+                        :     :     :     :           +- CometFilter
+                        :     :     :     :              +- CometNativeScan parquet spark_catalog.default.store
+                        :     :     :     +- CometBroadcastExchange
+                        :     :     :        +- CometProject
+                        :     :     :           +- CometFilter
+                        :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                        :     :     +- CometBroadcastExchange
+                        :     :        +- CometFilter
+                        :     :           +- CometNativeScan parquet spark_catalog.default.customer
+                        :     +- CometBroadcastExchange
+                        :        +- CometProject
+                        :           +- CometFilter
+                        :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                        +- CometBroadcastExchange
+                           +- CometProject
+                              +- CometFilter
+                                 +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 78 out of 83 eligible operators (93%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q61.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q61.native_iceberg_compat/extended.txt
@@ -1,0 +1,88 @@
+Project
++-  BroadcastNestedLoopJoin [COMET: BroadcastNestedLoopJoin is not supported]
+   :- CometNativeColumnarToRow
+   :  +- CometHashAggregate
+   :     +- CometExchange
+   :        +- CometHashAggregate
+   :           +- CometProject
+   :              +- CometBroadcastHashJoin
+   :                 :- CometProject
+   :                 :  +- CometBroadcastHashJoin
+   :                 :     :- CometProject
+   :                 :     :  +- CometBroadcastHashJoin
+   :                 :     :     :- CometProject
+   :                 :     :     :  +- CometBroadcastHashJoin
+   :                 :     :     :     :- CometProject
+   :                 :     :     :     :  +- CometBroadcastHashJoin
+   :                 :     :     :     :     :- CometProject
+   :                 :     :     :     :     :  +- CometBroadcastHashJoin
+   :                 :     :     :     :     :     :- CometFilter
+   :                 :     :     :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+   :                 :     :     :     :     :     :        +- SubqueryBroadcast
+   :                 :     :     :     :     :     :           +- BroadcastExchange
+   :                 :     :     :     :     :     :              +- CometNativeColumnarToRow
+   :                 :     :     :     :     :     :                 +- CometProject
+   :                 :     :     :     :     :     :                    +- CometFilter
+   :                 :     :     :     :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+   :                 :     :     :     :     :     +- CometBroadcastExchange
+   :                 :     :     :     :     :        +- CometProject
+   :                 :     :     :     :     :           +- CometFilter
+   :                 :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+   :                 :     :     :     :     +- CometBroadcastExchange
+   :                 :     :     :     :        +- CometProject
+   :                 :     :     :     :           +- CometFilter
+   :                 :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+   :                 :     :     :     +- CometBroadcastExchange
+   :                 :     :     :        +- CometProject
+   :                 :     :     :           +- CometFilter
+   :                 :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+   :                 :     :     +- CometBroadcastExchange
+   :                 :     :        +- CometFilter
+   :                 :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+   :                 :     +- CometBroadcastExchange
+   :                 :        +- CometProject
+   :                 :           +- CometFilter
+   :                 :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+   :                 +- CometBroadcastExchange
+   :                    +- CometProject
+   :                       +- CometFilter
+   :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+   +- BroadcastExchange
+      +- CometNativeColumnarToRow
+         +- CometHashAggregate
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometProject
+                     +- CometBroadcastHashJoin
+                        :- CometProject
+                        :  +- CometBroadcastHashJoin
+                        :     :- CometProject
+                        :     :  +- CometBroadcastHashJoin
+                        :     :     :- CometProject
+                        :     :     :  +- CometBroadcastHashJoin
+                        :     :     :     :- CometProject
+                        :     :     :     :  +- CometBroadcastHashJoin
+                        :     :     :     :     :- CometFilter
+                        :     :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                        :     :     :     :     :        +- ReusedSubquery
+                        :     :     :     :     +- CometBroadcastExchange
+                        :     :     :     :        +- CometProject
+                        :     :     :     :           +- CometFilter
+                        :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                        :     :     :     +- CometBroadcastExchange
+                        :     :     :        +- CometProject
+                        :     :     :           +- CometFilter
+                        :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                        :     :     +- CometBroadcastExchange
+                        :     :        +- CometFilter
+                        :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                        :     +- CometBroadcastExchange
+                        :        +- CometProject
+                        :           +- CometFilter
+                        :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                        +- CometBroadcastExchange
+                           +- CometProject
+                              +- CometFilter
+                                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 77 out of 83 eligible operators (92%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q62.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q62.native_datafusion/extended.txt
@@ -1,0 +1,31 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometFilter
+                  :     :     :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometFilter
+                  :     :     :           +- CometNativeScan parquet spark_catalog.default.warehouse
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometNativeScan parquet spark_catalog.default.ship_mode
+                  :     +- CometBroadcastExchange
+                  :        +- CometFilter
+                  :           +- CometNativeScan parquet spark_catalog.default.web_site
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 28 out of 28 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q62.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q62.native_iceberg_compat/extended.txt
@@ -1,0 +1,31 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometFilter
+                  :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometFilter
+                  :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.warehouse
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.ship_mode
+                  :     +- CometBroadcastExchange
+                  :        +- CometFilter
+                  :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_site
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 28 out of 28 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q63.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q63.native_datafusion/extended.txt
@@ -1,0 +1,36 @@
+TakeOrderedAndProject
++- Project
+   +- Filter
+      +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+         +- CometNativeColumnarToRow
+            +- CometSort
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometProject
+                                 :     :  +- CometBroadcastHashJoin
+                                 :     :     :- CometProject
+                                 :     :     :  +- CometFilter
+                                 :     :     :     +- CometNativeScan parquet spark_catalog.default.item
+                                 :     :     +- CometBroadcastExchange
+                                 :     :        +- CometFilter
+                                 :     :           +- CometNativeScan parquet spark_catalog.default.store_sales
+                                 :     :                 +- CometSubqueryBroadcast
+                                 :     :                    +- CometBroadcastExchange
+                                 :     :                       +- CometProject
+                                 :     :                          +- CometFilter
+                                 :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometProject
+                                 :           +- CometFilter
+                                 :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 +- CometBroadcastExchange
+                                    +- CometFilter
+                                       +- CometNativeScan parquet spark_catalog.default.store
+
+Comet accelerated 28 out of 33 eligible operators (84%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q63.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q63.native_iceberg_compat/extended.txt
@@ -1,0 +1,37 @@
+TakeOrderedAndProject
++- Project
+   +- Filter
+      +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+         +- CometNativeColumnarToRow
+            +- CometSort
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometProject
+                                 :     :  +- CometBroadcastHashJoin
+                                 :     :     :- CometProject
+                                 :     :     :  +- CometFilter
+                                 :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :     :     +- CometBroadcastExchange
+                                 :     :        +- CometFilter
+                                 :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                 :     :                 +- SubqueryBroadcast
+                                 :     :                    +- BroadcastExchange
+                                 :     :                       +- CometNativeColumnarToRow
+                                 :     :                          +- CometProject
+                                 :     :                             +- CometFilter
+                                 :     :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometProject
+                                 :           +- CometFilter
+                                 :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 +- CometBroadcastExchange
+                                    +- CometFilter
+                                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+
+Comet accelerated 27 out of 33 eligible operators (81%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q64.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q64.native_datafusion/extended.txt
@@ -1,0 +1,245 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometProject
+         +- CometSortMergeJoin
+            :- CometSort
+            :  +- CometExchange
+            :     +- CometHashAggregate
+            :        +- CometHashAggregate
+            :           +- CometProject
+            :              +- CometBroadcastHashJoin
+            :                 :- CometProject
+            :                 :  +- CometBroadcastHashJoin
+            :                 :     :- CometProject
+            :                 :     :  +- CometBroadcastHashJoin
+            :                 :     :     :- CometProject
+            :                 :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :- CometProject
+            :                 :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :- CometProject
+            :                 :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometSortMergeJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometSort
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :  +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :     +- CometNativeScan parquet spark_catalog.default.store_sales
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :           +- CometSubqueryBroadcast
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :              +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                 +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                 +- CometNativeScan parquet spark_catalog.default.store_returns
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometSort
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometHashAggregate
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                 +- CometExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                    +- CometHashAggregate
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                       +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                          +- CometSortMergeJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :- CometSort
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :  +- CometExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :     +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :           +- CometNativeScan parquet spark_catalog.default.catalog_sales
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             +- CometSort
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                +- CometExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                   +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                      +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                         +- CometNativeScan parquet spark_catalog.default.catalog_returns
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.store
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.customer
+            :                 :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :        +- CometProject
+            :                 :     :     :     :     :     :     :     :     :           +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+            :                 :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :        +- CometProject
+            :                 :     :     :     :     :     :     :     :           +- CometFilter
+            :                 :     :     :     :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+            :                 :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.promotion
+            :                 :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.household_demographics
+            :                 :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.household_demographics
+            :                 :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :        +- CometProject
+            :                 :     :     :     :           +- CometFilter
+            :                 :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+            :                 :     :     :     +- CometBroadcastExchange
+            :                 :     :     :        +- CometProject
+            :                 :     :     :           +- CometFilter
+            :                 :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+            :                 :     :     +- CometBroadcastExchange
+            :                 :     :        +- CometFilter
+            :                 :     :           +- CometNativeScan parquet spark_catalog.default.income_band
+            :                 :     +- CometBroadcastExchange
+            :                 :        +- CometFilter
+            :                 :           +- CometNativeScan parquet spark_catalog.default.income_band
+            :                 +- CometBroadcastExchange
+            :                    +- CometProject
+            :                       +- CometFilter
+            :                          +- CometNativeScan parquet spark_catalog.default.item
+            +- CometSort
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometBroadcastHashJoin
+                              :     :- CometProject
+                              :     :  +- CometBroadcastHashJoin
+                              :     :     :- CometProject
+                              :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :- CometProject
+                              :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :- CometProject
+                              :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometSortMergeJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometSort
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :  +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :     +- CometNativeScan parquet spark_catalog.default.store_sales
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :           +- CometSubqueryBroadcast
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :              +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                 +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                 +- CometNativeScan parquet spark_catalog.default.store_returns
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometSort
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometHashAggregate
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                 +- CometExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                    +- CometHashAggregate
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                       +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                          +- CometSortMergeJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :- CometSort
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :  +- CometExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :     +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :           +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             +- CometSort
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                +- CometExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                   +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                      +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                         +- CometNativeScan parquet spark_catalog.default.catalog_returns
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.store
+                              :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.customer
+                              :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :        +- CometProject
+                              :     :     :     :     :     :     :     :     :           +- CometFilter
+                              :     :     :     :     :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+                              :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :        +- CometProject
+                              :     :     :     :     :     :     :     :           +- CometFilter
+                              :     :     :     :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+                              :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.promotion
+                              :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.household_demographics
+                              :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.household_demographics
+                              :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :        +- CometProject
+                              :     :     :     :           +- CometFilter
+                              :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                              :     :     :     +- CometBroadcastExchange
+                              :     :     :        +- CometProject
+                              :     :     :           +- CometFilter
+                              :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                              :     :     +- CometBroadcastExchange
+                              :     :        +- CometFilter
+                              :     :           +- CometNativeScan parquet spark_catalog.default.income_band
+                              :     +- CometBroadcastExchange
+                              :        +- CometFilter
+                              :           +- CometNativeScan parquet spark_catalog.default.income_band
+                              +- CometBroadcastExchange
+                                 +- CometProject
+                                    +- CometFilter
+                                       +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 240 out of 242 eligible operators (99%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q64.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q64.native_iceberg_compat/extended.txt
@@ -1,0 +1,247 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometProject
+         +- CometSortMergeJoin
+            :- CometSort
+            :  +- CometExchange
+            :     +- CometHashAggregate
+            :        +- CometHashAggregate
+            :           +- CometProject
+            :              +- CometBroadcastHashJoin
+            :                 :- CometProject
+            :                 :  +- CometBroadcastHashJoin
+            :                 :     :- CometProject
+            :                 :     :  +- CometBroadcastHashJoin
+            :                 :     :     :- CometProject
+            :                 :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :- CometProject
+            :                 :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :- CometProject
+            :                 :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometSortMergeJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometSort
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :  +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :           +- SubqueryBroadcast
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :              +- BroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                 +- CometNativeColumnarToRow
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                    +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometSort
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometHashAggregate
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                 +- CometExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                    +- CometHashAggregate
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                       +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                          +- CometSortMergeJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :- CometSort
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :  +- CometExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :     +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             +- CometSort
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                +- CometExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                   +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                      +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+            :                 :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :                 :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :                 :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :        +- CometProject
+            :                 :     :     :     :     :     :     :     :     :           +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+            :                 :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :        +- CometProject
+            :                 :     :     :     :     :     :     :     :           +- CometFilter
+            :                 :     :     :     :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+            :                 :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+            :                 :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+            :                 :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+            :                 :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :        +- CometProject
+            :                 :     :     :     :           +- CometFilter
+            :                 :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+            :                 :     :     :     +- CometBroadcastExchange
+            :                 :     :     :        +- CometProject
+            :                 :     :     :           +- CometFilter
+            :                 :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+            :                 :     :     +- CometBroadcastExchange
+            :                 :     :        +- CometFilter
+            :                 :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.income_band
+            :                 :     +- CometBroadcastExchange
+            :                 :        +- CometFilter
+            :                 :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.income_band
+            :                 +- CometBroadcastExchange
+            :                    +- CometProject
+            :                       +- CometFilter
+            :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+            +- CometSort
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometBroadcastHashJoin
+                              :     :- CometProject
+                              :     :  +- CometBroadcastHashJoin
+                              :     :     :- CometProject
+                              :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :- CometProject
+                              :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :- CometProject
+                              :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometSortMergeJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometSort
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :  +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :           +- SubqueryBroadcast
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :              +- BroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                 +- CometNativeColumnarToRow
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                    +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometSort
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometHashAggregate
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                 +- CometExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                    +- CometHashAggregate
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                       +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                          +- CometSortMergeJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :- CometSort
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :  +- CometExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :     +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             +- CometSort
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                +- CometExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                   +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                      +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                              :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                              :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :        +- CometProject
+                              :     :     :     :     :     :     :     :     :           +- CometFilter
+                              :     :     :     :     :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+                              :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :        +- CometProject
+                              :     :     :     :     :     :     :     :           +- CometFilter
+                              :     :     :     :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+                              :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+                              :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+                              :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+                              :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :        +- CometProject
+                              :     :     :     :           +- CometFilter
+                              :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                              :     :     :     +- CometBroadcastExchange
+                              :     :     :        +- CometProject
+                              :     :     :           +- CometFilter
+                              :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                              :     :     +- CometBroadcastExchange
+                              :     :        +- CometFilter
+                              :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.income_band
+                              :     +- CometBroadcastExchange
+                              :        +- CometFilter
+                              :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.income_band
+                              +- CometBroadcastExchange
+                                 +- CometProject
+                                    +- CometFilter
+                                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 238 out of 242 eligible operators (98%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q65.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q65.native_datafusion/extended.txt
@@ -1,0 +1,51 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometProject
+         :     :  +- CometBroadcastHashJoin
+         :     :     :- CometFilter
+         :     :     :  +- CometNativeScan parquet spark_catalog.default.store
+         :     :     +- CometBroadcastExchange
+         :     :        +- CometFilter
+         :     :           +- CometHashAggregate
+         :     :              +- CometExchange
+         :     :                 +- CometHashAggregate
+         :     :                    +- CometProject
+         :     :                       +- CometBroadcastHashJoin
+         :     :                          :- CometFilter
+         :     :                          :  +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     :                          :        +- CometSubqueryBroadcast
+         :     :                          :           +- CometBroadcastExchange
+         :     :                          :              +- CometProject
+         :     :                          :                 +- CometFilter
+         :     :                          :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :                          +- CometBroadcastExchange
+         :     :                             +- CometProject
+         :     :                                +- CometFilter
+         :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     +- CometBroadcastExchange
+         :        +- CometProject
+         :           +- CometFilter
+         :              +- CometNativeScan parquet spark_catalog.default.item
+         +- CometBroadcastExchange
+            +- CometFilter
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometHashAggregate
+                           +- CometExchange
+                              +- CometHashAggregate
+                                 +- CometProject
+                                    +- CometBroadcastHashJoin
+                                       :- CometFilter
+                                       :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                       :        +- ReusedSubquery
+                                       +- CometBroadcastExchange
+                                          +- CometProject
+                                             +- CometFilter
+                                                +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 46 out of 48 eligible operators (95%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q65.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q65.native_iceberg_compat/extended.txt
@@ -1,0 +1,52 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometProject
+         :     :  +- CometBroadcastHashJoin
+         :     :     :- CometFilter
+         :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+         :     :     +- CometBroadcastExchange
+         :     :        +- CometFilter
+         :     :           +- CometHashAggregate
+         :     :              +- CometExchange
+         :     :                 +- CometHashAggregate
+         :     :                    +- CometProject
+         :     :                       +- CometBroadcastHashJoin
+         :     :                          :- CometFilter
+         :     :                          :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     :                          :        +- SubqueryBroadcast
+         :     :                          :           +- BroadcastExchange
+         :     :                          :              +- CometNativeColumnarToRow
+         :     :                          :                 +- CometProject
+         :     :                          :                    +- CometFilter
+         :     :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :                          +- CometBroadcastExchange
+         :     :                             +- CometProject
+         :     :                                +- CometFilter
+         :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     +- CometBroadcastExchange
+         :        +- CometProject
+         :           +- CometFilter
+         :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+         +- CometBroadcastExchange
+            +- CometFilter
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometHashAggregate
+                           +- CometExchange
+                              +- CometHashAggregate
+                                 +- CometProject
+                                    +- CometBroadcastHashJoin
+                                       :- CometFilter
+                                       :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                       :        +- ReusedSubquery
+                                       +- CometBroadcastExchange
+                                          +- CometProject
+                                             +- CometFilter
+                                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 45 out of 48 eligible operators (93%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q66.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q66.native_datafusion/extended.txt
@@ -1,0 +1,68 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometHashAggregate
+         +- CometUnion
+            :- CometHashAggregate
+            :  +- CometExchange
+            :     +- CometHashAggregate
+            :        +- CometProject
+            :           +- CometBroadcastHashJoin
+            :              :- CometProject
+            :              :  +- CometBroadcastHashJoin
+            :              :     :- CometProject
+            :              :     :  +- CometBroadcastHashJoin
+            :              :     :     :- CometProject
+            :              :     :     :  +- CometBroadcastHashJoin
+            :              :     :     :     :- CometFilter
+            :              :     :     :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+            :              :     :     :     :        +- CometSubqueryBroadcast
+            :              :     :     :     :           +- CometBroadcastExchange
+            :              :     :     :     :              +- CometFilter
+            :              :     :     :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+            :              :     :     :     +- CometBroadcastExchange
+            :              :     :     :        +- CometProject
+            :              :     :     :           +- CometFilter
+            :              :     :     :              +- CometNativeScan parquet spark_catalog.default.warehouse
+            :              :     :     +- CometBroadcastExchange
+            :              :     :        +- CometFilter
+            :              :     :           +- CometNativeScan parquet spark_catalog.default.date_dim
+            :              :     +- CometBroadcastExchange
+            :              :        +- CometProject
+            :              :           +- CometFilter
+            :              :              +- CometNativeScan parquet spark_catalog.default.time_dim
+            :              +- CometBroadcastExchange
+            :                 +- CometProject
+            :                    +- CometFilter
+            :                       +- CometNativeScan parquet spark_catalog.default.ship_mode
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometBroadcastHashJoin
+                           :     :     :- CometProject
+                           :     :     :  +- CometBroadcastHashJoin
+                           :     :     :     :- CometFilter
+                           :     :     :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                           :     :     :     :        +- ReusedSubquery
+                           :     :     :     +- CometBroadcastExchange
+                           :     :     :        +- CometProject
+                           :     :     :           +- CometFilter
+                           :     :     :              +- CometNativeScan parquet spark_catalog.default.warehouse
+                           :     :     +- CometBroadcastExchange
+                           :     :        +- CometFilter
+                           :     :           +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     +- CometBroadcastExchange
+                           :        +- CometProject
+                           :           +- CometFilter
+                           :              +- CometNativeScan parquet spark_catalog.default.time_dim
+                           +- CometBroadcastExchange
+                              +- CometProject
+                                 +- CometFilter
+                                    +- CometNativeScan parquet spark_catalog.default.ship_mode
+
+Comet accelerated 63 out of 65 eligible operators (96%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q66.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q66.native_iceberg_compat/extended.txt
@@ -1,0 +1,69 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometHashAggregate
+         +- CometUnion
+            :- CometHashAggregate
+            :  +- CometExchange
+            :     +- CometHashAggregate
+            :        +- CometProject
+            :           +- CometBroadcastHashJoin
+            :              :- CometProject
+            :              :  +- CometBroadcastHashJoin
+            :              :     :- CometProject
+            :              :     :  +- CometBroadcastHashJoin
+            :              :     :     :- CometProject
+            :              :     :     :  +- CometBroadcastHashJoin
+            :              :     :     :     :- CometFilter
+            :              :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+            :              :     :     :     :        +- SubqueryBroadcast
+            :              :     :     :     :           +- BroadcastExchange
+            :              :     :     :     :              +- CometNativeColumnarToRow
+            :              :     :     :     :                 +- CometFilter
+            :              :     :     :     :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :              :     :     :     +- CometBroadcastExchange
+            :              :     :     :        +- CometProject
+            :              :     :     :           +- CometFilter
+            :              :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.warehouse
+            :              :     :     +- CometBroadcastExchange
+            :              :     :        +- CometFilter
+            :              :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :              :     +- CometBroadcastExchange
+            :              :        +- CometProject
+            :              :           +- CometFilter
+            :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.time_dim
+            :              +- CometBroadcastExchange
+            :                 +- CometProject
+            :                    +- CometFilter
+            :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.ship_mode
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometBroadcastHashJoin
+                           :     :     :- CometProject
+                           :     :     :  +- CometBroadcastHashJoin
+                           :     :     :     :- CometFilter
+                           :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                           :     :     :     :        +- ReusedSubquery
+                           :     :     :     +- CometBroadcastExchange
+                           :     :     :        +- CometProject
+                           :     :     :           +- CometFilter
+                           :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.warehouse
+                           :     :     +- CometBroadcastExchange
+                           :     :        +- CometFilter
+                           :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     +- CometBroadcastExchange
+                           :        +- CometProject
+                           :           +- CometFilter
+                           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.time_dim
+                           +- CometBroadcastExchange
+                              +- CometProject
+                                 +- CometFilter
+                                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.ship_mode
+
+Comet accelerated 62 out of 65 eligible operators (95%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q67.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q67.native_datafusion/extended.txt
@@ -1,0 +1,41 @@
+TakeOrderedAndProject
++- Filter
+   +- Window
+      +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+         +- CometNativeColumnarToRow
+            +- CometSort
+               +- CometColumnarExchange
+                  +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+                     +- CometNativeColumnarToRow
+                        +- CometSort
+                           +- CometHashAggregate
+                              +- CometExchange
+                                 +- CometHashAggregate
+                                    +- CometExpand
+                                       +- CometProject
+                                          +- CometBroadcastHashJoin
+                                             :- CometProject
+                                             :  +- CometBroadcastHashJoin
+                                             :     :- CometProject
+                                             :     :  +- CometBroadcastHashJoin
+                                             :     :     :- CometFilter
+                                             :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                             :     :     :        +- CometSubqueryBroadcast
+                                             :     :     :           +- CometBroadcastExchange
+                                             :     :     :              +- CometProject
+                                             :     :     :                 +- CometFilter
+                                             :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                             :     :     +- CometBroadcastExchange
+                                             :     :        +- CometProject
+                                             :     :           +- CometFilter
+                                             :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                             :     +- CometBroadcastExchange
+                                             :        +- CometProject
+                                             :           +- CometFilter
+                                             :              +- CometNativeScan parquet spark_catalog.default.store
+                                             +- CometBroadcastExchange
+                                                +- CometProject
+                                                   +- CometFilter
+                                                      +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 31 out of 37 eligible operators (83%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q67.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q67.native_iceberg_compat/extended.txt
@@ -1,0 +1,42 @@
+TakeOrderedAndProject
++- Filter
+   +- Window
+      +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+         +- CometNativeColumnarToRow
+            +- CometSort
+               +- CometColumnarExchange
+                  +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+                     +- CometNativeColumnarToRow
+                        +- CometSort
+                           +- CometHashAggregate
+                              +- CometExchange
+                                 +- CometHashAggregate
+                                    +- CometExpand
+                                       +- CometProject
+                                          +- CometBroadcastHashJoin
+                                             :- CometProject
+                                             :  +- CometBroadcastHashJoin
+                                             :     :- CometProject
+                                             :     :  +- CometBroadcastHashJoin
+                                             :     :     :- CometFilter
+                                             :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                             :     :     :        +- SubqueryBroadcast
+                                             :     :     :           +- BroadcastExchange
+                                             :     :     :              +- CometNativeColumnarToRow
+                                             :     :     :                 +- CometProject
+                                             :     :     :                    +- CometFilter
+                                             :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                             :     :     +- CometBroadcastExchange
+                                             :     :        +- CometProject
+                                             :     :           +- CometFilter
+                                             :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                             :     +- CometBroadcastExchange
+                                             :        +- CometProject
+                                             :           +- CometFilter
+                                             :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                                             +- CometBroadcastExchange
+                                                +- CometProject
+                                                   +- CometFilter
+                                                      +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 30 out of 37 eligible operators (81%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q68.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q68.native_datafusion/extended.txt
@@ -1,0 +1,48 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometHashAggregate
+         :     :  +- CometExchange
+         :     :     +- CometHashAggregate
+         :     :        +- CometProject
+         :     :           +- CometBroadcastHashJoin
+         :     :              :- CometProject
+         :     :              :  +- CometBroadcastHashJoin
+         :     :              :     :- CometProject
+         :     :              :     :  +- CometBroadcastHashJoin
+         :     :              :     :     :- CometProject
+         :     :              :     :     :  +- CometBroadcastHashJoin
+         :     :              :     :     :     :- CometFilter
+         :     :              :     :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     :              :     :     :     :        +- CometSubqueryBroadcast
+         :     :              :     :     :     :           +- CometBroadcastExchange
+         :     :              :     :     :     :              +- CometProject
+         :     :              :     :     :     :                 +- CometFilter
+         :     :              :     :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :              :     :     :     +- CometBroadcastExchange
+         :     :              :     :     :        +- CometProject
+         :     :              :     :     :           +- CometFilter
+         :     :              :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :              :     :     +- CometBroadcastExchange
+         :     :              :     :        +- CometProject
+         :     :              :     :           +- CometFilter
+         :     :              :     :              +- CometNativeScan parquet spark_catalog.default.store
+         :     :              :     +- CometBroadcastExchange
+         :     :              :        +- CometProject
+         :     :              :           +- CometFilter
+         :     :              :              +- CometNativeScan parquet spark_catalog.default.household_demographics
+         :     :              +- CometBroadcastExchange
+         :     :                 +- CometFilter
+         :     :                    +- CometNativeScan parquet spark_catalog.default.customer_address
+         :     +- CometBroadcastExchange
+         :        +- CometProject
+         :           +- CometFilter
+         :              +- CometNativeScan parquet spark_catalog.default.customer
+         +- CometBroadcastExchange
+            +- CometFilter
+               +- CometNativeScan parquet spark_catalog.default.customer_address
+
+Comet accelerated 44 out of 45 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q68.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q68.native_iceberg_compat/extended.txt
@@ -1,0 +1,49 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometHashAggregate
+         :     :  +- CometExchange
+         :     :     +- CometHashAggregate
+         :     :        +- CometProject
+         :     :           +- CometBroadcastHashJoin
+         :     :              :- CometProject
+         :     :              :  +- CometBroadcastHashJoin
+         :     :              :     :- CometProject
+         :     :              :     :  +- CometBroadcastHashJoin
+         :     :              :     :     :- CometProject
+         :     :              :     :     :  +- CometBroadcastHashJoin
+         :     :              :     :     :     :- CometFilter
+         :     :              :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     :              :     :     :     :        +- SubqueryBroadcast
+         :     :              :     :     :     :           +- BroadcastExchange
+         :     :              :     :     :     :              +- CometNativeColumnarToRow
+         :     :              :     :     :     :                 +- CometProject
+         :     :              :     :     :     :                    +- CometFilter
+         :     :              :     :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :              :     :     :     +- CometBroadcastExchange
+         :     :              :     :     :        +- CometProject
+         :     :              :     :     :           +- CometFilter
+         :     :              :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :              :     :     +- CometBroadcastExchange
+         :     :              :     :        +- CometProject
+         :     :              :     :           +- CometFilter
+         :     :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+         :     :              :     +- CometBroadcastExchange
+         :     :              :        +- CometProject
+         :     :              :           +- CometFilter
+         :     :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+         :     :              +- CometBroadcastExchange
+         :     :                 +- CometFilter
+         :     :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+         :     +- CometBroadcastExchange
+         :        +- CometProject
+         :           +- CometFilter
+         :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         +- CometBroadcastExchange
+            +- CometFilter
+               +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+
+Comet accelerated 43 out of 45 eligible operators (95%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q69.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q69.native_datafusion/extended.txt
@@ -1,0 +1,60 @@
+TakeOrderedAndProject
++- HashAggregate
+   +- Exchange
+      +- HashAggregate
+         +- Project
+            +- BroadcastHashJoin
+               :- Project
+               :  +- BroadcastHashJoin
+               :     :- Project
+               :     :  +- BroadcastHashJoin
+               :     :     :-  BroadcastHashJoin [COMET: BuildRight with LeftAnti is not supported]
+               :     :     :  :- CometNativeColumnarToRow
+               :     :     :  :  +- CometBroadcastHashJoin
+               :     :     :  :     :- CometFilter
+               :     :     :  :     :  +- CometNativeScan parquet spark_catalog.default.customer
+               :     :     :  :     +- CometBroadcastExchange
+               :     :     :  :        +- CometProject
+               :     :     :  :           +- CometBroadcastHashJoin
+               :     :     :  :              :- CometNativeScan parquet spark_catalog.default.store_sales
+               :     :     :  :              :     +- CometSubqueryBroadcast
+               :     :     :  :              :        +- CometBroadcastExchange
+               :     :     :  :              :           +- CometProject
+               :     :     :  :              :              +- CometFilter
+               :     :     :  :              :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     :     :  :              +- CometBroadcastExchange
+               :     :     :  :                 +- CometProject
+               :     :     :  :                    +- CometFilter
+               :     :     :  :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     :     :  +- BroadcastExchange
+               :     :     :     +- CometNativeColumnarToRow
+               :     :     :        +- CometProject
+               :     :     :           +- CometBroadcastHashJoin
+               :     :     :              :- CometNativeScan parquet spark_catalog.default.web_sales
+               :     :     :              :     +- ReusedSubquery
+               :     :     :              +- CometBroadcastExchange
+               :     :     :                 +- CometProject
+               :     :     :                    +- CometFilter
+               :     :     :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     :     +- BroadcastExchange
+               :     :        +- CometNativeColumnarToRow
+               :     :           +- CometProject
+               :     :              +- CometBroadcastHashJoin
+               :     :                 :- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :     :                 :     +- ReusedSubquery
+               :     :                 +- CometBroadcastExchange
+               :     :                    +- CometProject
+               :     :                       +- CometFilter
+               :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     +- BroadcastExchange
+               :        +- CometNativeColumnarToRow
+               :           +- CometProject
+               :              +- CometFilter
+               :                 +- CometNativeScan parquet spark_catalog.default.customer_address
+               +- BroadcastExchange
+                  +- CometNativeColumnarToRow
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.customer_demographics
+
+Comet accelerated 35 out of 53 eligible operators (66%). Final plan contains 5 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q69.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q69.native_iceberg_compat/extended.txt
@@ -1,0 +1,61 @@
+TakeOrderedAndProject
++- HashAggregate
+   +- Exchange
+      +- HashAggregate
+         +- Project
+            +- BroadcastHashJoin
+               :- Project
+               :  +- BroadcastHashJoin
+               :     :- Project
+               :     :  +- BroadcastHashJoin
+               :     :     :-  BroadcastHashJoin [COMET: BuildRight with LeftAnti is not supported]
+               :     :     :  :- CometNativeColumnarToRow
+               :     :     :  :  +- CometBroadcastHashJoin
+               :     :     :  :     :- CometFilter
+               :     :     :  :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+               :     :     :  :     +- CometBroadcastExchange
+               :     :     :  :        +- CometProject
+               :     :     :  :           +- CometBroadcastHashJoin
+               :     :     :  :              :- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :     :     :  :              :     +- SubqueryBroadcast
+               :     :     :  :              :        +- BroadcastExchange
+               :     :     :  :              :           +- CometNativeColumnarToRow
+               :     :     :  :              :              +- CometProject
+               :     :     :  :              :                 +- CometFilter
+               :     :     :  :              :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     :     :  :              +- CometBroadcastExchange
+               :     :     :  :                 +- CometProject
+               :     :     :  :                    +- CometFilter
+               :     :     :  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     :     :  +- BroadcastExchange
+               :     :     :     +- CometNativeColumnarToRow
+               :     :     :        +- CometProject
+               :     :     :           +- CometBroadcastHashJoin
+               :     :     :              :- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :     :     :              :     +- ReusedSubquery
+               :     :     :              +- CometBroadcastExchange
+               :     :     :                 +- CometProject
+               :     :     :                    +- CometFilter
+               :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     :     +- BroadcastExchange
+               :     :        +- CometNativeColumnarToRow
+               :     :           +- CometProject
+               :     :              +- CometBroadcastHashJoin
+               :     :                 :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :     :                 :     +- ReusedSubquery
+               :     :                 +- CometBroadcastExchange
+               :     :                    +- CometProject
+               :     :                       +- CometFilter
+               :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     +- BroadcastExchange
+               :        +- CometNativeColumnarToRow
+               :           +- CometProject
+               :              +- CometFilter
+               :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+               +- BroadcastExchange
+                  +- CometNativeColumnarToRow
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+
+Comet accelerated 34 out of 53 eligible operators (64%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q7.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q7.native_datafusion/extended.txt
@@ -1,0 +1,38 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometFilter
+                  :     :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                  :     :     :     :        +- CometSubqueryBroadcast
+                  :     :     :     :           +- CometBroadcastExchange
+                  :     :     :     :              +- CometProject
+                  :     :     :     :                 +- CometFilter
+                  :     :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometProject
+                  :     :     :           +- CometFilter
+                  :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometNativeScan parquet spark_catalog.default.item
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.promotion
+
+Comet accelerated 34 out of 35 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q7.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q7.native_iceberg_compat/extended.txt
@@ -1,0 +1,39 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometFilter
+                  :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :     :     :     :        +- SubqueryBroadcast
+                  :     :     :     :           +- BroadcastExchange
+                  :     :     :     :              +- CometNativeColumnarToRow
+                  :     :     :     :                 +- CometProject
+                  :     :     :     :                    +- CometFilter
+                  :     :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometProject
+                  :     :     :           +- CometFilter
+                  :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+
+Comet accelerated 33 out of 35 eligible operators (94%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q70.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q70.native_datafusion/extended.txt
@@ -1,0 +1,59 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometColumnarExchange
+               +- HashAggregate
+                  +- Exchange
+                     +- HashAggregate
+                        +- Expand
+                           +- Project
+                              +- BroadcastHashJoin
+                                 :- CometNativeColumnarToRow
+                                 :  +- CometProject
+                                 :     +- CometBroadcastHashJoin
+                                 :        :- CometFilter
+                                 :        :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                 :        :        +- CometSubqueryBroadcast
+                                 :        :           +- CometBroadcastExchange
+                                 :        :              +- CometProject
+                                 :        :                 +- CometFilter
+                                 :        :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :        +- CometBroadcastExchange
+                                 :           +- CometProject
+                                 :              +- CometFilter
+                                 :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 +- BroadcastExchange
+                                    +- Project
+                                       +- BroadcastHashJoin
+                                          :- CometNativeColumnarToRow
+                                          :  +- CometFilter
+                                          :     +- CometNativeScan parquet spark_catalog.default.store
+                                          +- BroadcastExchange
+                                             +- Project
+                                                +- Filter
+                                                   +- Window
+                                                      +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+                                                         +- CometNativeColumnarToRow
+                                                            +- CometSort
+                                                               +- CometHashAggregate
+                                                                  +- CometExchange
+                                                                     +- CometHashAggregate
+                                                                        +- CometProject
+                                                                           +- CometBroadcastHashJoin
+                                                                              :- CometProject
+                                                                              :  +- CometBroadcastHashJoin
+                                                                              :     :- CometFilter
+                                                                              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                                                              :     :        +- ReusedSubquery
+                                                                              :     +- CometBroadcastExchange
+                                                                              :        +- CometProject
+                                                                              :           +- CometFilter
+                                                                              :              +- CometNativeScan parquet spark_catalog.default.store
+                                                                              +- CometBroadcastExchange
+                                                                                 +- CometProject
+                                                                                    +- CometFilter
+                                                                                       +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 34 out of 53 eligible operators (64%). Final plan contains 4 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q70.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q70.native_iceberg_compat/extended.txt
@@ -1,0 +1,60 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometColumnarExchange
+               +- HashAggregate
+                  +- Exchange
+                     +- HashAggregate
+                        +- Expand
+                           +- Project
+                              +- BroadcastHashJoin
+                                 :- CometNativeColumnarToRow
+                                 :  +- CometProject
+                                 :     +- CometBroadcastHashJoin
+                                 :        :- CometFilter
+                                 :        :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                 :        :        +- SubqueryBroadcast
+                                 :        :           +- BroadcastExchange
+                                 :        :              +- CometNativeColumnarToRow
+                                 :        :                 +- CometProject
+                                 :        :                    +- CometFilter
+                                 :        :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :        +- CometBroadcastExchange
+                                 :           +- CometProject
+                                 :              +- CometFilter
+                                 :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 +- BroadcastExchange
+                                    +- Project
+                                       +- BroadcastHashJoin
+                                          :- CometNativeColumnarToRow
+                                          :  +- CometFilter
+                                          :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                                          +- BroadcastExchange
+                                             +- Project
+                                                +- Filter
+                                                   +- Window
+                                                      +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+                                                         +- CometNativeColumnarToRow
+                                                            +- CometSort
+                                                               +- CometHashAggregate
+                                                                  +- CometExchange
+                                                                     +- CometHashAggregate
+                                                                        +- CometProject
+                                                                           +- CometBroadcastHashJoin
+                                                                              :- CometProject
+                                                                              :  +- CometBroadcastHashJoin
+                                                                              :     :- CometFilter
+                                                                              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                                                              :     :        +- ReusedSubquery
+                                                                              :     +- CometBroadcastExchange
+                                                                              :        +- CometProject
+                                                                              :           +- CometFilter
+                                                                              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                                                                              +- CometBroadcastExchange
+                                                                                 +- CometProject
+                                                                                    +- CometFilter
+                                                                                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 33 out of 53 eligible operators (62%). Final plan contains 5 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q71.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q71.native_datafusion/extended.txt
@@ -1,0 +1,52 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometBroadcastExchange
+                     :     :  +- CometProject
+                     :     :     +- CometFilter
+                     :     :        +- CometNativeScan parquet spark_catalog.default.item
+                     :     +- CometUnion
+                     :        :- CometProject
+                     :        :  +- CometBroadcastHashJoin
+                     :        :     :- CometFilter
+                     :        :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                     :        :     :        +- CometSubqueryBroadcast
+                     :        :     :           +- CometBroadcastExchange
+                     :        :     :              +- CometProject
+                     :        :     :                 +- CometFilter
+                     :        :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :        :     +- CometBroadcastExchange
+                     :        :        +- CometProject
+                     :        :           +- CometFilter
+                     :        :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :        :- CometProject
+                     :        :  +- CometBroadcastHashJoin
+                     :        :     :- CometFilter
+                     :        :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                     :        :     :        +- ReusedSubquery
+                     :        :     +- CometBroadcastExchange
+                     :        :        +- CometProject
+                     :        :           +- CometFilter
+                     :        :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :        +- CometProject
+                     :           +- CometBroadcastHashJoin
+                     :              :- CometFilter
+                     :              :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                     :              :        +- ReusedSubquery
+                     :              +- CometBroadcastExchange
+                     :                 +- CometProject
+                     :                    +- CometFilter
+                     :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                     +- CometBroadcastExchange
+                        +- CometProject
+                           +- CometFilter
+                              +- CometNativeScan parquet spark_catalog.default.time_dim
+
+Comet accelerated 46 out of 49 eligible operators (93%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q71.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q71.native_iceberg_compat/extended.txt
@@ -1,0 +1,53 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometBroadcastExchange
+                     :     :  +- CometProject
+                     :     :     +- CometFilter
+                     :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                     :     +- CometUnion
+                     :        :- CometProject
+                     :        :  +- CometBroadcastHashJoin
+                     :        :     :- CometFilter
+                     :        :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                     :        :     :        +- SubqueryBroadcast
+                     :        :     :           +- BroadcastExchange
+                     :        :     :              +- CometNativeColumnarToRow
+                     :        :     :                 +- CometProject
+                     :        :     :                    +- CometFilter
+                     :        :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :        :     +- CometBroadcastExchange
+                     :        :        +- CometProject
+                     :        :           +- CometFilter
+                     :        :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :        :- CometProject
+                     :        :  +- CometBroadcastHashJoin
+                     :        :     :- CometFilter
+                     :        :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                     :        :     :        +- ReusedSubquery
+                     :        :     +- CometBroadcastExchange
+                     :        :        +- CometProject
+                     :        :           +- CometFilter
+                     :        :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :        +- CometProject
+                     :           +- CometBroadcastHashJoin
+                     :              :- CometFilter
+                     :              :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                     :              :        +- ReusedSubquery
+                     :              +- CometBroadcastExchange
+                     :                 +- CometProject
+                     :                    +- CometFilter
+                     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     +- CometBroadcastExchange
+                        +- CometProject
+                           +- CometFilter
+                              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.time_dim
+
+Comet accelerated 45 out of 49 eligible operators (91%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q72.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q72.native_datafusion/extended.txt
@@ -1,0 +1,71 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometSortMergeJoin
+                  :- CometSort
+                  :  +- CometExchange
+                  :     +- CometProject
+                  :        +- CometBroadcastHashJoin
+                  :           :- CometProject
+                  :           :  +- CometBroadcastHashJoin
+                  :           :     :- CometProject
+                  :           :     :  +- CometBroadcastHashJoin
+                  :           :     :     :- CometProject
+                  :           :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :- CometProject
+                  :           :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :- CometProject
+                  :           :     :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :     :- CometProject
+                  :           :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :     :     :- CometProject
+                  :           :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :     :     :     :- CometProject
+                  :           :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :     :     :     :     :- CometFilter
+                  :           :     :     :     :     :     :     :     :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                  :           :     :     :     :     :     :     :     :     :        +- CometSubqueryBroadcast
+                  :           :     :     :     :     :     :     :     :     :           +- CometBroadcastExchange
+                  :           :     :     :     :     :     :     :     :     :              +- CometProject
+                  :           :     :     :     :     :     :     :     :     :                 +- CometFilter
+                  :           :     :     :     :     :     :     :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :           :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :     :     :     :     :        +- CometFilter
+                  :           :     :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.inventory
+                  :           :     :     :     :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :     :     :     :        +- CometFilter
+                  :           :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.warehouse
+                  :           :     :     :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :     :     :        +- CometFilter
+                  :           :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.item
+                  :           :     :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :     :        +- CometProject
+                  :           :     :     :     :     :           +- CometFilter
+                  :           :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+                  :           :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :        +- CometProject
+                  :           :     :     :     :           +- CometFilter
+                  :           :     :     :     :              +- CometNativeScan parquet spark_catalog.default.household_demographics
+                  :           :     :     :     +- CometBroadcastExchange
+                  :           :     :     :        +- CometProject
+                  :           :     :     :           +- CometFilter
+                  :           :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :           :     :     +- CometBroadcastExchange
+                  :           :     :        +- CometFilter
+                  :           :     :           +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :           :     +- CometBroadcastExchange
+                  :           :        +- CometFilter
+                  :           :           +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :           +- CometBroadcastExchange
+                  :              +- CometFilter
+                  :                 +- CometNativeScan parquet spark_catalog.default.promotion
+                  +- CometSort
+                     +- CometExchange
+                        +- CometProject
+                           +- CometFilter
+                              +- CometNativeScan parquet spark_catalog.default.catalog_returns
+
+Comet accelerated 67 out of 68 eligible operators (98%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q72.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q72.native_iceberg_compat/extended.txt
@@ -1,0 +1,72 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometSortMergeJoin
+                  :- CometSort
+                  :  +- CometExchange
+                  :     +- CometProject
+                  :        +- CometBroadcastHashJoin
+                  :           :- CometProject
+                  :           :  +- CometBroadcastHashJoin
+                  :           :     :- CometProject
+                  :           :     :  +- CometBroadcastHashJoin
+                  :           :     :     :- CometProject
+                  :           :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :- CometProject
+                  :           :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :- CometProject
+                  :           :     :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :     :- CometProject
+                  :           :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :     :     :- CometProject
+                  :           :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :     :     :     :- CometProject
+                  :           :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :     :     :     :     :- CometFilter
+                  :           :     :     :     :     :     :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                  :           :     :     :     :     :     :     :     :     :        +- SubqueryBroadcast
+                  :           :     :     :     :     :     :     :     :     :           +- BroadcastExchange
+                  :           :     :     :     :     :     :     :     :     :              +- CometNativeColumnarToRow
+                  :           :     :     :     :     :     :     :     :     :                 +- CometProject
+                  :           :     :     :     :     :     :     :     :     :                    +- CometFilter
+                  :           :     :     :     :     :     :     :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :           :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :     :     :     :     :        +- CometFilter
+                  :           :     :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.inventory
+                  :           :     :     :     :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :     :     :     :        +- CometFilter
+                  :           :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.warehouse
+                  :           :     :     :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :     :     :        +- CometFilter
+                  :           :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :           :     :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :     :        +- CometProject
+                  :           :     :     :     :     :           +- CometFilter
+                  :           :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+                  :           :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :        +- CometProject
+                  :           :     :     :     :           +- CometFilter
+                  :           :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+                  :           :     :     :     +- CometBroadcastExchange
+                  :           :     :     :        +- CometProject
+                  :           :     :     :           +- CometFilter
+                  :           :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :           :     :     +- CometBroadcastExchange
+                  :           :     :        +- CometFilter
+                  :           :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :           :     +- CometBroadcastExchange
+                  :           :        +- CometFilter
+                  :           :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :           +- CometBroadcastExchange
+                  :              +- CometFilter
+                  :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+                  +- CometSort
+                     +- CometExchange
+                        +- CometProject
+                           +- CometFilter
+                              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+
+Comet accelerated 66 out of 68 eligible operators (97%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q73.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q73.native_datafusion/extended.txt
@@ -1,0 +1,40 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometProject
+         +- CometBroadcastHashJoin
+            :- CometFilter
+            :  +- CometHashAggregate
+            :     +- CometExchange
+            :        +- CometHashAggregate
+            :           +- CometProject
+            :              +- CometBroadcastHashJoin
+            :                 :- CometProject
+            :                 :  +- CometBroadcastHashJoin
+            :                 :     :- CometProject
+            :                 :     :  +- CometBroadcastHashJoin
+            :                 :     :     :- CometFilter
+            :                 :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+            :                 :     :     :        +- CometSubqueryBroadcast
+            :                 :     :     :           +- CometBroadcastExchange
+            :                 :     :     :              +- CometProject
+            :                 :     :     :                 +- CometFilter
+            :                 :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     +- CometBroadcastExchange
+            :                 :     :        +- CometProject
+            :                 :     :           +- CometFilter
+            :                 :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     +- CometBroadcastExchange
+            :                 :        +- CometProject
+            :                 :           +- CometFilter
+            :                 :              +- CometNativeScan parquet spark_catalog.default.store
+            :                 +- CometBroadcastExchange
+            :                    +- CometProject
+            :                       +- CometFilter
+            :                          +- CometNativeScan parquet spark_catalog.default.household_demographics
+            +- CometBroadcastExchange
+               +- CometProject
+                  +- CometFilter
+                     +- CometNativeScan parquet spark_catalog.default.customer
+
+Comet accelerated 36 out of 37 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q73.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q73.native_iceberg_compat/extended.txt
@@ -1,0 +1,41 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometProject
+         +- CometBroadcastHashJoin
+            :- CometFilter
+            :  +- CometHashAggregate
+            :     +- CometExchange
+            :        +- CometHashAggregate
+            :           +- CometProject
+            :              +- CometBroadcastHashJoin
+            :                 :- CometProject
+            :                 :  +- CometBroadcastHashJoin
+            :                 :     :- CometProject
+            :                 :     :  +- CometBroadcastHashJoin
+            :                 :     :     :- CometFilter
+            :                 :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+            :                 :     :     :        +- SubqueryBroadcast
+            :                 :     :     :           +- BroadcastExchange
+            :                 :     :     :              +- CometNativeColumnarToRow
+            :                 :     :     :                 +- CometProject
+            :                 :     :     :                    +- CometFilter
+            :                 :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :                 :     :     +- CometBroadcastExchange
+            :                 :     :        +- CometProject
+            :                 :     :           +- CometFilter
+            :                 :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :                 :     +- CometBroadcastExchange
+            :                 :        +- CometProject
+            :                 :           +- CometFilter
+            :                 :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+            :                 +- CometBroadcastExchange
+            :                    +- CometProject
+            :                       +- CometFilter
+            :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+            +- CometBroadcastExchange
+               +- CometProject
+                  +- CometFilter
+                     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+
+Comet accelerated 35 out of 37 eligible operators (94%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q74.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q74.native_datafusion/extended.txt
@@ -1,0 +1,88 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometBroadcastHashJoin
+         :     :  :- CometFilter
+         :     :  :  +- CometHashAggregate
+         :     :  :     +- CometExchange
+         :     :  :        +- CometHashAggregate
+         :     :  :           +- CometProject
+         :     :  :              +- CometBroadcastHashJoin
+         :     :  :                 :- CometProject
+         :     :  :                 :  +- CometBroadcastHashJoin
+         :     :  :                 :     :- CometProject
+         :     :  :                 :     :  +- CometFilter
+         :     :  :                 :     :     +- CometNativeScan parquet spark_catalog.default.customer
+         :     :  :                 :     +- CometBroadcastExchange
+         :     :  :                 :        +- CometFilter
+         :     :  :                 :           +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     :  :                 :                 +- CometSubqueryBroadcast
+         :     :  :                 :                    +- CometBroadcastExchange
+         :     :  :                 :                       +- CometFilter
+         :     :  :                 :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :  :                 +- CometBroadcastExchange
+         :     :  :                    +- CometFilter
+         :     :  :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :  +- CometBroadcastExchange
+         :     :     +- CometHashAggregate
+         :     :        +- CometExchange
+         :     :           +- CometHashAggregate
+         :     :              +- CometProject
+         :     :                 +- CometBroadcastHashJoin
+         :     :                    :- CometProject
+         :     :                    :  +- CometBroadcastHashJoin
+         :     :                    :     :- CometProject
+         :     :                    :     :  +- CometFilter
+         :     :                    :     :     +- CometNativeScan parquet spark_catalog.default.customer
+         :     :                    :     +- CometBroadcastExchange
+         :     :                    :        +- CometFilter
+         :     :                    :           +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     :                    :                 +- CometSubqueryBroadcast
+         :     :                    :                    +- CometBroadcastExchange
+         :     :                    :                       +- CometFilter
+         :     :                    :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :                    +- CometBroadcastExchange
+         :     :                       +- CometFilter
+         :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     +- CometBroadcastExchange
+         :        +- CometFilter
+         :           +- CometHashAggregate
+         :              +- CometExchange
+         :                 +- CometHashAggregate
+         :                    +- CometProject
+         :                       +- CometBroadcastHashJoin
+         :                          :- CometProject
+         :                          :  +- CometBroadcastHashJoin
+         :                          :     :- CometProject
+         :                          :     :  +- CometFilter
+         :                          :     :     +- CometNativeScan parquet spark_catalog.default.customer
+         :                          :     +- CometBroadcastExchange
+         :                          :        +- CometFilter
+         :                          :           +- CometNativeScan parquet spark_catalog.default.web_sales
+         :                          :                 +- ReusedSubquery
+         :                          +- CometBroadcastExchange
+         :                             +- CometFilter
+         :                                +- CometNativeScan parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometFilter
+                           :     :     +- CometNativeScan parquet spark_catalog.default.customer
+                           :     +- CometBroadcastExchange
+                           :        +- CometFilter
+                           :           +- CometNativeScan parquet spark_catalog.default.web_sales
+                           :                 +- ReusedSubquery
+                           +- CometBroadcastExchange
+                              +- CometFilter
+                                 +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 81 out of 85 eligible operators (95%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q74.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q74.native_iceberg_compat/extended.txt
@@ -1,0 +1,90 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometBroadcastHashJoin
+         :     :  :- CometFilter
+         :     :  :  +- CometHashAggregate
+         :     :  :     +- CometExchange
+         :     :  :        +- CometHashAggregate
+         :     :  :           +- CometProject
+         :     :  :              +- CometBroadcastHashJoin
+         :     :  :                 :- CometProject
+         :     :  :                 :  +- CometBroadcastHashJoin
+         :     :  :                 :     :- CometProject
+         :     :  :                 :     :  +- CometFilter
+         :     :  :                 :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         :     :  :                 :     +- CometBroadcastExchange
+         :     :  :                 :        +- CometFilter
+         :     :  :                 :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     :  :                 :                 +- SubqueryBroadcast
+         :     :  :                 :                    +- BroadcastExchange
+         :     :  :                 :                       +- CometNativeColumnarToRow
+         :     :  :                 :                          +- CometFilter
+         :     :  :                 :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :  :                 +- CometBroadcastExchange
+         :     :  :                    +- CometFilter
+         :     :  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :  +- CometBroadcastExchange
+         :     :     +- CometHashAggregate
+         :     :        +- CometExchange
+         :     :           +- CometHashAggregate
+         :     :              +- CometProject
+         :     :                 +- CometBroadcastHashJoin
+         :     :                    :- CometProject
+         :     :                    :  +- CometBroadcastHashJoin
+         :     :                    :     :- CometProject
+         :     :                    :     :  +- CometFilter
+         :     :                    :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         :     :                    :     +- CometBroadcastExchange
+         :     :                    :        +- CometFilter
+         :     :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     :                    :                 +- SubqueryBroadcast
+         :     :                    :                    +- BroadcastExchange
+         :     :                    :                       +- CometNativeColumnarToRow
+         :     :                    :                          +- CometFilter
+         :     :                    :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :                    +- CometBroadcastExchange
+         :     :                       +- CometFilter
+         :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     +- CometBroadcastExchange
+         :        +- CometFilter
+         :           +- CometHashAggregate
+         :              +- CometExchange
+         :                 +- CometHashAggregate
+         :                    +- CometProject
+         :                       +- CometBroadcastHashJoin
+         :                          :- CometProject
+         :                          :  +- CometBroadcastHashJoin
+         :                          :     :- CometProject
+         :                          :     :  +- CometFilter
+         :                          :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         :                          :     +- CometBroadcastExchange
+         :                          :        +- CometFilter
+         :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+         :                          :                 +- ReusedSubquery
+         :                          +- CometBroadcastExchange
+         :                             +- CometFilter
+         :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometFilter
+                           :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                           :     +- CometBroadcastExchange
+                           :        +- CometFilter
+                           :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                           :                 +- ReusedSubquery
+                           +- CometBroadcastExchange
+                              +- CometFilter
+                                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 79 out of 85 eligible operators (92%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q75.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q75.native_datafusion/extended.txt
@@ -1,0 +1,170 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometSortMergeJoin
+         :- CometSort
+         :  +- CometExchange
+         :     +- CometFilter
+         :        +- CometHashAggregate
+         :           +- CometExchange
+         :              +- CometHashAggregate
+         :                 +- CometHashAggregate
+         :                    +- CometExchange
+         :                       +- CometHashAggregate
+         :                          +- CometUnion
+         :                             :- CometProject
+         :                             :  +- CometSortMergeJoin
+         :                             :     :- CometSort
+         :                             :     :  +- CometExchange
+         :                             :     :     +- CometProject
+         :                             :     :        +- CometBroadcastHashJoin
+         :                             :     :           :- CometProject
+         :                             :     :           :  +- CometBroadcastHashJoin
+         :                             :     :           :     :- CometFilter
+         :                             :     :           :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+         :                             :     :           :     :        +- CometSubqueryBroadcast
+         :                             :     :           :     :           +- CometBroadcastExchange
+         :                             :     :           :     :              +- CometFilter
+         :                             :     :           :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+         :                             :     :           :     +- CometBroadcastExchange
+         :                             :     :           :        +- CometProject
+         :                             :     :           :           +- CometFilter
+         :                             :     :           :              +- CometNativeScan parquet spark_catalog.default.item
+         :                             :     :           +- CometBroadcastExchange
+         :                             :     :              +- CometFilter
+         :                             :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+         :                             :     +- CometSort
+         :                             :        +- CometExchange
+         :                             :           +- CometProject
+         :                             :              +- CometFilter
+         :                             :                 +- CometNativeScan parquet spark_catalog.default.catalog_returns
+         :                             :- CometProject
+         :                             :  +- CometSortMergeJoin
+         :                             :     :- CometSort
+         :                             :     :  +- CometExchange
+         :                             :     :     +- CometProject
+         :                             :     :        +- CometBroadcastHashJoin
+         :                             :     :           :- CometProject
+         :                             :     :           :  +- CometBroadcastHashJoin
+         :                             :     :           :     :- CometFilter
+         :                             :     :           :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+         :                             :     :           :     :        +- ReusedSubquery
+         :                             :     :           :     +- CometBroadcastExchange
+         :                             :     :           :        +- CometProject
+         :                             :     :           :           +- CometFilter
+         :                             :     :           :              +- CometNativeScan parquet spark_catalog.default.item
+         :                             :     :           +- CometBroadcastExchange
+         :                             :     :              +- CometFilter
+         :                             :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+         :                             :     +- CometSort
+         :                             :        +- CometExchange
+         :                             :           +- CometProject
+         :                             :              +- CometFilter
+         :                             :                 +- CometNativeScan parquet spark_catalog.default.store_returns
+         :                             +- CometProject
+         :                                +- CometSortMergeJoin
+         :                                   :- CometSort
+         :                                   :  +- CometExchange
+         :                                   :     +- CometProject
+         :                                   :        +- CometBroadcastHashJoin
+         :                                   :           :- CometProject
+         :                                   :           :  +- CometBroadcastHashJoin
+         :                                   :           :     :- CometFilter
+         :                                   :           :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+         :                                   :           :     :        +- ReusedSubquery
+         :                                   :           :     +- CometBroadcastExchange
+         :                                   :           :        +- CometProject
+         :                                   :           :           +- CometFilter
+         :                                   :           :              +- CometNativeScan parquet spark_catalog.default.item
+         :                                   :           +- CometBroadcastExchange
+         :                                   :              +- CometFilter
+         :                                   :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+         :                                   +- CometSort
+         :                                      +- CometExchange
+         :                                         +- CometProject
+         :                                            +- CometFilter
+         :                                               +- CometNativeScan parquet spark_catalog.default.web_returns
+         +- CometSort
+            +- CometExchange
+               +- CometFilter
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometHashAggregate
+                              +- CometExchange
+                                 +- CometHashAggregate
+                                    +- CometUnion
+                                       :- CometProject
+                                       :  +- CometSortMergeJoin
+                                       :     :- CometSort
+                                       :     :  +- CometExchange
+                                       :     :     +- CometProject
+                                       :     :        +- CometBroadcastHashJoin
+                                       :     :           :- CometProject
+                                       :     :           :  +- CometBroadcastHashJoin
+                                       :     :           :     :- CometFilter
+                                       :     :           :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                                       :     :           :     :        +- CometSubqueryBroadcast
+                                       :     :           :     :           +- CometBroadcastExchange
+                                       :     :           :     :              +- CometFilter
+                                       :     :           :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       :     :           :     +- CometBroadcastExchange
+                                       :     :           :        +- CometProject
+                                       :     :           :           +- CometFilter
+                                       :     :           :              +- CometNativeScan parquet spark_catalog.default.item
+                                       :     :           +- CometBroadcastExchange
+                                       :     :              +- CometFilter
+                                       :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       :     +- CometSort
+                                       :        +- CometExchange
+                                       :           +- CometProject
+                                       :              +- CometFilter
+                                       :                 +- CometNativeScan parquet spark_catalog.default.catalog_returns
+                                       :- CometProject
+                                       :  +- CometSortMergeJoin
+                                       :     :- CometSort
+                                       :     :  +- CometExchange
+                                       :     :     +- CometProject
+                                       :     :        +- CometBroadcastHashJoin
+                                       :     :           :- CometProject
+                                       :     :           :  +- CometBroadcastHashJoin
+                                       :     :           :     :- CometFilter
+                                       :     :           :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                       :     :           :     :        +- ReusedSubquery
+                                       :     :           :     +- CometBroadcastExchange
+                                       :     :           :        +- CometProject
+                                       :     :           :           +- CometFilter
+                                       :     :           :              +- CometNativeScan parquet spark_catalog.default.item
+                                       :     :           +- CometBroadcastExchange
+                                       :     :              +- CometFilter
+                                       :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       :     +- CometSort
+                                       :        +- CometExchange
+                                       :           +- CometProject
+                                       :              +- CometFilter
+                                       :                 +- CometNativeScan parquet spark_catalog.default.store_returns
+                                       +- CometProject
+                                          +- CometSortMergeJoin
+                                             :- CometSort
+                                             :  +- CometExchange
+                                             :     +- CometProject
+                                             :        +- CometBroadcastHashJoin
+                                             :           :- CometProject
+                                             :           :  +- CometBroadcastHashJoin
+                                             :           :     :- CometFilter
+                                             :           :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                                             :           :     :        +- ReusedSubquery
+                                             :           :     +- CometBroadcastExchange
+                                             :           :        +- CometProject
+                                             :           :           +- CometFilter
+                                             :           :              +- CometNativeScan parquet spark_catalog.default.item
+                                             :           +- CometBroadcastExchange
+                                             :              +- CometFilter
+                                             :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                                             +- CometSort
+                                                +- CometExchange
+                                                   +- CometProject
+                                                      +- CometFilter
+                                                         +- CometNativeScan parquet spark_catalog.default.web_returns
+
+Comet accelerated 161 out of 167 eligible operators (96%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q75.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q75.native_iceberg_compat/extended.txt
@@ -1,0 +1,172 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometSortMergeJoin
+         :- CometSort
+         :  +- CometExchange
+         :     +- CometFilter
+         :        +- CometHashAggregate
+         :           +- CometExchange
+         :              +- CometHashAggregate
+         :                 +- CometHashAggregate
+         :                    +- CometExchange
+         :                       +- CometHashAggregate
+         :                          +- CometUnion
+         :                             :- CometProject
+         :                             :  +- CometSortMergeJoin
+         :                             :     :- CometSort
+         :                             :     :  +- CometExchange
+         :                             :     :     +- CometProject
+         :                             :     :        +- CometBroadcastHashJoin
+         :                             :     :           :- CometProject
+         :                             :     :           :  +- CometBroadcastHashJoin
+         :                             :     :           :     :- CometFilter
+         :                             :     :           :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+         :                             :     :           :     :        +- SubqueryBroadcast
+         :                             :     :           :     :           +- BroadcastExchange
+         :                             :     :           :     :              +- CometNativeColumnarToRow
+         :                             :     :           :     :                 +- CometFilter
+         :                             :     :           :     :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :                             :     :           :     +- CometBroadcastExchange
+         :                             :     :           :        +- CometProject
+         :                             :     :           :           +- CometFilter
+         :                             :     :           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+         :                             :     :           +- CometBroadcastExchange
+         :                             :     :              +- CometFilter
+         :                             :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :                             :     +- CometSort
+         :                             :        +- CometExchange
+         :                             :           +- CometProject
+         :                             :              +- CometFilter
+         :                             :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+         :                             :- CometProject
+         :                             :  +- CometSortMergeJoin
+         :                             :     :- CometSort
+         :                             :     :  +- CometExchange
+         :                             :     :     +- CometProject
+         :                             :     :        +- CometBroadcastHashJoin
+         :                             :     :           :- CometProject
+         :                             :     :           :  +- CometBroadcastHashJoin
+         :                             :     :           :     :- CometFilter
+         :                             :     :           :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :                             :     :           :     :        +- ReusedSubquery
+         :                             :     :           :     +- CometBroadcastExchange
+         :                             :     :           :        +- CometProject
+         :                             :     :           :           +- CometFilter
+         :                             :     :           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+         :                             :     :           +- CometBroadcastExchange
+         :                             :     :              +- CometFilter
+         :                             :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :                             :     +- CometSort
+         :                             :        +- CometExchange
+         :                             :           +- CometProject
+         :                             :              +- CometFilter
+         :                             :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+         :                             +- CometProject
+         :                                +- CometSortMergeJoin
+         :                                   :- CometSort
+         :                                   :  +- CometExchange
+         :                                   :     +- CometProject
+         :                                   :        +- CometBroadcastHashJoin
+         :                                   :           :- CometProject
+         :                                   :           :  +- CometBroadcastHashJoin
+         :                                   :           :     :- CometFilter
+         :                                   :           :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+         :                                   :           :     :        +- ReusedSubquery
+         :                                   :           :     +- CometBroadcastExchange
+         :                                   :           :        +- CometProject
+         :                                   :           :           +- CometFilter
+         :                                   :           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+         :                                   :           +- CometBroadcastExchange
+         :                                   :              +- CometFilter
+         :                                   :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :                                   +- CometSort
+         :                                      +- CometExchange
+         :                                         +- CometProject
+         :                                            +- CometFilter
+         :                                               +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+         +- CometSort
+            +- CometExchange
+               +- CometFilter
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometHashAggregate
+                              +- CometExchange
+                                 +- CometHashAggregate
+                                    +- CometUnion
+                                       :- CometProject
+                                       :  +- CometSortMergeJoin
+                                       :     :- CometSort
+                                       :     :  +- CometExchange
+                                       :     :     +- CometProject
+                                       :     :        +- CometBroadcastHashJoin
+                                       :     :           :- CometProject
+                                       :     :           :  +- CometBroadcastHashJoin
+                                       :     :           :     :- CometFilter
+                                       :     :           :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                                       :     :           :     :        +- SubqueryBroadcast
+                                       :     :           :     :           +- BroadcastExchange
+                                       :     :           :     :              +- CometNativeColumnarToRow
+                                       :     :           :     :                 +- CometFilter
+                                       :     :           :     :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       :     :           :     +- CometBroadcastExchange
+                                       :     :           :        +- CometProject
+                                       :     :           :           +- CometFilter
+                                       :     :           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                       :     :           +- CometBroadcastExchange
+                                       :     :              +- CometFilter
+                                       :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       :     +- CometSort
+                                       :        +- CometExchange
+                                       :           +- CometProject
+                                       :              +- CometFilter
+                                       :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+                                       :- CometProject
+                                       :  +- CometSortMergeJoin
+                                       :     :- CometSort
+                                       :     :  +- CometExchange
+                                       :     :     +- CometProject
+                                       :     :        +- CometBroadcastHashJoin
+                                       :     :           :- CometProject
+                                       :     :           :  +- CometBroadcastHashJoin
+                                       :     :           :     :- CometFilter
+                                       :     :           :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                       :     :           :     :        +- ReusedSubquery
+                                       :     :           :     +- CometBroadcastExchange
+                                       :     :           :        +- CometProject
+                                       :     :           :           +- CometFilter
+                                       :     :           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                       :     :           +- CometBroadcastExchange
+                                       :     :              +- CometFilter
+                                       :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       :     +- CometSort
+                                       :        +- CometExchange
+                                       :           +- CometProject
+                                       :              +- CometFilter
+                                       :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+                                       +- CometProject
+                                          +- CometSortMergeJoin
+                                             :- CometSort
+                                             :  +- CometExchange
+                                             :     +- CometProject
+                                             :        +- CometBroadcastHashJoin
+                                             :           :- CometProject
+                                             :           :  +- CometBroadcastHashJoin
+                                             :           :     :- CometFilter
+                                             :           :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                             :           :     :        +- ReusedSubquery
+                                             :           :     +- CometBroadcastExchange
+                                             :           :        +- CometProject
+                                             :           :           +- CometFilter
+                                             :           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                             :           +- CometBroadcastExchange
+                                             :              +- CometFilter
+                                             :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                             +- CometSort
+                                                +- CometExchange
+                                                   +- CometProject
+                                                      +- CometFilter
+                                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+
+Comet accelerated 159 out of 167 eligible operators (95%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q76.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q76.native_datafusion/extended.txt
@@ -1,0 +1,47 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometUnion
+               :- CometProject
+               :  +- CometBroadcastHashJoin
+               :     :- CometProject
+               :     :  +- CometBroadcastHashJoin
+               :     :     :- CometFilter
+               :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :     :     +- CometBroadcastExchange
+               :     :        +- CometProject
+               :     :           +- CometFilter
+               :     :              +- CometNativeScan parquet spark_catalog.default.item
+               :     +- CometBroadcastExchange
+               :        +- CometFilter
+               :           +- CometNativeScan parquet spark_catalog.default.date_dim
+               :- CometProject
+               :  +- CometBroadcastHashJoin
+               :     :- CometProject
+               :     :  +- CometBroadcastHashJoin
+               :     :     :- CometFilter
+               :     :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :     :     +- CometBroadcastExchange
+               :     :        +- CometProject
+               :     :           +- CometFilter
+               :     :              +- CometNativeScan parquet spark_catalog.default.item
+               :     +- CometBroadcastExchange
+               :        +- CometFilter
+               :           +- CometNativeScan parquet spark_catalog.default.date_dim
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometFilter
+                     :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              +- CometNativeScan parquet spark_catalog.default.item
+                     +- CometBroadcastExchange
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 44 out of 44 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q76.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q76.native_iceberg_compat/extended.txt
@@ -1,0 +1,47 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometUnion
+               :- CometProject
+               :  +- CometBroadcastHashJoin
+               :     :- CometProject
+               :     :  +- CometBroadcastHashJoin
+               :     :     :- CometFilter
+               :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :     :     +- CometBroadcastExchange
+               :     :        +- CometProject
+               :     :           +- CometFilter
+               :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :     +- CometBroadcastExchange
+               :        +- CometFilter
+               :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :- CometProject
+               :  +- CometBroadcastHashJoin
+               :     :- CometProject
+               :     :  +- CometBroadcastHashJoin
+               :     :     :- CometFilter
+               :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :     :     +- CometBroadcastExchange
+               :     :        +- CometProject
+               :     :           +- CometFilter
+               :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :     +- CometBroadcastExchange
+               :        +- CometFilter
+               :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometFilter
+                     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                     +- CometBroadcastExchange
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 44 out of 44 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q77.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q77.native_datafusion/extended.txt
@@ -1,0 +1,115 @@
+TakeOrderedAndProject
++- HashAggregate
+   +- Exchange
+      +- HashAggregate
+         +- Expand
+            +- Union
+               :- CometNativeColumnarToRow
+               :  +- CometProject
+               :     +- CometBroadcastHashJoin
+               :        :- CometHashAggregate
+               :        :  +- CometExchange
+               :        :     +- CometHashAggregate
+               :        :        +- CometProject
+               :        :           +- CometBroadcastHashJoin
+               :        :              :- CometProject
+               :        :              :  +- CometBroadcastHashJoin
+               :        :              :     :- CometFilter
+               :        :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :        :              :     :        +- CometSubqueryBroadcast
+               :        :              :     :           +- CometBroadcastExchange
+               :        :              :     :              +- CometProject
+               :        :              :     :                 +- CometFilter
+               :        :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :              :     +- CometBroadcastExchange
+               :        :              :        +- CometProject
+               :        :              :           +- CometFilter
+               :        :              :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :              +- CometBroadcastExchange
+               :        :                 +- CometFilter
+               :        :                    +- CometNativeScan parquet spark_catalog.default.store
+               :        +- CometBroadcastExchange
+               :           +- CometHashAggregate
+               :              +- CometExchange
+               :                 +- CometHashAggregate
+               :                    +- CometProject
+               :                       +- CometBroadcastHashJoin
+               :                          :- CometProject
+               :                          :  +- CometBroadcastHashJoin
+               :                          :     :- CometFilter
+               :                          :     :  +- CometNativeScan parquet spark_catalog.default.store_returns
+               :                          :     :        +- ReusedSubquery
+               :                          :     +- CometBroadcastExchange
+               :                          :        +- CometProject
+               :                          :           +- CometFilter
+               :                          :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                          +- CometBroadcastExchange
+               :                             +- CometFilter
+               :                                +- CometNativeScan parquet spark_catalog.default.store
+               :- Project
+               :  +-  BroadcastNestedLoopJoin [COMET: BroadcastNestedLoopJoin is not supported]
+               :     :- BroadcastExchange
+               :     :  +- CometNativeColumnarToRow
+               :     :     +- CometHashAggregate
+               :     :        +- CometExchange
+               :     :           +- CometHashAggregate
+               :     :              +- CometProject
+               :     :                 +- CometBroadcastHashJoin
+               :     :                    :- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :     :                    :     +- ReusedSubquery
+               :     :                    +- CometBroadcastExchange
+               :     :                       +- CometProject
+               :     :                          +- CometFilter
+               :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     +- CometNativeColumnarToRow
+               :        +- CometHashAggregate
+               :           +- CometExchange
+               :              +- CometHashAggregate
+               :                 +- CometProject
+               :                    +- CometBroadcastHashJoin
+               :                       :- CometNativeScan parquet spark_catalog.default.catalog_returns
+               :                       :     +- ReusedSubquery
+               :                       +- CometBroadcastExchange
+               :                          +- CometProject
+               :                             +- CometFilter
+               :                                +- CometNativeScan parquet spark_catalog.default.date_dim
+               +- CometNativeColumnarToRow
+                  +- CometProject
+                     +- CometBroadcastHashJoin
+                        :- CometHashAggregate
+                        :  +- CometExchange
+                        :     +- CometHashAggregate
+                        :        +- CometProject
+                        :           +- CometBroadcastHashJoin
+                        :              :- CometProject
+                        :              :  +- CometBroadcastHashJoin
+                        :              :     :- CometFilter
+                        :              :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                        :              :     :        +- ReusedSubquery
+                        :              :     +- CometBroadcastExchange
+                        :              :        +- CometProject
+                        :              :           +- CometFilter
+                        :              :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                        :              +- CometBroadcastExchange
+                        :                 +- CometFilter
+                        :                    +- CometNativeScan parquet spark_catalog.default.web_page
+                        +- CometBroadcastExchange
+                           +- CometHashAggregate
+                              +- CometExchange
+                                 +- CometHashAggregate
+                                    +- CometProject
+                                       +- CometBroadcastHashJoin
+                                          :- CometProject
+                                          :  +- CometBroadcastHashJoin
+                                          :     :- CometFilter
+                                          :     :  +- CometNativeScan parquet spark_catalog.default.web_returns
+                                          :     :        +- ReusedSubquery
+                                          :     +- CometBroadcastExchange
+                                          :        +- CometProject
+                                          :           +- CometFilter
+                                          :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                          +- CometBroadcastExchange
+                                             +- CometFilter
+                                                +- CometNativeScan parquet spark_catalog.default.web_page
+
+Comet accelerated 94 out of 109 eligible operators (86%). Final plan contains 4 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q77.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q77.native_iceberg_compat/extended.txt
@@ -1,0 +1,116 @@
+TakeOrderedAndProject
++- HashAggregate
+   +- Exchange
+      +- HashAggregate
+         +- Expand
+            +- Union
+               :- CometNativeColumnarToRow
+               :  +- CometProject
+               :     +- CometBroadcastHashJoin
+               :        :- CometHashAggregate
+               :        :  +- CometExchange
+               :        :     +- CometHashAggregate
+               :        :        +- CometProject
+               :        :           +- CometBroadcastHashJoin
+               :        :              :- CometProject
+               :        :              :  +- CometBroadcastHashJoin
+               :        :              :     :- CometFilter
+               :        :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :        :              :     :        +- SubqueryBroadcast
+               :        :              :     :           +- BroadcastExchange
+               :        :              :     :              +- CometNativeColumnarToRow
+               :        :              :     :                 +- CometProject
+               :        :              :     :                    +- CometFilter
+               :        :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :              :     +- CometBroadcastExchange
+               :        :              :        +- CometProject
+               :        :              :           +- CometFilter
+               :        :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :              +- CometBroadcastExchange
+               :        :                 +- CometFilter
+               :        :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+               :        +- CometBroadcastExchange
+               :           +- CometHashAggregate
+               :              +- CometExchange
+               :                 +- CometHashAggregate
+               :                    +- CometProject
+               :                       +- CometBroadcastHashJoin
+               :                          :- CometProject
+               :                          :  +- CometBroadcastHashJoin
+               :                          :     :- CometFilter
+               :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+               :                          :     :        +- ReusedSubquery
+               :                          :     +- CometBroadcastExchange
+               :                          :        +- CometProject
+               :                          :           +- CometFilter
+               :                          :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                          +- CometBroadcastExchange
+               :                             +- CometFilter
+               :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+               :- Project
+               :  +-  BroadcastNestedLoopJoin [COMET: BroadcastNestedLoopJoin is not supported]
+               :     :- BroadcastExchange
+               :     :  +- CometNativeColumnarToRow
+               :     :     +- CometHashAggregate
+               :     :        +- CometExchange
+               :     :           +- CometHashAggregate
+               :     :              +- CometProject
+               :     :                 +- CometBroadcastHashJoin
+               :     :                    :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :     :                    :     +- ReusedSubquery
+               :     :                    +- CometBroadcastExchange
+               :     :                       +- CometProject
+               :     :                          +- CometFilter
+               :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     +- CometNativeColumnarToRow
+               :        +- CometHashAggregate
+               :           +- CometExchange
+               :              +- CometHashAggregate
+               :                 +- CometProject
+               :                    +- CometBroadcastHashJoin
+               :                       :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+               :                       :     +- ReusedSubquery
+               :                       +- CometBroadcastExchange
+               :                          +- CometProject
+               :                             +- CometFilter
+               :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               +- CometNativeColumnarToRow
+                  +- CometProject
+                     +- CometBroadcastHashJoin
+                        :- CometHashAggregate
+                        :  +- CometExchange
+                        :     +- CometHashAggregate
+                        :        +- CometProject
+                        :           +- CometBroadcastHashJoin
+                        :              :- CometProject
+                        :              :  +- CometBroadcastHashJoin
+                        :              :     :- CometFilter
+                        :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                        :              :     :        +- ReusedSubquery
+                        :              :     +- CometBroadcastExchange
+                        :              :        +- CometProject
+                        :              :           +- CometFilter
+                        :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                        :              +- CometBroadcastExchange
+                        :                 +- CometFilter
+                        :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_page
+                        +- CometBroadcastExchange
+                           +- CometHashAggregate
+                              +- CometExchange
+                                 +- CometHashAggregate
+                                    +- CometProject
+                                       +- CometBroadcastHashJoin
+                                          :- CometProject
+                                          :  +- CometBroadcastHashJoin
+                                          :     :- CometFilter
+                                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+                                          :     :        +- ReusedSubquery
+                                          :     +- CometBroadcastExchange
+                                          :        +- CometProject
+                                          :           +- CometFilter
+                                          :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                          +- CometBroadcastExchange
+                                             +- CometFilter
+                                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_page
+
+Comet accelerated 93 out of 109 eligible operators (85%). Final plan contains 5 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q78.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q78.native_datafusion/extended.txt
@@ -1,0 +1,79 @@
+TakeOrderedAndProject
++-  Project [COMET: Comet does not support Spark's BigDecimal rounding]
+   +- CometNativeColumnarToRow
+      +- CometSortMergeJoin
+         :- CometProject
+         :  +- CometSortMergeJoin
+         :     :- CometSort
+         :     :  +- CometHashAggregate
+         :     :     +- CometExchange
+         :     :        +- CometHashAggregate
+         :     :           +- CometProject
+         :     :              +- CometBroadcastHashJoin
+         :     :                 :- CometProject
+         :     :                 :  +- CometFilter
+         :     :                 :     +- CometSortMergeJoin
+         :     :                 :        :- CometSort
+         :     :                 :        :  +- CometExchange
+         :     :                 :        :     +- CometFilter
+         :     :                 :        :        +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     :                 :        :              +- CometSubqueryBroadcast
+         :     :                 :        :                 +- CometBroadcastExchange
+         :     :                 :        :                    +- CometFilter
+         :     :                 :        :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :                 :        +- CometSort
+         :     :                 :           +- CometExchange
+         :     :                 :              +- CometProject
+         :     :                 :                 +- CometFilter
+         :     :                 :                    +- CometNativeScan parquet spark_catalog.default.store_returns
+         :     :                 +- CometBroadcastExchange
+         :     :                    +- CometFilter
+         :     :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     +- CometSort
+         :        +- CometFilter
+         :           +- CometHashAggregate
+         :              +- CometExchange
+         :                 +- CometHashAggregate
+         :                    +- CometProject
+         :                       +- CometBroadcastHashJoin
+         :                          :- CometProject
+         :                          :  +- CometFilter
+         :                          :     +- CometSortMergeJoin
+         :                          :        :- CometSort
+         :                          :        :  +- CometExchange
+         :                          :        :     +- CometFilter
+         :                          :        :        +- CometNativeScan parquet spark_catalog.default.web_sales
+         :                          :        :              +- ReusedSubquery
+         :                          :        +- CometSort
+         :                          :           +- CometExchange
+         :                          :              +- CometProject
+         :                          :                 +- CometFilter
+         :                          :                    +- CometNativeScan parquet spark_catalog.default.web_returns
+         :                          +- CometBroadcastExchange
+         :                             +- CometFilter
+         :                                +- CometNativeScan parquet spark_catalog.default.date_dim
+         +- CometSort
+            +- CometFilter
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometFilter
+                              :     +- CometSortMergeJoin
+                              :        :- CometSort
+                              :        :  +- CometExchange
+                              :        :     +- CometFilter
+                              :        :        +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                              :        :              +- ReusedSubquery
+                              :        +- CometSort
+                              :           +- CometExchange
+                              :              +- CometProject
+                              :                 +- CometFilter
+                              :                    +- CometNativeScan parquet spark_catalog.default.catalog_returns
+                              +- CometBroadcastExchange
+                                 +- CometFilter
+                                    +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 71 out of 76 eligible operators (93%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q78.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q78.native_iceberg_compat/extended.txt
@@ -1,0 +1,80 @@
+TakeOrderedAndProject
++-  Project [COMET: Comet does not support Spark's BigDecimal rounding]
+   +- CometNativeColumnarToRow
+      +- CometSortMergeJoin
+         :- CometProject
+         :  +- CometSortMergeJoin
+         :     :- CometSort
+         :     :  +- CometHashAggregate
+         :     :     +- CometExchange
+         :     :        +- CometHashAggregate
+         :     :           +- CometProject
+         :     :              +- CometBroadcastHashJoin
+         :     :                 :- CometProject
+         :     :                 :  +- CometFilter
+         :     :                 :     +- CometSortMergeJoin
+         :     :                 :        :- CometSort
+         :     :                 :        :  +- CometExchange
+         :     :                 :        :     +- CometFilter
+         :     :                 :        :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     :                 :        :              +- SubqueryBroadcast
+         :     :                 :        :                 +- BroadcastExchange
+         :     :                 :        :                    +- CometNativeColumnarToRow
+         :     :                 :        :                       +- CometFilter
+         :     :                 :        :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :                 :        +- CometSort
+         :     :                 :           +- CometExchange
+         :     :                 :              +- CometProject
+         :     :                 :                 +- CometFilter
+         :     :                 :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+         :     :                 +- CometBroadcastExchange
+         :     :                    +- CometFilter
+         :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     +- CometSort
+         :        +- CometFilter
+         :           +- CometHashAggregate
+         :              +- CometExchange
+         :                 +- CometHashAggregate
+         :                    +- CometProject
+         :                       +- CometBroadcastHashJoin
+         :                          :- CometProject
+         :                          :  +- CometFilter
+         :                          :     +- CometSortMergeJoin
+         :                          :        :- CometSort
+         :                          :        :  +- CometExchange
+         :                          :        :     +- CometFilter
+         :                          :        :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+         :                          :        :              +- ReusedSubquery
+         :                          :        +- CometSort
+         :                          :           +- CometExchange
+         :                          :              +- CometProject
+         :                          :                 +- CometFilter
+         :                          :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+         :                          +- CometBroadcastExchange
+         :                             +- CometFilter
+         :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         +- CometSort
+            +- CometFilter
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometFilter
+                              :     +- CometSortMergeJoin
+                              :        :- CometSort
+                              :        :  +- CometExchange
+                              :        :     +- CometFilter
+                              :        :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                              :        :              +- ReusedSubquery
+                              :        +- CometSort
+                              :           +- CometExchange
+                              :              +- CometProject
+                              :                 +- CometFilter
+                              :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+                              +- CometBroadcastExchange
+                                 +- CometFilter
+                                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 70 out of 76 eligible operators (92%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q79.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q79.native_datafusion/extended.txt
@@ -1,0 +1,38 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometHashAggregate
+         :  +- CometExchange
+         :     +- CometHashAggregate
+         :        +- CometProject
+         :           +- CometBroadcastHashJoin
+         :              :- CometProject
+         :              :  +- CometBroadcastHashJoin
+         :              :     :- CometProject
+         :              :     :  +- CometBroadcastHashJoin
+         :              :     :     :- CometFilter
+         :              :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+         :              :     :     :        +- CometSubqueryBroadcast
+         :              :     :     :           +- CometBroadcastExchange
+         :              :     :     :              +- CometProject
+         :              :     :     :                 +- CometFilter
+         :              :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+         :              :     :     +- CometBroadcastExchange
+         :              :     :        +- CometProject
+         :              :     :           +- CometFilter
+         :              :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+         :              :     +- CometBroadcastExchange
+         :              :        +- CometProject
+         :              :           +- CometFilter
+         :              :              +- CometNativeScan parquet spark_catalog.default.store
+         :              +- CometBroadcastExchange
+         :                 +- CometProject
+         :                    +- CometFilter
+         :                       +- CometNativeScan parquet spark_catalog.default.household_demographics
+         +- CometBroadcastExchange
+            +- CometProject
+               +- CometFilter
+                  +- CometNativeScan parquet spark_catalog.default.customer
+
+Comet accelerated 34 out of 35 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q79.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q79.native_iceberg_compat/extended.txt
@@ -1,0 +1,39 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometHashAggregate
+         :  +- CometExchange
+         :     +- CometHashAggregate
+         :        +- CometProject
+         :           +- CometBroadcastHashJoin
+         :              :- CometProject
+         :              :  +- CometBroadcastHashJoin
+         :              :     :- CometProject
+         :              :     :  +- CometBroadcastHashJoin
+         :              :     :     :- CometFilter
+         :              :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :              :     :     :        +- SubqueryBroadcast
+         :              :     :     :           +- BroadcastExchange
+         :              :     :     :              +- CometNativeColumnarToRow
+         :              :     :     :                 +- CometProject
+         :              :     :     :                    +- CometFilter
+         :              :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :              :     :     +- CometBroadcastExchange
+         :              :     :        +- CometProject
+         :              :     :           +- CometFilter
+         :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :              :     +- CometBroadcastExchange
+         :              :        +- CometProject
+         :              :           +- CometFilter
+         :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+         :              +- CometBroadcastExchange
+         :                 +- CometProject
+         :                    +- CometFilter
+         :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+         +- CometBroadcastExchange
+            +- CometProject
+               +- CometFilter
+                  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+
+Comet accelerated 33 out of 35 eligible operators (94%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q8.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q8.native_datafusion/extended.txt
@@ -1,0 +1,51 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometFilter
+                  :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                  :     :     :        +- CometSubqueryBroadcast
+                  :     :     :           +- CometBroadcastExchange
+                  :     :     :              +- CometProject
+                  :     :     :                 +- CometFilter
+                  :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometNativeScan parquet spark_catalog.default.store
+                  +- CometBroadcastExchange
+                     +- CometHashAggregate
+                        +- CometExchange
+                           +- CometHashAggregate
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometFilter
+                                 :     +- CometNativeScan parquet spark_catalog.default.customer_address
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometHashAggregate
+                                             +- CometExchange
+                                                +- CometHashAggregate
+                                                   +- CometProject
+                                                      +- CometBroadcastHashJoin
+                                                         :- CometProject
+                                                         :  +- CometFilter
+                                                         :     +- CometNativeScan parquet spark_catalog.default.customer_address
+                                                         +- CometBroadcastExchange
+                                                            +- CometProject
+                                                               +- CometFilter
+                                                                  +- CometNativeScan parquet spark_catalog.default.customer
+
+Comet accelerated 47 out of 48 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q8.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q8.native_iceberg_compat/extended.txt
@@ -1,0 +1,52 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometFilter
+                  :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :     :     :        +- SubqueryBroadcast
+                  :     :     :           +- BroadcastExchange
+                  :     :     :              +- CometNativeColumnarToRow
+                  :     :     :                 +- CometProject
+                  :     :     :                    +- CometFilter
+                  :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                  +- CometBroadcastExchange
+                     +- CometHashAggregate
+                        +- CometExchange
+                           +- CometHashAggregate
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometFilter
+                                 :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometHashAggregate
+                                             +- CometExchange
+                                                +- CometHashAggregate
+                                                   +- CometProject
+                                                      +- CometBroadcastHashJoin
+                                                         :- CometProject
+                                                         :  +- CometFilter
+                                                         :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                                                         +- CometBroadcastExchange
+                                                            +- CometProject
+                                                               +- CometFilter
+                                                                  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+
+Comet accelerated 46 out of 48 eligible operators (95%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q80.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q80.native_datafusion/extended.txt
@@ -1,0 +1,130 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometExpand
+               +- CometUnion
+                  :- CometHashAggregate
+                  :  +- CometExchange
+                  :     +- CometHashAggregate
+                  :        +- CometProject
+                  :           +- CometBroadcastHashJoin
+                  :              :- CometProject
+                  :              :  +- CometBroadcastHashJoin
+                  :              :     :- CometProject
+                  :              :     :  +- CometBroadcastHashJoin
+                  :              :     :     :- CometProject
+                  :              :     :     :  +- CometBroadcastHashJoin
+                  :              :     :     :     :- CometProject
+                  :              :     :     :     :  +- CometSortMergeJoin
+                  :              :     :     :     :     :- CometSort
+                  :              :     :     :     :     :  +- CometExchange
+                  :              :     :     :     :     :     +- CometFilter
+                  :              :     :     :     :     :        +- CometNativeScan parquet spark_catalog.default.store_sales
+                  :              :     :     :     :     :              +- CometSubqueryBroadcast
+                  :              :     :     :     :     :                 +- CometBroadcastExchange
+                  :              :     :     :     :     :                    +- CometProject
+                  :              :     :     :     :     :                       +- CometFilter
+                  :              :     :     :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :              :     :     :     :     +- CometSort
+                  :              :     :     :     :        +- CometExchange
+                  :              :     :     :     :           +- CometProject
+                  :              :     :     :     :              +- CometFilter
+                  :              :     :     :     :                 +- CometNativeScan parquet spark_catalog.default.store_returns
+                  :              :     :     :     +- CometBroadcastExchange
+                  :              :     :     :        +- CometProject
+                  :              :     :     :           +- CometFilter
+                  :              :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :              :     :     +- CometBroadcastExchange
+                  :              :     :        +- CometProject
+                  :              :     :           +- CometFilter
+                  :              :     :              +- CometNativeScan parquet spark_catalog.default.store
+                  :              :     +- CometBroadcastExchange
+                  :              :        +- CometProject
+                  :              :           +- CometFilter
+                  :              :              +- CometNativeScan parquet spark_catalog.default.item
+                  :              +- CometBroadcastExchange
+                  :                 +- CometProject
+                  :                    +- CometFilter
+                  :                       +- CometNativeScan parquet spark_catalog.default.promotion
+                  :- CometHashAggregate
+                  :  +- CometExchange
+                  :     +- CometHashAggregate
+                  :        +- CometProject
+                  :           +- CometBroadcastHashJoin
+                  :              :- CometProject
+                  :              :  +- CometBroadcastHashJoin
+                  :              :     :- CometProject
+                  :              :     :  +- CometBroadcastHashJoin
+                  :              :     :     :- CometProject
+                  :              :     :     :  +- CometBroadcastHashJoin
+                  :              :     :     :     :- CometProject
+                  :              :     :     :     :  +- CometSortMergeJoin
+                  :              :     :     :     :     :- CometSort
+                  :              :     :     :     :     :  +- CometExchange
+                  :              :     :     :     :     :     +- CometFilter
+                  :              :     :     :     :     :        +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                  :              :     :     :     :     :              +- ReusedSubquery
+                  :              :     :     :     :     +- CometSort
+                  :              :     :     :     :        +- CometExchange
+                  :              :     :     :     :           +- CometProject
+                  :              :     :     :     :              +- CometFilter
+                  :              :     :     :     :                 +- CometNativeScan parquet spark_catalog.default.catalog_returns
+                  :              :     :     :     +- CometBroadcastExchange
+                  :              :     :     :        +- CometProject
+                  :              :     :     :           +- CometFilter
+                  :              :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :              :     :     +- CometBroadcastExchange
+                  :              :     :        +- CometProject
+                  :              :     :           +- CometFilter
+                  :              :     :              +- CometNativeScan parquet spark_catalog.default.catalog_page
+                  :              :     +- CometBroadcastExchange
+                  :              :        +- CometProject
+                  :              :           +- CometFilter
+                  :              :              +- CometNativeScan parquet spark_catalog.default.item
+                  :              +- CometBroadcastExchange
+                  :                 +- CometProject
+                  :                    +- CometFilter
+                  :                       +- CometNativeScan parquet spark_catalog.default.promotion
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometProject
+                                 :     :  +- CometBroadcastHashJoin
+                                 :     :     :- CometProject
+                                 :     :     :  +- CometBroadcastHashJoin
+                                 :     :     :     :- CometProject
+                                 :     :     :     :  +- CometSortMergeJoin
+                                 :     :     :     :     :- CometSort
+                                 :     :     :     :     :  +- CometExchange
+                                 :     :     :     :     :     +- CometFilter
+                                 :     :     :     :     :        +- CometNativeScan parquet spark_catalog.default.web_sales
+                                 :     :     :     :     :              +- ReusedSubquery
+                                 :     :     :     :     +- CometSort
+                                 :     :     :     :        +- CometExchange
+                                 :     :     :     :           +- CometProject
+                                 :     :     :     :              +- CometFilter
+                                 :     :     :     :                 +- CometNativeScan parquet spark_catalog.default.web_returns
+                                 :     :     :     +- CometBroadcastExchange
+                                 :     :     :        +- CometProject
+                                 :     :     :           +- CometFilter
+                                 :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :     :     +- CometBroadcastExchange
+                                 :     :        +- CometProject
+                                 :     :           +- CometFilter
+                                 :     :              +- CometNativeScan parquet spark_catalog.default.web_site
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometProject
+                                 :           +- CometFilter
+                                 :              +- CometNativeScan parquet spark_catalog.default.item
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometNativeScan parquet spark_catalog.default.promotion
+
+Comet accelerated 124 out of 127 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q80.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q80.native_iceberg_compat/extended.txt
@@ -1,0 +1,131 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometExpand
+               +- CometUnion
+                  :- CometHashAggregate
+                  :  +- CometExchange
+                  :     +- CometHashAggregate
+                  :        +- CometProject
+                  :           +- CometBroadcastHashJoin
+                  :              :- CometProject
+                  :              :  +- CometBroadcastHashJoin
+                  :              :     :- CometProject
+                  :              :     :  +- CometBroadcastHashJoin
+                  :              :     :     :- CometProject
+                  :              :     :     :  +- CometBroadcastHashJoin
+                  :              :     :     :     :- CometProject
+                  :              :     :     :     :  +- CometSortMergeJoin
+                  :              :     :     :     :     :- CometSort
+                  :              :     :     :     :     :  +- CometExchange
+                  :              :     :     :     :     :     +- CometFilter
+                  :              :     :     :     :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :              :     :     :     :     :              +- SubqueryBroadcast
+                  :              :     :     :     :     :                 +- BroadcastExchange
+                  :              :     :     :     :     :                    +- CometNativeColumnarToRow
+                  :              :     :     :     :     :                       +- CometProject
+                  :              :     :     :     :     :                          +- CometFilter
+                  :              :     :     :     :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :              :     :     :     :     +- CometSort
+                  :              :     :     :     :        +- CometExchange
+                  :              :     :     :     :           +- CometProject
+                  :              :     :     :     :              +- CometFilter
+                  :              :     :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+                  :              :     :     :     +- CometBroadcastExchange
+                  :              :     :     :        +- CometProject
+                  :              :     :     :           +- CometFilter
+                  :              :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :              :     :     +- CometBroadcastExchange
+                  :              :     :        +- CometProject
+                  :              :     :           +- CometFilter
+                  :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                  :              :     +- CometBroadcastExchange
+                  :              :        +- CometProject
+                  :              :           +- CometFilter
+                  :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :              +- CometBroadcastExchange
+                  :                 +- CometProject
+                  :                    +- CometFilter
+                  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+                  :- CometHashAggregate
+                  :  +- CometExchange
+                  :     +- CometHashAggregate
+                  :        +- CometProject
+                  :           +- CometBroadcastHashJoin
+                  :              :- CometProject
+                  :              :  +- CometBroadcastHashJoin
+                  :              :     :- CometProject
+                  :              :     :  +- CometBroadcastHashJoin
+                  :              :     :     :- CometProject
+                  :              :     :     :  +- CometBroadcastHashJoin
+                  :              :     :     :     :- CometProject
+                  :              :     :     :     :  +- CometSortMergeJoin
+                  :              :     :     :     :     :- CometSort
+                  :              :     :     :     :     :  +- CometExchange
+                  :              :     :     :     :     :     +- CometFilter
+                  :              :     :     :     :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                  :              :     :     :     :     :              +- ReusedSubquery
+                  :              :     :     :     :     +- CometSort
+                  :              :     :     :     :        +- CometExchange
+                  :              :     :     :     :           +- CometProject
+                  :              :     :     :     :              +- CometFilter
+                  :              :     :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+                  :              :     :     :     +- CometBroadcastExchange
+                  :              :     :     :        +- CometProject
+                  :              :     :     :           +- CometFilter
+                  :              :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :              :     :     +- CometBroadcastExchange
+                  :              :     :        +- CometProject
+                  :              :     :           +- CometFilter
+                  :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_page
+                  :              :     +- CometBroadcastExchange
+                  :              :        +- CometProject
+                  :              :           +- CometFilter
+                  :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :              +- CometBroadcastExchange
+                  :                 +- CometProject
+                  :                    +- CometFilter
+                  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometProject
+                                 :     :  +- CometBroadcastHashJoin
+                                 :     :     :- CometProject
+                                 :     :     :  +- CometBroadcastHashJoin
+                                 :     :     :     :- CometProject
+                                 :     :     :     :  +- CometSortMergeJoin
+                                 :     :     :     :     :- CometSort
+                                 :     :     :     :     :  +- CometExchange
+                                 :     :     :     :     :     +- CometFilter
+                                 :     :     :     :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                 :     :     :     :     :              +- ReusedSubquery
+                                 :     :     :     :     +- CometSort
+                                 :     :     :     :        +- CometExchange
+                                 :     :     :     :           +- CometProject
+                                 :     :     :     :              +- CometFilter
+                                 :     :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+                                 :     :     :     +- CometBroadcastExchange
+                                 :     :     :        +- CometProject
+                                 :     :     :           +- CometFilter
+                                 :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :     :     +- CometBroadcastExchange
+                                 :     :        +- CometProject
+                                 :     :           +- CometFilter
+                                 :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_site
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometProject
+                                 :           +- CometFilter
+                                 :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+
+Comet accelerated 123 out of 127 eligible operators (96%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q81.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q81.native_datafusion/extended.txt
@@ -1,0 +1,64 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometProject
+         :     :  +- CometBroadcastHashJoin
+         :     :     :- CometFilter
+         :     :     :  +- CometHashAggregate
+         :     :     :     +- CometExchange
+         :     :     :        +- CometHashAggregate
+         :     :     :           +- CometProject
+         :     :     :              +- CometBroadcastHashJoin
+         :     :     :                 :- CometProject
+         :     :     :                 :  +- CometBroadcastHashJoin
+         :     :     :                 :     :- CometFilter
+         :     :     :                 :     :  +- CometNativeScan parquet spark_catalog.default.catalog_returns
+         :     :     :                 :     :        +- CometSubqueryBroadcast
+         :     :     :                 :     :           +- CometBroadcastExchange
+         :     :     :                 :     :              +- CometProject
+         :     :     :                 :     :                 +- CometFilter
+         :     :     :                 :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :     :                 :     +- CometBroadcastExchange
+         :     :     :                 :        +- CometProject
+         :     :     :                 :           +- CometFilter
+         :     :     :                 :              +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :     :                 +- CometBroadcastExchange
+         :     :     :                    +- CometProject
+         :     :     :                       +- CometFilter
+         :     :     :                          +- CometNativeScan parquet spark_catalog.default.customer_address
+         :     :     +- CometBroadcastExchange
+         :     :        +- CometFilter
+         :     :           +- CometHashAggregate
+         :     :              +- CometExchange
+         :     :                 +- CometHashAggregate
+         :     :                    +- CometHashAggregate
+         :     :                       +- CometExchange
+         :     :                          +- CometHashAggregate
+         :     :                             +- CometProject
+         :     :                                +- CometBroadcastHashJoin
+         :     :                                   :- CometProject
+         :     :                                   :  +- CometBroadcastHashJoin
+         :     :                                   :     :- CometFilter
+         :     :                                   :     :  +- CometNativeScan parquet spark_catalog.default.catalog_returns
+         :     :                                   :     :        +- ReusedSubquery
+         :     :                                   :     +- CometBroadcastExchange
+         :     :                                   :        +- CometProject
+         :     :                                   :           +- CometFilter
+         :     :                                   :              +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :                                   +- CometBroadcastExchange
+         :     :                                      +- CometProject
+         :     :                                         +- CometFilter
+         :     :                                            +- CometNativeScan parquet spark_catalog.default.customer_address
+         :     +- CometBroadcastExchange
+         :        +- CometProject
+         :           +- CometFilter
+         :              +- CometNativeScan parquet spark_catalog.default.customer
+         +- CometBroadcastExchange
+            +- CometProject
+               +- CometFilter
+                  +- CometNativeScan parquet spark_catalog.default.customer_address
+
+Comet accelerated 59 out of 61 eligible operators (96%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q81.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q81.native_iceberg_compat/extended.txt
@@ -1,0 +1,65 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometProject
+         :     :  +- CometBroadcastHashJoin
+         :     :     :- CometFilter
+         :     :     :  +- CometHashAggregate
+         :     :     :     +- CometExchange
+         :     :     :        +- CometHashAggregate
+         :     :     :           +- CometProject
+         :     :     :              +- CometBroadcastHashJoin
+         :     :     :                 :- CometProject
+         :     :     :                 :  +- CometBroadcastHashJoin
+         :     :     :                 :     :- CometFilter
+         :     :     :                 :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+         :     :     :                 :     :        +- SubqueryBroadcast
+         :     :     :                 :     :           +- BroadcastExchange
+         :     :     :                 :     :              +- CometNativeColumnarToRow
+         :     :     :                 :     :                 +- CometProject
+         :     :     :                 :     :                    +- CometFilter
+         :     :     :                 :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :     :                 :     +- CometBroadcastExchange
+         :     :     :                 :        +- CometProject
+         :     :     :                 :           +- CometFilter
+         :     :     :                 :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :     :                 +- CometBroadcastExchange
+         :     :     :                    +- CometProject
+         :     :     :                       +- CometFilter
+         :     :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+         :     :     +- CometBroadcastExchange
+         :     :        +- CometFilter
+         :     :           +- CometHashAggregate
+         :     :              +- CometExchange
+         :     :                 +- CometHashAggregate
+         :     :                    +- CometHashAggregate
+         :     :                       +- CometExchange
+         :     :                          +- CometHashAggregate
+         :     :                             +- CometProject
+         :     :                                +- CometBroadcastHashJoin
+         :     :                                   :- CometProject
+         :     :                                   :  +- CometBroadcastHashJoin
+         :     :                                   :     :- CometFilter
+         :     :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+         :     :                                   :     :        +- ReusedSubquery
+         :     :                                   :     +- CometBroadcastExchange
+         :     :                                   :        +- CometProject
+         :     :                                   :           +- CometFilter
+         :     :                                   :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :                                   +- CometBroadcastExchange
+         :     :                                      +- CometProject
+         :     :                                         +- CometFilter
+         :     :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+         :     +- CometBroadcastExchange
+         :        +- CometProject
+         :           +- CometFilter
+         :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         +- CometBroadcastExchange
+            +- CometProject
+               +- CometFilter
+                  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+
+Comet accelerated 58 out of 61 eligible operators (95%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q82.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q82.native_datafusion/extended.txt
@@ -1,0 +1,33 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometBroadcastExchange
+                  :  +- CometProject
+                  :     +- CometBroadcastHashJoin
+                  :        :- CometProject
+                  :        :  +- CometBroadcastHashJoin
+                  :        :     :- CometProject
+                  :        :     :  +- CometFilter
+                  :        :     :     +- CometNativeScan parquet spark_catalog.default.item
+                  :        :     +- CometBroadcastExchange
+                  :        :        +- CometProject
+                  :        :           +- CometFilter
+                  :        :              +- CometNativeScan parquet spark_catalog.default.inventory
+                  :        :                    +- CometSubqueryBroadcast
+                  :        :                       +- CometBroadcastExchange
+                  :        :                          +- CometProject
+                  :        :                             +- CometFilter
+                  :        :                                +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :        +- CometBroadcastExchange
+                  :           +- CometProject
+                  :              +- CometFilter
+                  :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                  +- CometProject
+                     +- CometFilter
+                        +- CometNativeScan parquet spark_catalog.default.store_sales
+
+Comet accelerated 29 out of 30 eligible operators (96%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q82.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q82.native_iceberg_compat/extended.txt
@@ -1,0 +1,34 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometBroadcastExchange
+                  :  +- CometProject
+                  :     +- CometBroadcastHashJoin
+                  :        :- CometProject
+                  :        :  +- CometBroadcastHashJoin
+                  :        :     :- CometProject
+                  :        :     :  +- CometFilter
+                  :        :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :        :     +- CometBroadcastExchange
+                  :        :        +- CometProject
+                  :        :           +- CometFilter
+                  :        :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.inventory
+                  :        :                    +- SubqueryBroadcast
+                  :        :                       +- BroadcastExchange
+                  :        :                          +- CometNativeColumnarToRow
+                  :        :                             +- CometProject
+                  :        :                                +- CometFilter
+                  :        :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :        +- CometBroadcastExchange
+                  :           +- CometProject
+                  :              +- CometFilter
+                  :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  +- CometProject
+                     +- CometFilter
+                        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+
+Comet accelerated 28 out of 30 eligible operators (93%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q83.ansi.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q83.ansi.native_datafusion/extended.txt
@@ -1,0 +1,104 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometHashAggregate
+         :     :  +- CometExchange
+         :     :     +- CometHashAggregate
+         :     :        +- CometProject
+         :     :           +- CometBroadcastHashJoin
+         :     :              :- CometProject
+         :     :              :  +- CometBroadcastHashJoin
+         :     :              :     :- CometFilter
+         :     :              :     :  +- CometNativeScan parquet spark_catalog.default.store_returns
+         :     :              :     :        +- CometSubqueryBroadcast
+         :     :              :     :           +- CometBroadcastExchange
+         :     :              :     :              +- CometProject
+         :     :              :     :                 +- CometBroadcastHashJoin
+         :     :              :     :                    :- CometFilter
+         :     :              :     :                    :  +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :              :     :                    +- CometBroadcastExchange
+         :     :              :     :                       +- CometProject
+         :     :              :     :                          +- CometBroadcastHashJoin
+         :     :              :     :                             :- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :              :     :                             +- CometBroadcastExchange
+         :     :              :     :                                +- CometProject
+         :     :              :     :                                   +- CometFilter
+         :     :              :     :                                      +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :              :     +- CometBroadcastExchange
+         :     :              :        +- CometProject
+         :     :              :           +- CometFilter
+         :     :              :              +- CometNativeScan parquet spark_catalog.default.item
+         :     :              +- CometBroadcastExchange
+         :     :                 +- CometProject
+         :     :                    +- CometBroadcastHashJoin
+         :     :                       :- CometFilter
+         :     :                       :  +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :                       +- CometBroadcastExchange
+         :     :                          +- CometProject
+         :     :                             +- CometBroadcastHashJoin
+         :     :                                :- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :                                +- CometBroadcastExchange
+         :     :                                   +- CometProject
+         :     :                                      +- CometFilter
+         :     :                                         +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     +- CometBroadcastExchange
+         :        +- CometHashAggregate
+         :           +- CometExchange
+         :              +- CometHashAggregate
+         :                 +- CometProject
+         :                    +- CometBroadcastHashJoin
+         :                       :- CometProject
+         :                       :  +- CometBroadcastHashJoin
+         :                       :     :- CometFilter
+         :                       :     :  +- CometNativeScan parquet spark_catalog.default.catalog_returns
+         :                       :     :        +- ReusedSubquery
+         :                       :     +- CometBroadcastExchange
+         :                       :        +- CometProject
+         :                       :           +- CometFilter
+         :                       :              +- CometNativeScan parquet spark_catalog.default.item
+         :                       +- CometBroadcastExchange
+         :                          +- CometProject
+         :                             +- CometBroadcastHashJoin
+         :                                :- CometFilter
+         :                                :  +- CometNativeScan parquet spark_catalog.default.date_dim
+         :                                +- CometBroadcastExchange
+         :                                   +- CometProject
+         :                                      +- CometBroadcastHashJoin
+         :                                         :- CometNativeScan parquet spark_catalog.default.date_dim
+         :                                         +- CometBroadcastExchange
+         :                                            +- CometProject
+         :                                               +- CometFilter
+         :                                                  +- CometNativeScan parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometFilter
+                           :     :  +- CometNativeScan parquet spark_catalog.default.web_returns
+                           :     :        +- ReusedSubquery
+                           :     +- CometBroadcastExchange
+                           :        +- CometProject
+                           :           +- CometFilter
+                           :              +- CometNativeScan parquet spark_catalog.default.item
+                           +- CometBroadcastExchange
+                              +- CometProject
+                                 +- CometBroadcastHashJoin
+                                    :- CometFilter
+                                    :  +- CometNativeScan parquet spark_catalog.default.date_dim
+                                    +- CometBroadcastExchange
+                                       +- CometProject
+                                          +- CometBroadcastHashJoin
+                                             :- CometNativeScan parquet spark_catalog.default.date_dim
+                                             +- CometBroadcastExchange
+                                                +- CometProject
+                                                   +- CometFilter
+                                                      +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 98 out of 101 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q83.ansi.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q83.ansi.native_iceberg_compat/extended.txt
@@ -1,0 +1,105 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometHashAggregate
+         :     :  +- CometExchange
+         :     :     +- CometHashAggregate
+         :     :        +- CometProject
+         :     :           +- CometBroadcastHashJoin
+         :     :              :- CometProject
+         :     :              :  +- CometBroadcastHashJoin
+         :     :              :     :- CometFilter
+         :     :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+         :     :              :     :        +- SubqueryBroadcast
+         :     :              :     :           +- BroadcastExchange
+         :     :              :     :              +- CometNativeColumnarToRow
+         :     :              :     :                 +- CometProject
+         :     :              :     :                    +- CometBroadcastHashJoin
+         :     :              :     :                       :- CometFilter
+         :     :              :     :                       :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :              :     :                       +- CometBroadcastExchange
+         :     :              :     :                          +- CometProject
+         :     :              :     :                             +- CometBroadcastHashJoin
+         :     :              :     :                                :- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :              :     :                                +- CometBroadcastExchange
+         :     :              :     :                                   +- CometProject
+         :     :              :     :                                      +- CometFilter
+         :     :              :     :                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :              :     +- CometBroadcastExchange
+         :     :              :        +- CometProject
+         :     :              :           +- CometFilter
+         :     :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+         :     :              +- CometBroadcastExchange
+         :     :                 +- CometProject
+         :     :                    +- CometBroadcastHashJoin
+         :     :                       :- CometFilter
+         :     :                       :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :                       +- CometBroadcastExchange
+         :     :                          +- CometProject
+         :     :                             +- CometBroadcastHashJoin
+         :     :                                :- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :                                +- CometBroadcastExchange
+         :     :                                   +- CometProject
+         :     :                                      +- CometFilter
+         :     :                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     +- CometBroadcastExchange
+         :        +- CometHashAggregate
+         :           +- CometExchange
+         :              +- CometHashAggregate
+         :                 +- CometProject
+         :                    +- CometBroadcastHashJoin
+         :                       :- CometProject
+         :                       :  +- CometBroadcastHashJoin
+         :                       :     :- CometFilter
+         :                       :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+         :                       :     :        +- ReusedSubquery
+         :                       :     +- CometBroadcastExchange
+         :                       :        +- CometProject
+         :                       :           +- CometFilter
+         :                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+         :                       +- CometBroadcastExchange
+         :                          +- CometProject
+         :                             +- CometBroadcastHashJoin
+         :                                :- CometFilter
+         :                                :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :                                +- CometBroadcastExchange
+         :                                   +- CometProject
+         :                                      +- CometBroadcastHashJoin
+         :                                         :- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :                                         +- CometBroadcastExchange
+         :                                            +- CometProject
+         :                                               +- CometFilter
+         :                                                  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometFilter
+                           :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+                           :     :        +- ReusedSubquery
+                           :     +- CometBroadcastExchange
+                           :        +- CometProject
+                           :           +- CometFilter
+                           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           +- CometBroadcastExchange
+                              +- CometProject
+                                 +- CometBroadcastHashJoin
+                                    :- CometFilter
+                                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                    +- CometBroadcastExchange
+                                       +- CometProject
+                                          +- CometBroadcastHashJoin
+                                             :- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                             +- CometBroadcastExchange
+                                                +- CometProject
+                                                   +- CometFilter
+                                                      +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 97 out of 101 eligible operators (96%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q84.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q84.native_datafusion/extended.txt
@@ -1,0 +1,35 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometBroadcastExchange
+         :  +- CometProject
+         :     +- CometBroadcastHashJoin
+         :        :- CometProject
+         :        :  +- CometBroadcastHashJoin
+         :        :     :- CometProject
+         :        :     :  +- CometBroadcastHashJoin
+         :        :     :     :- CometProject
+         :        :     :     :  +- CometBroadcastHashJoin
+         :        :     :     :     :- CometProject
+         :        :     :     :     :  +- CometFilter
+         :        :     :     :     :     +- CometNativeScan parquet spark_catalog.default.customer
+         :        :     :     :     +- CometBroadcastExchange
+         :        :     :     :        +- CometProject
+         :        :     :     :           +- CometFilter
+         :        :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+         :        :     :     +- CometBroadcastExchange
+         :        :     :        +- CometFilter
+         :        :     :           +- CometNativeScan parquet spark_catalog.default.customer_demographics
+         :        :     +- CometBroadcastExchange
+         :        :        +- CometFilter
+         :        :           +- CometNativeScan parquet spark_catalog.default.household_demographics
+         :        +- CometBroadcastExchange
+         :           +- CometProject
+         :              +- CometFilter
+         :                 +- CometNativeScan parquet spark_catalog.default.income_band
+         +- CometProject
+            +- CometFilter
+               +- CometNativeScan parquet spark_catalog.default.store_returns
+
+Comet accelerated 32 out of 32 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q84.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q84.native_iceberg_compat/extended.txt
@@ -1,0 +1,35 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometBroadcastExchange
+         :  +- CometProject
+         :     +- CometBroadcastHashJoin
+         :        :- CometProject
+         :        :  +- CometBroadcastHashJoin
+         :        :     :- CometProject
+         :        :     :  +- CometBroadcastHashJoin
+         :        :     :     :- CometProject
+         :        :     :     :  +- CometBroadcastHashJoin
+         :        :     :     :     :- CometProject
+         :        :     :     :     :  +- CometFilter
+         :        :     :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         :        :     :     :     +- CometBroadcastExchange
+         :        :     :     :        +- CometProject
+         :        :     :     :           +- CometFilter
+         :        :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+         :        :     :     +- CometBroadcastExchange
+         :        :     :        +- CometFilter
+         :        :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+         :        :     +- CometBroadcastExchange
+         :        :        +- CometFilter
+         :        :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+         :        +- CometBroadcastExchange
+         :           +- CometProject
+         :              +- CometFilter
+         :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.income_band
+         +- CometProject
+            +- CometFilter
+               +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+
+Comet accelerated 32 out of 32 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q85.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q85.native_datafusion/extended.txt
@@ -1,0 +1,55 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometProject
+                  :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :- CometProject
+                  :     :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :     :- CometProject
+                  :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :     :     :- CometBroadcastExchange
+                  :     :     :     :     :     :     :  +- CometFilter
+                  :     :     :     :     :     :     :     +- CometNativeScan parquet spark_catalog.default.web_sales
+                  :     :     :     :     :     :     :           +- CometSubqueryBroadcast
+                  :     :     :     :     :     :     :              +- CometBroadcastExchange
+                  :     :     :     :     :     :     :                 +- CometProject
+                  :     :     :     :     :     :     :                    +- CometFilter
+                  :     :     :     :     :     :     :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     :     :     :     :     +- CometProject
+                  :     :     :     :     :     :        +- CometFilter
+                  :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.web_returns
+                  :     :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :     :        +- CometFilter
+                  :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.web_page
+                  :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :        +- CometProject
+                  :     :     :     :           +- CometFilter
+                  :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometProject
+                  :     :     :           +- CometFilter
+                  :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.reason
+
+Comet accelerated 51 out of 52 eligible operators (98%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q85.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q85.native_iceberg_compat/extended.txt
@@ -1,0 +1,56 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometProject
+                  :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :- CometProject
+                  :     :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :     :- CometProject
+                  :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :     :     :     :- CometBroadcastExchange
+                  :     :     :     :     :     :     :  +- CometFilter
+                  :     :     :     :     :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                  :     :     :     :     :     :     :           +- SubqueryBroadcast
+                  :     :     :     :     :     :     :              +- BroadcastExchange
+                  :     :     :     :     :     :     :                 +- CometNativeColumnarToRow
+                  :     :     :     :     :     :     :                    +- CometProject
+                  :     :     :     :     :     :     :                       +- CometFilter
+                  :     :     :     :     :     :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     :     :     :     :     +- CometProject
+                  :     :     :     :     :     :        +- CometFilter
+                  :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+                  :     :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :     :        +- CometFilter
+                  :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_page
+                  :     :     :     :     +- CometBroadcastExchange
+                  :     :     :     :        +- CometProject
+                  :     :     :     :           +- CometFilter
+                  :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometProject
+                  :     :     :           +- CometFilter
+                  :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.reason
+
+Comet accelerated 50 out of 52 eligible operators (96%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q86.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q86.native_datafusion/extended.txt
@@ -1,0 +1,31 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometExpand
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometFilter
+                                 :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                                 :     :        +- CometSubqueryBroadcast
+                                 :     :           +- CometBroadcastExchange
+                                 :     :              +- CometProject
+                                 :     :                 +- CometFilter
+                                 :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometProject
+                                 :           +- CometFilter
+                                 :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 24 out of 28 eligible operators (85%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q86.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q86.native_iceberg_compat/extended.txt
@@ -1,0 +1,32 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometExpand
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometFilter
+                                 :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                 :     :        +- SubqueryBroadcast
+                                 :     :           +- BroadcastExchange
+                                 :     :              +- CometNativeColumnarToRow
+                                 :     :                 +- CometProject
+                                 :     :                    +- CometFilter
+                                 :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometProject
+                                 :           +- CometFilter
+                                 :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 23 out of 28 eligible operators (82%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q87.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q87.native_datafusion/extended.txt
@@ -1,0 +1,71 @@
+HashAggregate
++- Exchange
+   +- HashAggregate
+      +- Project
+         +- BroadcastHashJoin
+            :-  BroadcastHashJoin [COMET: BuildRight with LeftAnti is not supported]
+            :  :- CometNativeColumnarToRow
+            :  :  +- CometHashAggregate
+            :  :     +- CometExchange
+            :  :        +- CometHashAggregate
+            :  :           +- CometProject
+            :  :              +- CometBroadcastHashJoin
+            :  :                 :- CometProject
+            :  :                 :  +- CometBroadcastHashJoin
+            :  :                 :     :- CometFilter
+            :  :                 :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+            :  :                 :     :        +- CometSubqueryBroadcast
+            :  :                 :     :           +- CometBroadcastExchange
+            :  :                 :     :              +- CometProject
+            :  :                 :     :                 +- CometFilter
+            :  :                 :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+            :  :                 :     +- CometBroadcastExchange
+            :  :                 :        +- CometProject
+            :  :                 :           +- CometFilter
+            :  :                 :              +- CometNativeScan parquet spark_catalog.default.date_dim
+            :  :                 +- CometBroadcastExchange
+            :  :                    +- CometProject
+            :  :                       +- CometFilter
+            :  :                          +- CometNativeScan parquet spark_catalog.default.customer
+            :  +- BroadcastExchange
+            :     +- CometNativeColumnarToRow
+            :        +- CometHashAggregate
+            :           +- CometExchange
+            :              +- CometHashAggregate
+            :                 +- CometProject
+            :                    +- CometBroadcastHashJoin
+            :                       :- CometProject
+            :                       :  +- CometBroadcastHashJoin
+            :                       :     :- CometFilter
+            :                       :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+            :                       :     :        +- ReusedSubquery
+            :                       :     +- CometBroadcastExchange
+            :                       :        +- CometProject
+            :                       :           +- CometFilter
+            :                       :              +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                       +- CometBroadcastExchange
+            :                          +- CometProject
+            :                             +- CometFilter
+            :                                +- CometNativeScan parquet spark_catalog.default.customer
+            +- BroadcastExchange
+               +- CometNativeColumnarToRow
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometFilter
+                                 :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                                 :     :        +- ReusedSubquery
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometProject
+                                 :           +- CometFilter
+                                 :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometNativeScan parquet spark_catalog.default.customer
+
+Comet accelerated 55 out of 66 eligible operators (83%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q87.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q87.native_iceberg_compat/extended.txt
@@ -1,0 +1,72 @@
+HashAggregate
++- Exchange
+   +- HashAggregate
+      +- Project
+         +- BroadcastHashJoin
+            :-  BroadcastHashJoin [COMET: BuildRight with LeftAnti is not supported]
+            :  :- CometNativeColumnarToRow
+            :  :  +- CometHashAggregate
+            :  :     +- CometExchange
+            :  :        +- CometHashAggregate
+            :  :           +- CometProject
+            :  :              +- CometBroadcastHashJoin
+            :  :                 :- CometProject
+            :  :                 :  +- CometBroadcastHashJoin
+            :  :                 :     :- CometFilter
+            :  :                 :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+            :  :                 :     :        +- SubqueryBroadcast
+            :  :                 :     :           +- BroadcastExchange
+            :  :                 :     :              +- CometNativeColumnarToRow
+            :  :                 :     :                 +- CometProject
+            :  :                 :     :                    +- CometFilter
+            :  :                 :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :  :                 :     +- CometBroadcastExchange
+            :  :                 :        +- CometProject
+            :  :                 :           +- CometFilter
+            :  :                 :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :  :                 +- CometBroadcastExchange
+            :  :                    +- CometProject
+            :  :                       +- CometFilter
+            :  :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+            :  +- BroadcastExchange
+            :     +- CometNativeColumnarToRow
+            :        +- CometHashAggregate
+            :           +- CometExchange
+            :              +- CometHashAggregate
+            :                 +- CometProject
+            :                    +- CometBroadcastHashJoin
+            :                       :- CometProject
+            :                       :  +- CometBroadcastHashJoin
+            :                       :     :- CometFilter
+            :                       :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+            :                       :     :        +- ReusedSubquery
+            :                       :     +- CometBroadcastExchange
+            :                       :        +- CometProject
+            :                       :           +- CometFilter
+            :                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :                       +- CometBroadcastExchange
+            :                          +- CometProject
+            :                             +- CometFilter
+            :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+            +- BroadcastExchange
+               +- CometNativeColumnarToRow
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometFilter
+                                 :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                 :     :        +- ReusedSubquery
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometProject
+                                 :           +- CometFilter
+                                 :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+
+Comet accelerated 54 out of 66 eligible operators (81%). Final plan contains 4 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q88.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q88.native_datafusion/extended.txt
@@ -1,0 +1,216 @@
+BroadcastNestedLoopJoin
+:- BroadcastNestedLoopJoin
+:  :- BroadcastNestedLoopJoin
+:  :  :- BroadcastNestedLoopJoin
+:  :  :  :- BroadcastNestedLoopJoin
+:  :  :  :  :- BroadcastNestedLoopJoin
+:  :  :  :  :  :-  BroadcastNestedLoopJoin [COMET: BroadcastNestedLoopJoin is not supported]
+:  :  :  :  :  :  :- CometNativeColumnarToRow
+:  :  :  :  :  :  :  +- CometHashAggregate
+:  :  :  :  :  :  :     +- CometExchange
+:  :  :  :  :  :  :        +- CometHashAggregate
+:  :  :  :  :  :  :           +- CometProject
+:  :  :  :  :  :  :              +- CometBroadcastHashJoin
+:  :  :  :  :  :  :                 :- CometProject
+:  :  :  :  :  :  :                 :  +- CometBroadcastHashJoin
+:  :  :  :  :  :  :                 :     :- CometProject
+:  :  :  :  :  :  :                 :     :  +- CometBroadcastHashJoin
+:  :  :  :  :  :  :                 :     :     :- CometProject
+:  :  :  :  :  :  :                 :     :     :  +- CometFilter
+:  :  :  :  :  :  :                 :     :     :     +- CometNativeScan parquet spark_catalog.default.store_sales
+:  :  :  :  :  :  :                 :     :     +- CometBroadcastExchange
+:  :  :  :  :  :  :                 :     :        +- CometProject
+:  :  :  :  :  :  :                 :     :           +- CometFilter
+:  :  :  :  :  :  :                 :     :              +- CometNativeScan parquet spark_catalog.default.household_demographics
+:  :  :  :  :  :  :                 :     +- CometBroadcastExchange
+:  :  :  :  :  :  :                 :        +- CometProject
+:  :  :  :  :  :  :                 :           +- CometFilter
+:  :  :  :  :  :  :                 :              +- CometNativeScan parquet spark_catalog.default.time_dim
+:  :  :  :  :  :  :                 +- CometBroadcastExchange
+:  :  :  :  :  :  :                    +- CometProject
+:  :  :  :  :  :  :                       +- CometFilter
+:  :  :  :  :  :  :                          +- CometNativeScan parquet spark_catalog.default.store
+:  :  :  :  :  :  +- BroadcastExchange
+:  :  :  :  :  :     +- CometNativeColumnarToRow
+:  :  :  :  :  :        +- CometHashAggregate
+:  :  :  :  :  :           +- CometExchange
+:  :  :  :  :  :              +- CometHashAggregate
+:  :  :  :  :  :                 +- CometProject
+:  :  :  :  :  :                    +- CometBroadcastHashJoin
+:  :  :  :  :  :                       :- CometProject
+:  :  :  :  :  :                       :  +- CometBroadcastHashJoin
+:  :  :  :  :  :                       :     :- CometProject
+:  :  :  :  :  :                       :     :  +- CometBroadcastHashJoin
+:  :  :  :  :  :                       :     :     :- CometProject
+:  :  :  :  :  :                       :     :     :  +- CometFilter
+:  :  :  :  :  :                       :     :     :     +- CometNativeScan parquet spark_catalog.default.store_sales
+:  :  :  :  :  :                       :     :     +- CometBroadcastExchange
+:  :  :  :  :  :                       :     :        +- CometProject
+:  :  :  :  :  :                       :     :           +- CometFilter
+:  :  :  :  :  :                       :     :              +- CometNativeScan parquet spark_catalog.default.household_demographics
+:  :  :  :  :  :                       :     +- CometBroadcastExchange
+:  :  :  :  :  :                       :        +- CometProject
+:  :  :  :  :  :                       :           +- CometFilter
+:  :  :  :  :  :                       :              +- CometNativeScan parquet spark_catalog.default.time_dim
+:  :  :  :  :  :                       +- CometBroadcastExchange
+:  :  :  :  :  :                          +- CometProject
+:  :  :  :  :  :                             +- CometFilter
+:  :  :  :  :  :                                +- CometNativeScan parquet spark_catalog.default.store
+:  :  :  :  :  +- BroadcastExchange
+:  :  :  :  :     +- CometNativeColumnarToRow
+:  :  :  :  :        +- CometHashAggregate
+:  :  :  :  :           +- CometExchange
+:  :  :  :  :              +- CometHashAggregate
+:  :  :  :  :                 +- CometProject
+:  :  :  :  :                    +- CometBroadcastHashJoin
+:  :  :  :  :                       :- CometProject
+:  :  :  :  :                       :  +- CometBroadcastHashJoin
+:  :  :  :  :                       :     :- CometProject
+:  :  :  :  :                       :     :  +- CometBroadcastHashJoin
+:  :  :  :  :                       :     :     :- CometProject
+:  :  :  :  :                       :     :     :  +- CometFilter
+:  :  :  :  :                       :     :     :     +- CometNativeScan parquet spark_catalog.default.store_sales
+:  :  :  :  :                       :     :     +- CometBroadcastExchange
+:  :  :  :  :                       :     :        +- CometProject
+:  :  :  :  :                       :     :           +- CometFilter
+:  :  :  :  :                       :     :              +- CometNativeScan parquet spark_catalog.default.household_demographics
+:  :  :  :  :                       :     +- CometBroadcastExchange
+:  :  :  :  :                       :        +- CometProject
+:  :  :  :  :                       :           +- CometFilter
+:  :  :  :  :                       :              +- CometNativeScan parquet spark_catalog.default.time_dim
+:  :  :  :  :                       +- CometBroadcastExchange
+:  :  :  :  :                          +- CometProject
+:  :  :  :  :                             +- CometFilter
+:  :  :  :  :                                +- CometNativeScan parquet spark_catalog.default.store
+:  :  :  :  +- BroadcastExchange
+:  :  :  :     +- CometNativeColumnarToRow
+:  :  :  :        +- CometHashAggregate
+:  :  :  :           +- CometExchange
+:  :  :  :              +- CometHashAggregate
+:  :  :  :                 +- CometProject
+:  :  :  :                    +- CometBroadcastHashJoin
+:  :  :  :                       :- CometProject
+:  :  :  :                       :  +- CometBroadcastHashJoin
+:  :  :  :                       :     :- CometProject
+:  :  :  :                       :     :  +- CometBroadcastHashJoin
+:  :  :  :                       :     :     :- CometProject
+:  :  :  :                       :     :     :  +- CometFilter
+:  :  :  :                       :     :     :     +- CometNativeScan parquet spark_catalog.default.store_sales
+:  :  :  :                       :     :     +- CometBroadcastExchange
+:  :  :  :                       :     :        +- CometProject
+:  :  :  :                       :     :           +- CometFilter
+:  :  :  :                       :     :              +- CometNativeScan parquet spark_catalog.default.household_demographics
+:  :  :  :                       :     +- CometBroadcastExchange
+:  :  :  :                       :        +- CometProject
+:  :  :  :                       :           +- CometFilter
+:  :  :  :                       :              +- CometNativeScan parquet spark_catalog.default.time_dim
+:  :  :  :                       +- CometBroadcastExchange
+:  :  :  :                          +- CometProject
+:  :  :  :                             +- CometFilter
+:  :  :  :                                +- CometNativeScan parquet spark_catalog.default.store
+:  :  :  +- BroadcastExchange
+:  :  :     +- CometNativeColumnarToRow
+:  :  :        +- CometHashAggregate
+:  :  :           +- CometExchange
+:  :  :              +- CometHashAggregate
+:  :  :                 +- CometProject
+:  :  :                    +- CometBroadcastHashJoin
+:  :  :                       :- CometProject
+:  :  :                       :  +- CometBroadcastHashJoin
+:  :  :                       :     :- CometProject
+:  :  :                       :     :  +- CometBroadcastHashJoin
+:  :  :                       :     :     :- CometProject
+:  :  :                       :     :     :  +- CometFilter
+:  :  :                       :     :     :     +- CometNativeScan parquet spark_catalog.default.store_sales
+:  :  :                       :     :     +- CometBroadcastExchange
+:  :  :                       :     :        +- CometProject
+:  :  :                       :     :           +- CometFilter
+:  :  :                       :     :              +- CometNativeScan parquet spark_catalog.default.household_demographics
+:  :  :                       :     +- CometBroadcastExchange
+:  :  :                       :        +- CometProject
+:  :  :                       :           +- CometFilter
+:  :  :                       :              +- CometNativeScan parquet spark_catalog.default.time_dim
+:  :  :                       +- CometBroadcastExchange
+:  :  :                          +- CometProject
+:  :  :                             +- CometFilter
+:  :  :                                +- CometNativeScan parquet spark_catalog.default.store
+:  :  +- BroadcastExchange
+:  :     +- CometNativeColumnarToRow
+:  :        +- CometHashAggregate
+:  :           +- CometExchange
+:  :              +- CometHashAggregate
+:  :                 +- CometProject
+:  :                    +- CometBroadcastHashJoin
+:  :                       :- CometProject
+:  :                       :  +- CometBroadcastHashJoin
+:  :                       :     :- CometProject
+:  :                       :     :  +- CometBroadcastHashJoin
+:  :                       :     :     :- CometProject
+:  :                       :     :     :  +- CometFilter
+:  :                       :     :     :     +- CometNativeScan parquet spark_catalog.default.store_sales
+:  :                       :     :     +- CometBroadcastExchange
+:  :                       :     :        +- CometProject
+:  :                       :     :           +- CometFilter
+:  :                       :     :              +- CometNativeScan parquet spark_catalog.default.household_demographics
+:  :                       :     +- CometBroadcastExchange
+:  :                       :        +- CometProject
+:  :                       :           +- CometFilter
+:  :                       :              +- CometNativeScan parquet spark_catalog.default.time_dim
+:  :                       +- CometBroadcastExchange
+:  :                          +- CometProject
+:  :                             +- CometFilter
+:  :                                +- CometNativeScan parquet spark_catalog.default.store
+:  +- BroadcastExchange
+:     +- CometNativeColumnarToRow
+:        +- CometHashAggregate
+:           +- CometExchange
+:              +- CometHashAggregate
+:                 +- CometProject
+:                    +- CometBroadcastHashJoin
+:                       :- CometProject
+:                       :  +- CometBroadcastHashJoin
+:                       :     :- CometProject
+:                       :     :  +- CometBroadcastHashJoin
+:                       :     :     :- CometProject
+:                       :     :     :  +- CometFilter
+:                       :     :     :     +- CometNativeScan parquet spark_catalog.default.store_sales
+:                       :     :     +- CometBroadcastExchange
+:                       :     :        +- CometProject
+:                       :     :           +- CometFilter
+:                       :     :              +- CometNativeScan parquet spark_catalog.default.household_demographics
+:                       :     +- CometBroadcastExchange
+:                       :        +- CometProject
+:                       :           +- CometFilter
+:                       :              +- CometNativeScan parquet spark_catalog.default.time_dim
+:                       +- CometBroadcastExchange
+:                          +- CometProject
+:                             +- CometFilter
+:                                +- CometNativeScan parquet spark_catalog.default.store
++- BroadcastExchange
+   +- CometNativeColumnarToRow
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometProject
+                     :     :     :  +- CometFilter
+                     :     :     :     +- CometNativeScan parquet spark_catalog.default.store_sales
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometProject
+                     :     :           +- CometFilter
+                     :     :              +- CometNativeScan parquet spark_catalog.default.household_demographics
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              +- CometNativeScan parquet spark_catalog.default.time_dim
+                     +- CometBroadcastExchange
+                        +- CometProject
+                           +- CometFilter
+                              +- CometNativeScan parquet spark_catalog.default.store
+
+Comet accelerated 192 out of 206 eligible operators (93%). Final plan contains 8 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q88.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q88.native_iceberg_compat/extended.txt
@@ -1,0 +1,216 @@
+BroadcastNestedLoopJoin
+:- BroadcastNestedLoopJoin
+:  :- BroadcastNestedLoopJoin
+:  :  :- BroadcastNestedLoopJoin
+:  :  :  :- BroadcastNestedLoopJoin
+:  :  :  :  :- BroadcastNestedLoopJoin
+:  :  :  :  :  :-  BroadcastNestedLoopJoin [COMET: BroadcastNestedLoopJoin is not supported]
+:  :  :  :  :  :  :- CometNativeColumnarToRow
+:  :  :  :  :  :  :  +- CometHashAggregate
+:  :  :  :  :  :  :     +- CometExchange
+:  :  :  :  :  :  :        +- CometHashAggregate
+:  :  :  :  :  :  :           +- CometProject
+:  :  :  :  :  :  :              +- CometBroadcastHashJoin
+:  :  :  :  :  :  :                 :- CometProject
+:  :  :  :  :  :  :                 :  +- CometBroadcastHashJoin
+:  :  :  :  :  :  :                 :     :- CometProject
+:  :  :  :  :  :  :                 :     :  +- CometBroadcastHashJoin
+:  :  :  :  :  :  :                 :     :     :- CometProject
+:  :  :  :  :  :  :                 :     :     :  +- CometFilter
+:  :  :  :  :  :  :                 :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+:  :  :  :  :  :  :                 :     :     +- CometBroadcastExchange
+:  :  :  :  :  :  :                 :     :        +- CometProject
+:  :  :  :  :  :  :                 :     :           +- CometFilter
+:  :  :  :  :  :  :                 :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+:  :  :  :  :  :  :                 :     +- CometBroadcastExchange
+:  :  :  :  :  :  :                 :        +- CometProject
+:  :  :  :  :  :  :                 :           +- CometFilter
+:  :  :  :  :  :  :                 :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.time_dim
+:  :  :  :  :  :  :                 +- CometBroadcastExchange
+:  :  :  :  :  :  :                    +- CometProject
+:  :  :  :  :  :  :                       +- CometFilter
+:  :  :  :  :  :  :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+:  :  :  :  :  :  +- BroadcastExchange
+:  :  :  :  :  :     +- CometNativeColumnarToRow
+:  :  :  :  :  :        +- CometHashAggregate
+:  :  :  :  :  :           +- CometExchange
+:  :  :  :  :  :              +- CometHashAggregate
+:  :  :  :  :  :                 +- CometProject
+:  :  :  :  :  :                    +- CometBroadcastHashJoin
+:  :  :  :  :  :                       :- CometProject
+:  :  :  :  :  :                       :  +- CometBroadcastHashJoin
+:  :  :  :  :  :                       :     :- CometProject
+:  :  :  :  :  :                       :     :  +- CometBroadcastHashJoin
+:  :  :  :  :  :                       :     :     :- CometProject
+:  :  :  :  :  :                       :     :     :  +- CometFilter
+:  :  :  :  :  :                       :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+:  :  :  :  :  :                       :     :     +- CometBroadcastExchange
+:  :  :  :  :  :                       :     :        +- CometProject
+:  :  :  :  :  :                       :     :           +- CometFilter
+:  :  :  :  :  :                       :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+:  :  :  :  :  :                       :     +- CometBroadcastExchange
+:  :  :  :  :  :                       :        +- CometProject
+:  :  :  :  :  :                       :           +- CometFilter
+:  :  :  :  :  :                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.time_dim
+:  :  :  :  :  :                       +- CometBroadcastExchange
+:  :  :  :  :  :                          +- CometProject
+:  :  :  :  :  :                             +- CometFilter
+:  :  :  :  :  :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+:  :  :  :  :  +- BroadcastExchange
+:  :  :  :  :     +- CometNativeColumnarToRow
+:  :  :  :  :        +- CometHashAggregate
+:  :  :  :  :           +- CometExchange
+:  :  :  :  :              +- CometHashAggregate
+:  :  :  :  :                 +- CometProject
+:  :  :  :  :                    +- CometBroadcastHashJoin
+:  :  :  :  :                       :- CometProject
+:  :  :  :  :                       :  +- CometBroadcastHashJoin
+:  :  :  :  :                       :     :- CometProject
+:  :  :  :  :                       :     :  +- CometBroadcastHashJoin
+:  :  :  :  :                       :     :     :- CometProject
+:  :  :  :  :                       :     :     :  +- CometFilter
+:  :  :  :  :                       :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+:  :  :  :  :                       :     :     +- CometBroadcastExchange
+:  :  :  :  :                       :     :        +- CometProject
+:  :  :  :  :                       :     :           +- CometFilter
+:  :  :  :  :                       :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+:  :  :  :  :                       :     +- CometBroadcastExchange
+:  :  :  :  :                       :        +- CometProject
+:  :  :  :  :                       :           +- CometFilter
+:  :  :  :  :                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.time_dim
+:  :  :  :  :                       +- CometBroadcastExchange
+:  :  :  :  :                          +- CometProject
+:  :  :  :  :                             +- CometFilter
+:  :  :  :  :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+:  :  :  :  +- BroadcastExchange
+:  :  :  :     +- CometNativeColumnarToRow
+:  :  :  :        +- CometHashAggregate
+:  :  :  :           +- CometExchange
+:  :  :  :              +- CometHashAggregate
+:  :  :  :                 +- CometProject
+:  :  :  :                    +- CometBroadcastHashJoin
+:  :  :  :                       :- CometProject
+:  :  :  :                       :  +- CometBroadcastHashJoin
+:  :  :  :                       :     :- CometProject
+:  :  :  :                       :     :  +- CometBroadcastHashJoin
+:  :  :  :                       :     :     :- CometProject
+:  :  :  :                       :     :     :  +- CometFilter
+:  :  :  :                       :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+:  :  :  :                       :     :     +- CometBroadcastExchange
+:  :  :  :                       :     :        +- CometProject
+:  :  :  :                       :     :           +- CometFilter
+:  :  :  :                       :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+:  :  :  :                       :     +- CometBroadcastExchange
+:  :  :  :                       :        +- CometProject
+:  :  :  :                       :           +- CometFilter
+:  :  :  :                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.time_dim
+:  :  :  :                       +- CometBroadcastExchange
+:  :  :  :                          +- CometProject
+:  :  :  :                             +- CometFilter
+:  :  :  :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+:  :  :  +- BroadcastExchange
+:  :  :     +- CometNativeColumnarToRow
+:  :  :        +- CometHashAggregate
+:  :  :           +- CometExchange
+:  :  :              +- CometHashAggregate
+:  :  :                 +- CometProject
+:  :  :                    +- CometBroadcastHashJoin
+:  :  :                       :- CometProject
+:  :  :                       :  +- CometBroadcastHashJoin
+:  :  :                       :     :- CometProject
+:  :  :                       :     :  +- CometBroadcastHashJoin
+:  :  :                       :     :     :- CometProject
+:  :  :                       :     :     :  +- CometFilter
+:  :  :                       :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+:  :  :                       :     :     +- CometBroadcastExchange
+:  :  :                       :     :        +- CometProject
+:  :  :                       :     :           +- CometFilter
+:  :  :                       :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+:  :  :                       :     +- CometBroadcastExchange
+:  :  :                       :        +- CometProject
+:  :  :                       :           +- CometFilter
+:  :  :                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.time_dim
+:  :  :                       +- CometBroadcastExchange
+:  :  :                          +- CometProject
+:  :  :                             +- CometFilter
+:  :  :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+:  :  +- BroadcastExchange
+:  :     +- CometNativeColumnarToRow
+:  :        +- CometHashAggregate
+:  :           +- CometExchange
+:  :              +- CometHashAggregate
+:  :                 +- CometProject
+:  :                    +- CometBroadcastHashJoin
+:  :                       :- CometProject
+:  :                       :  +- CometBroadcastHashJoin
+:  :                       :     :- CometProject
+:  :                       :     :  +- CometBroadcastHashJoin
+:  :                       :     :     :- CometProject
+:  :                       :     :     :  +- CometFilter
+:  :                       :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+:  :                       :     :     +- CometBroadcastExchange
+:  :                       :     :        +- CometProject
+:  :                       :     :           +- CometFilter
+:  :                       :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+:  :                       :     +- CometBroadcastExchange
+:  :                       :        +- CometProject
+:  :                       :           +- CometFilter
+:  :                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.time_dim
+:  :                       +- CometBroadcastExchange
+:  :                          +- CometProject
+:  :                             +- CometFilter
+:  :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+:  +- BroadcastExchange
+:     +- CometNativeColumnarToRow
+:        +- CometHashAggregate
+:           +- CometExchange
+:              +- CometHashAggregate
+:                 +- CometProject
+:                    +- CometBroadcastHashJoin
+:                       :- CometProject
+:                       :  +- CometBroadcastHashJoin
+:                       :     :- CometProject
+:                       :     :  +- CometBroadcastHashJoin
+:                       :     :     :- CometProject
+:                       :     :     :  +- CometFilter
+:                       :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+:                       :     :     +- CometBroadcastExchange
+:                       :     :        +- CometProject
+:                       :     :           +- CometFilter
+:                       :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+:                       :     +- CometBroadcastExchange
+:                       :        +- CometProject
+:                       :           +- CometFilter
+:                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.time_dim
+:                       +- CometBroadcastExchange
+:                          +- CometProject
+:                             +- CometFilter
+:                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
++- BroadcastExchange
+   +- CometNativeColumnarToRow
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometProject
+                     :     :     :  +- CometFilter
+                     :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometProject
+                     :     :           +- CometFilter
+                     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.time_dim
+                     +- CometBroadcastExchange
+                        +- CometProject
+                           +- CometFilter
+                              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+
+Comet accelerated 192 out of 206 eligible operators (93%). Final plan contains 8 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q89.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q89.native_datafusion/extended.txt
@@ -1,0 +1,36 @@
+TakeOrderedAndProject
++- Project
+   +- Filter
+      +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+         +- CometNativeColumnarToRow
+            +- CometSort
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometProject
+                                 :     :  +- CometBroadcastHashJoin
+                                 :     :     :- CometProject
+                                 :     :     :  +- CometFilter
+                                 :     :     :     +- CometNativeScan parquet spark_catalog.default.item
+                                 :     :     +- CometBroadcastExchange
+                                 :     :        +- CometFilter
+                                 :     :           +- CometNativeScan parquet spark_catalog.default.store_sales
+                                 :     :                 +- CometSubqueryBroadcast
+                                 :     :                    +- CometBroadcastExchange
+                                 :     :                       +- CometProject
+                                 :     :                          +- CometFilter
+                                 :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometProject
+                                 :           +- CometFilter
+                                 :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 +- CometBroadcastExchange
+                                    +- CometFilter
+                                       +- CometNativeScan parquet spark_catalog.default.store
+
+Comet accelerated 28 out of 33 eligible operators (84%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q89.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q89.native_iceberg_compat/extended.txt
@@ -1,0 +1,37 @@
+TakeOrderedAndProject
++- Project
+   +- Filter
+      +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+         +- CometNativeColumnarToRow
+            +- CometSort
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometProject
+                                 :  +- CometBroadcastHashJoin
+                                 :     :- CometProject
+                                 :     :  +- CometBroadcastHashJoin
+                                 :     :     :- CometProject
+                                 :     :     :  +- CometFilter
+                                 :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :     :     +- CometBroadcastExchange
+                                 :     :        +- CometFilter
+                                 :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                 :     :                 +- SubqueryBroadcast
+                                 :     :                    +- BroadcastExchange
+                                 :     :                       +- CometNativeColumnarToRow
+                                 :     :                          +- CometProject
+                                 :     :                             +- CometFilter
+                                 :     :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :     +- CometBroadcastExchange
+                                 :        +- CometProject
+                                 :           +- CometFilter
+                                 :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 +- CometBroadcastExchange
+                                    +- CometFilter
+                                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+
+Comet accelerated 27 out of 33 eligible operators (81%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q9.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q9.native_datafusion/extended.txt
@@ -1,0 +1,61 @@
+ Project [COMET: ]
+:  :- Subquery
+:  :  +- CometNativeColumnarToRow
+:  :     +- CometProject
+:  :        +- CometHashAggregate
+:  :           +- CometExchange
+:  :              +- CometHashAggregate
+:  :                 +- CometProject
+:  :                    +- CometFilter
+:  :                       +- CometNativeScan parquet spark_catalog.default.store_sales
+:  :- ReusedSubquery
+:  :- ReusedSubquery
+:  :- Subquery
+:  :  +- CometNativeColumnarToRow
+:  :     +- CometProject
+:  :        +- CometHashAggregate
+:  :           +- CometExchange
+:  :              +- CometHashAggregate
+:  :                 +- CometProject
+:  :                    +- CometFilter
+:  :                       +- CometNativeScan parquet spark_catalog.default.store_sales
+:  :- ReusedSubquery
+:  :- ReusedSubquery
+:  :- Subquery
+:  :  +- CometNativeColumnarToRow
+:  :     +- CometProject
+:  :        +- CometHashAggregate
+:  :           +- CometExchange
+:  :              +- CometHashAggregate
+:  :                 +- CometProject
+:  :                    +- CometFilter
+:  :                       +- CometNativeScan parquet spark_catalog.default.store_sales
+:  :- ReusedSubquery
+:  :- ReusedSubquery
+:  :- Subquery
+:  :  +- CometNativeColumnarToRow
+:  :     +- CometProject
+:  :        +- CometHashAggregate
+:  :           +- CometExchange
+:  :              +- CometHashAggregate
+:  :                 +- CometProject
+:  :                    +- CometFilter
+:  :                       +- CometNativeScan parquet spark_catalog.default.store_sales
+:  :- ReusedSubquery
+:  :- ReusedSubquery
+:  :- Subquery
+:  :  +- CometNativeColumnarToRow
+:  :     +- CometProject
+:  :        +- CometHashAggregate
+:  :           +- CometExchange
+:  :              +- CometHashAggregate
+:  :                 +- CometProject
+:  :                    +- CometFilter
+:  :                       +- CometNativeScan parquet spark_catalog.default.store_sales
+:  :- ReusedSubquery
+:  +- ReusedSubquery
++- CometNativeColumnarToRow
+   +- CometFilter
+      +- CometNativeScan parquet spark_catalog.default.reason
+
+Comet accelerated 37 out of 53 eligible operators (69%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q9.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q9.native_iceberg_compat/extended.txt
@@ -1,0 +1,61 @@
+ Project [COMET: ]
+:  :- Subquery
+:  :  +- CometNativeColumnarToRow
+:  :     +- CometProject
+:  :        +- CometHashAggregate
+:  :           +- CometExchange
+:  :              +- CometHashAggregate
+:  :                 +- CometProject
+:  :                    +- CometFilter
+:  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+:  :- ReusedSubquery
+:  :- ReusedSubquery
+:  :- Subquery
+:  :  +- CometNativeColumnarToRow
+:  :     +- CometProject
+:  :        +- CometHashAggregate
+:  :           +- CometExchange
+:  :              +- CometHashAggregate
+:  :                 +- CometProject
+:  :                    +- CometFilter
+:  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+:  :- ReusedSubquery
+:  :- ReusedSubquery
+:  :- Subquery
+:  :  +- CometNativeColumnarToRow
+:  :     +- CometProject
+:  :        +- CometHashAggregate
+:  :           +- CometExchange
+:  :              +- CometHashAggregate
+:  :                 +- CometProject
+:  :                    +- CometFilter
+:  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+:  :- ReusedSubquery
+:  :- ReusedSubquery
+:  :- Subquery
+:  :  +- CometNativeColumnarToRow
+:  :     +- CometProject
+:  :        +- CometHashAggregate
+:  :           +- CometExchange
+:  :              +- CometHashAggregate
+:  :                 +- CometProject
+:  :                    +- CometFilter
+:  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+:  :- ReusedSubquery
+:  :- ReusedSubquery
+:  :- Subquery
+:  :  +- CometNativeColumnarToRow
+:  :     +- CometProject
+:  :        +- CometHashAggregate
+:  :           +- CometExchange
+:  :              +- CometHashAggregate
+:  :                 +- CometProject
+:  :                    +- CometFilter
+:  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+:  :- ReusedSubquery
+:  +- ReusedSubquery
++- CometNativeColumnarToRow
+   +- CometFilter
+      +- CometScan [native_iceberg_compat] parquet spark_catalog.default.reason
+
+Comet accelerated 37 out of 53 eligible operators (69%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q90.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q90.native_datafusion/extended.txt
@@ -1,0 +1,55 @@
+Project
++-  BroadcastNestedLoopJoin [COMET: BroadcastNestedLoopJoin is not supported]
+   :- CometNativeColumnarToRow
+   :  +- CometHashAggregate
+   :     +- CometExchange
+   :        +- CometHashAggregate
+   :           +- CometProject
+   :              +- CometBroadcastHashJoin
+   :                 :- CometProject
+   :                 :  +- CometBroadcastHashJoin
+   :                 :     :- CometProject
+   :                 :     :  +- CometBroadcastHashJoin
+   :                 :     :     :- CometProject
+   :                 :     :     :  +- CometFilter
+   :                 :     :     :     +- CometNativeScan parquet spark_catalog.default.web_sales
+   :                 :     :     +- CometBroadcastExchange
+   :                 :     :        +- CometProject
+   :                 :     :           +- CometFilter
+   :                 :     :              +- CometNativeScan parquet spark_catalog.default.household_demographics
+   :                 :     +- CometBroadcastExchange
+   :                 :        +- CometProject
+   :                 :           +- CometFilter
+   :                 :              +- CometNativeScan parquet spark_catalog.default.time_dim
+   :                 +- CometBroadcastExchange
+   :                    +- CometProject
+   :                       +- CometFilter
+   :                          +- CometNativeScan parquet spark_catalog.default.web_page
+   +- BroadcastExchange
+      +- CometNativeColumnarToRow
+         +- CometHashAggregate
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometProject
+                     +- CometBroadcastHashJoin
+                        :- CometProject
+                        :  +- CometBroadcastHashJoin
+                        :     :- CometProject
+                        :     :  +- CometBroadcastHashJoin
+                        :     :     :- CometProject
+                        :     :     :  +- CometFilter
+                        :     :     :     +- CometNativeScan parquet spark_catalog.default.web_sales
+                        :     :     +- CometBroadcastExchange
+                        :     :        +- CometProject
+                        :     :           +- CometFilter
+                        :     :              +- CometNativeScan parquet spark_catalog.default.household_demographics
+                        :     +- CometBroadcastExchange
+                        :        +- CometProject
+                        :           +- CometFilter
+                        :              +- CometNativeScan parquet spark_catalog.default.time_dim
+                        +- CometBroadcastExchange
+                           +- CometProject
+                              +- CometFilter
+                                 +- CometNativeScan parquet spark_catalog.default.web_page
+
+Comet accelerated 48 out of 51 eligible operators (94%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q90.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q90.native_iceberg_compat/extended.txt
@@ -1,0 +1,55 @@
+Project
++-  BroadcastNestedLoopJoin [COMET: BroadcastNestedLoopJoin is not supported]
+   :- CometNativeColumnarToRow
+   :  +- CometHashAggregate
+   :     +- CometExchange
+   :        +- CometHashAggregate
+   :           +- CometProject
+   :              +- CometBroadcastHashJoin
+   :                 :- CometProject
+   :                 :  +- CometBroadcastHashJoin
+   :                 :     :- CometProject
+   :                 :     :  +- CometBroadcastHashJoin
+   :                 :     :     :- CometProject
+   :                 :     :     :  +- CometFilter
+   :                 :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+   :                 :     :     +- CometBroadcastExchange
+   :                 :     :        +- CometProject
+   :                 :     :           +- CometFilter
+   :                 :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+   :                 :     +- CometBroadcastExchange
+   :                 :        +- CometProject
+   :                 :           +- CometFilter
+   :                 :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.time_dim
+   :                 +- CometBroadcastExchange
+   :                    +- CometProject
+   :                       +- CometFilter
+   :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_page
+   +- BroadcastExchange
+      +- CometNativeColumnarToRow
+         +- CometHashAggregate
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometProject
+                     +- CometBroadcastHashJoin
+                        :- CometProject
+                        :  +- CometBroadcastHashJoin
+                        :     :- CometProject
+                        :     :  +- CometBroadcastHashJoin
+                        :     :     :- CometProject
+                        :     :     :  +- CometFilter
+                        :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                        :     :     +- CometBroadcastExchange
+                        :     :        +- CometProject
+                        :     :           +- CometFilter
+                        :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+                        :     +- CometBroadcastExchange
+                        :        +- CometProject
+                        :           +- CometFilter
+                        :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.time_dim
+                        +- CometBroadcastExchange
+                           +- CometProject
+                              +- CometFilter
+                                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_page
+
+Comet accelerated 48 out of 51 eligible operators (94%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q91.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q91.native_datafusion/extended.txt
@@ -1,0 +1,50 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometProject
+                     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :- CometProject
+                     :     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :     :- CometProject
+                     :     :     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :     :     :- CometProject
+                     :     :     :     :     :     :  +- CometFilter
+                     :     :     :     :     :     :     +- CometNativeScan parquet spark_catalog.default.call_center
+                     :     :     :     :     :     +- CometBroadcastExchange
+                     :     :     :     :     :        +- CometFilter
+                     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.catalog_returns
+                     :     :     :     :     :                 +- CometSubqueryBroadcast
+                     :     :     :     :     :                    +- CometBroadcastExchange
+                     :     :     :     :     :                       +- CometProject
+                     :     :     :     :     :                          +- CometFilter
+                     :     :     :     :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :     :     :     :     +- CometBroadcastExchange
+                     :     :     :     :        +- CometProject
+                     :     :     :     :           +- CometFilter
+                     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :     :     :     +- CometBroadcastExchange
+                     :     :     :        +- CometFilter
+                     :     :     :           +- CometNativeScan parquet spark_catalog.default.customer
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometProject
+                     :     :           +- CometFilter
+                     :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+                     +- CometBroadcastExchange
+                        +- CometProject
+                           +- CometFilter
+                              +- CometNativeScan parquet spark_catalog.default.household_demographics
+
+Comet accelerated 46 out of 47 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q91.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q91.native_iceberg_compat/extended.txt
@@ -1,0 +1,51 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometProject
+                     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :- CometProject
+                     :     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :     :- CometProject
+                     :     :     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :     :     :- CometProject
+                     :     :     :     :     :     :  +- CometFilter
+                     :     :     :     :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.call_center
+                     :     :     :     :     :     +- CometBroadcastExchange
+                     :     :     :     :     :        +- CometFilter
+                     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+                     :     :     :     :     :                 +- SubqueryBroadcast
+                     :     :     :     :     :                    +- BroadcastExchange
+                     :     :     :     :     :                       +- CometNativeColumnarToRow
+                     :     :     :     :     :                          +- CometProject
+                     :     :     :     :     :                             +- CometFilter
+                     :     :     :     :     :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :     :     :     :     +- CometBroadcastExchange
+                     :     :     :     :        +- CometProject
+                     :     :     :     :           +- CometFilter
+                     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :     :     :     +- CometBroadcastExchange
+                     :     :     :        +- CometFilter
+                     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometProject
+                     :     :           +- CometFilter
+                     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+                     +- CometBroadcastExchange
+                        +- CometProject
+                           +- CometFilter
+                              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+
+Comet accelerated 45 out of 47 eligible operators (95%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q92.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q92.native_datafusion/extended.txt
@@ -1,0 +1,41 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometProject
+            +- CometBroadcastHashJoin
+               :- CometProject
+               :  +- CometBroadcastHashJoin
+               :     :- CometProject
+               :     :  +- CometBroadcastHashJoin
+               :     :     :- CometFilter
+               :     :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :     :     :        +- CometSubqueryBroadcast
+               :     :     :           +- CometBroadcastExchange
+               :     :     :              +- CometProject
+               :     :     :                 +- CometFilter
+               :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     :     +- CometBroadcastExchange
+               :     :        +- CometProject
+               :     :           +- CometFilter
+               :     :              +- CometNativeScan parquet spark_catalog.default.item
+               :     +- CometBroadcastExchange
+               :        +- CometFilter
+               :           +- CometHashAggregate
+               :              +- CometExchange
+               :                 +- CometHashAggregate
+               :                    +- CometProject
+               :                       +- CometBroadcastHashJoin
+               :                          :- CometFilter
+               :                          :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                          :        +- ReusedSubquery
+               :                          +- CometBroadcastExchange
+               :                             +- CometProject
+               :                                +- CometFilter
+               :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+               +- CometBroadcastExchange
+                  +- CometProject
+                     +- CometFilter
+                        +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 36 out of 38 eligible operators (94%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q92.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q92.native_iceberg_compat/extended.txt
@@ -1,0 +1,42 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometProject
+            +- CometBroadcastHashJoin
+               :- CometProject
+               :  +- CometBroadcastHashJoin
+               :     :- CometProject
+               :     :  +- CometBroadcastHashJoin
+               :     :     :- CometFilter
+               :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :     :     :        +- SubqueryBroadcast
+               :     :     :           +- BroadcastExchange
+               :     :     :              +- CometNativeColumnarToRow
+               :     :     :                 +- CometProject
+               :     :     :                    +- CometFilter
+               :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     :     +- CometBroadcastExchange
+               :     :        +- CometProject
+               :     :           +- CometFilter
+               :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :     +- CometBroadcastExchange
+               :        +- CometFilter
+               :           +- CometHashAggregate
+               :              +- CometExchange
+               :                 +- CometHashAggregate
+               :                    +- CometProject
+               :                       +- CometBroadcastHashJoin
+               :                          :- CometFilter
+               :                          :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                          :        +- ReusedSubquery
+               :                          +- CometBroadcastExchange
+               :                             +- CometProject
+               :                                +- CometFilter
+               :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               +- CometBroadcastExchange
+                  +- CometProject
+                     +- CometFilter
+                        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 35 out of 38 eligible operators (92%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q93.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q93.native_datafusion/extended.txt
@@ -1,0 +1,24 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometSortMergeJoin
+                  :     :- CometSort
+                  :     :  +- CometExchange
+                  :     :     +- CometProject
+                  :     :        +- CometNativeScan parquet spark_catalog.default.store_sales
+                  :     +- CometSort
+                  :        +- CometExchange
+                  :           +- CometProject
+                  :              +- CometFilter
+                  :                 +- CometNativeScan parquet spark_catalog.default.store_returns
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.reason
+
+Comet accelerated 21 out of 21 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q93.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q93.native_iceberg_compat/extended.txt
@@ -1,0 +1,24 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometSortMergeJoin
+                  :     :- CometSort
+                  :     :  +- CometExchange
+                  :     :     +- CometProject
+                  :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :     +- CometSort
+                  :        +- CometExchange
+                  :           +- CometProject
+                  :              +- CometFilter
+                  :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.reason
+
+Comet accelerated 21 out of 21 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q94.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q94.native_datafusion/extended.txt
@@ -1,0 +1,43 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometColumnarExchange
+      +- HashAggregate
+         +-  HashAggregate [COMET: Unsupported aggregation mode PartialMerge]
+            +- CometNativeColumnarToRow
+               +- CometHashAggregate
+                  +- CometProject
+                     +- CometBroadcastHashJoin
+                        :- CometProject
+                        :  +- CometBroadcastHashJoin
+                        :     :- CometProject
+                        :     :  +- CometBroadcastHashJoin
+                        :     :     :- CometSortMergeJoin
+                        :     :     :  :- CometProject
+                        :     :     :  :  +- CometSortMergeJoin
+                        :     :     :  :     :- CometSort
+                        :     :     :  :     :  +- CometExchange
+                        :     :     :  :     :     +- CometProject
+                        :     :     :  :     :        +- CometFilter
+                        :     :     :  :     :           +- CometNativeScan parquet spark_catalog.default.web_sales
+                        :     :     :  :     +- CometSort
+                        :     :     :  :        +- CometExchange
+                        :     :     :  :           +- CometProject
+                        :     :     :  :              +- CometNativeScan parquet spark_catalog.default.web_sales
+                        :     :     :  +- CometSort
+                        :     :     :     +- CometExchange
+                        :     :     :        +- CometProject
+                        :     :     :           +- CometNativeScan parquet spark_catalog.default.web_returns
+                        :     :     +- CometBroadcastExchange
+                        :     :        +- CometProject
+                        :     :           +- CometFilter
+                        :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                        :     +- CometBroadcastExchange
+                        :        +- CometProject
+                        :           +- CometFilter
+                        :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                        +- CometBroadcastExchange
+                           +- CometProject
+                              +- CometFilter
+                                 +- CometNativeScan parquet spark_catalog.default.web_site
+
+Comet accelerated 37 out of 39 eligible operators (94%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q94.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q94.native_iceberg_compat/extended.txt
@@ -1,0 +1,43 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometColumnarExchange
+      +- HashAggregate
+         +-  HashAggregate [COMET: Unsupported aggregation mode PartialMerge]
+            +- CometNativeColumnarToRow
+               +- CometHashAggregate
+                  +- CometProject
+                     +- CometBroadcastHashJoin
+                        :- CometProject
+                        :  +- CometBroadcastHashJoin
+                        :     :- CometProject
+                        :     :  +- CometBroadcastHashJoin
+                        :     :     :- CometSortMergeJoin
+                        :     :     :  :- CometProject
+                        :     :     :  :  +- CometSortMergeJoin
+                        :     :     :  :     :- CometSort
+                        :     :     :  :     :  +- CometExchange
+                        :     :     :  :     :     +- CometProject
+                        :     :     :  :     :        +- CometFilter
+                        :     :     :  :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                        :     :     :  :     +- CometSort
+                        :     :     :  :        +- CometExchange
+                        :     :     :  :           +- CometProject
+                        :     :     :  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                        :     :     :  +- CometSort
+                        :     :     :     +- CometExchange
+                        :     :     :        +- CometProject
+                        :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+                        :     :     +- CometBroadcastExchange
+                        :     :        +- CometProject
+                        :     :           +- CometFilter
+                        :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                        :     +- CometBroadcastExchange
+                        :        +- CometProject
+                        :           +- CometFilter
+                        :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                        +- CometBroadcastExchange
+                           +- CometProject
+                              +- CometFilter
+                                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_site
+
+Comet accelerated 37 out of 39 eligible operators (94%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q95.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q95.native_datafusion/extended.txt
@@ -1,0 +1,65 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometColumnarExchange
+      +- HashAggregate
+         +-  HashAggregate [COMET: Unsupported aggregation mode PartialMerge]
+            +- CometNativeColumnarToRow
+               +- CometHashAggregate
+                  +- CometProject
+                     +- CometBroadcastHashJoin
+                        :- CometProject
+                        :  +- CometBroadcastHashJoin
+                        :     :- CometProject
+                        :     :  +- CometBroadcastHashJoin
+                        :     :     :- CometSortMergeJoin
+                        :     :     :  :- CometSortMergeJoin
+                        :     :     :  :  :- CometSort
+                        :     :     :  :  :  +- CometExchange
+                        :     :     :  :  :     +- CometProject
+                        :     :     :  :  :        +- CometFilter
+                        :     :     :  :  :           +- CometNativeScan parquet spark_catalog.default.web_sales
+                        :     :     :  :  +- CometProject
+                        :     :     :  :     +- CometSortMergeJoin
+                        :     :     :  :        :- CometSort
+                        :     :     :  :        :  +- CometExchange
+                        :     :     :  :        :     +- CometProject
+                        :     :     :  :        :        +- CometFilter
+                        :     :     :  :        :           +- CometNativeScan parquet spark_catalog.default.web_sales
+                        :     :     :  :        +- CometSort
+                        :     :     :  :           +- CometExchange
+                        :     :     :  :              +- CometProject
+                        :     :     :  :                 +- CometFilter
+                        :     :     :  :                    +- CometNativeScan parquet spark_catalog.default.web_sales
+                        :     :     :  +- CometProject
+                        :     :     :     +- CometSortMergeJoin
+                        :     :     :        :- CometSort
+                        :     :     :        :  +- CometExchange
+                        :     :     :        :     +- CometProject
+                        :     :     :        :        +- CometFilter
+                        :     :     :        :           +- CometNativeScan parquet spark_catalog.default.web_returns
+                        :     :     :        +- CometProject
+                        :     :     :           +- CometSortMergeJoin
+                        :     :     :              :- CometSort
+                        :     :     :              :  +- CometExchange
+                        :     :     :              :     +- CometProject
+                        :     :     :              :        +- CometFilter
+                        :     :     :              :           +- CometNativeScan parquet spark_catalog.default.web_sales
+                        :     :     :              +- CometSort
+                        :     :     :                 +- CometExchange
+                        :     :     :                    +- CometProject
+                        :     :     :                       +- CometFilter
+                        :     :     :                          +- CometNativeScan parquet spark_catalog.default.web_sales
+                        :     :     +- CometBroadcastExchange
+                        :     :        +- CometProject
+                        :     :           +- CometFilter
+                        :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                        :     +- CometBroadcastExchange
+                        :        +- CometProject
+                        :           +- CometFilter
+                        :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                        +- CometBroadcastExchange
+                           +- CometProject
+                              +- CometFilter
+                                 +- CometNativeScan parquet spark_catalog.default.web_site
+
+Comet accelerated 59 out of 61 eligible operators (96%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q95.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q95.native_iceberg_compat/extended.txt
@@ -1,0 +1,65 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometColumnarExchange
+      +- HashAggregate
+         +-  HashAggregate [COMET: Unsupported aggregation mode PartialMerge]
+            +- CometNativeColumnarToRow
+               +- CometHashAggregate
+                  +- CometProject
+                     +- CometBroadcastHashJoin
+                        :- CometProject
+                        :  +- CometBroadcastHashJoin
+                        :     :- CometProject
+                        :     :  +- CometBroadcastHashJoin
+                        :     :     :- CometSortMergeJoin
+                        :     :     :  :- CometSortMergeJoin
+                        :     :     :  :  :- CometSort
+                        :     :     :  :  :  +- CometExchange
+                        :     :     :  :  :     +- CometProject
+                        :     :     :  :  :        +- CometFilter
+                        :     :     :  :  :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                        :     :     :  :  +- CometProject
+                        :     :     :  :     +- CometSortMergeJoin
+                        :     :     :  :        :- CometSort
+                        :     :     :  :        :  +- CometExchange
+                        :     :     :  :        :     +- CometProject
+                        :     :     :  :        :        +- CometFilter
+                        :     :     :  :        :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                        :     :     :  :        +- CometSort
+                        :     :     :  :           +- CometExchange
+                        :     :     :  :              +- CometProject
+                        :     :     :  :                 +- CometFilter
+                        :     :     :  :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                        :     :     :  +- CometProject
+                        :     :     :     +- CometSortMergeJoin
+                        :     :     :        :- CometSort
+                        :     :     :        :  +- CometExchange
+                        :     :     :        :     +- CometProject
+                        :     :     :        :        +- CometFilter
+                        :     :     :        :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+                        :     :     :        +- CometProject
+                        :     :     :           +- CometSortMergeJoin
+                        :     :     :              :- CometSort
+                        :     :     :              :  +- CometExchange
+                        :     :     :              :     +- CometProject
+                        :     :     :              :        +- CometFilter
+                        :     :     :              :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                        :     :     :              +- CometSort
+                        :     :     :                 +- CometExchange
+                        :     :     :                    +- CometProject
+                        :     :     :                       +- CometFilter
+                        :     :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                        :     :     +- CometBroadcastExchange
+                        :     :        +- CometProject
+                        :     :           +- CometFilter
+                        :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                        :     +- CometBroadcastExchange
+                        :        +- CometProject
+                        :           +- CometFilter
+                        :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                        +- CometBroadcastExchange
+                           +- CometProject
+                              +- CometFilter
+                                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_site
+
+Comet accelerated 59 out of 61 eligible operators (96%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q96.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q96.native_datafusion/extended.txt
@@ -1,0 +1,27 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometProject
+            +- CometBroadcastHashJoin
+               :- CometProject
+               :  +- CometBroadcastHashJoin
+               :     :- CometProject
+               :     :  +- CometBroadcastHashJoin
+               :     :     :- CometProject
+               :     :     :  +- CometFilter
+               :     :     :     +- CometNativeScan parquet spark_catalog.default.store_sales
+               :     :     +- CometBroadcastExchange
+               :     :        +- CometProject
+               :     :           +- CometFilter
+               :     :              +- CometNativeScan parquet spark_catalog.default.household_demographics
+               :     +- CometBroadcastExchange
+               :        +- CometProject
+               :           +- CometFilter
+               :              +- CometNativeScan parquet spark_catalog.default.time_dim
+               +- CometBroadcastExchange
+                  +- CometProject
+                     +- CometFilter
+                        +- CometNativeScan parquet spark_catalog.default.store
+
+Comet accelerated 24 out of 24 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q96.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q96.native_iceberg_compat/extended.txt
@@ -1,0 +1,27 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometProject
+            +- CometBroadcastHashJoin
+               :- CometProject
+               :  +- CometBroadcastHashJoin
+               :     :- CometProject
+               :     :  +- CometBroadcastHashJoin
+               :     :     :- CometProject
+               :     :     :  +- CometFilter
+               :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :     :     +- CometBroadcastExchange
+               :     :        +- CometProject
+               :     :           +- CometFilter
+               :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+               :     +- CometBroadcastExchange
+               :        +- CometProject
+               :           +- CometFilter
+               :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.time_dim
+               +- CometBroadcastExchange
+                  +- CometProject
+                     +- CometFilter
+                        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+
+Comet accelerated 24 out of 24 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q97.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q97.native_datafusion/extended.txt
@@ -1,0 +1,36 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometProject
+            +- CometSortMergeJoin
+               :- CometSort
+               :  +- CometHashAggregate
+               :     +- CometExchange
+               :        +- CometHashAggregate
+               :           +- CometProject
+               :              +- CometBroadcastHashJoin
+               :                 :- CometNativeScan parquet spark_catalog.default.store_sales
+               :                 :     +- CometSubqueryBroadcast
+               :                 :        +- CometBroadcastExchange
+               :                 :           +- CometProject
+               :                 :              +- CometFilter
+               :                 :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 +- CometBroadcastExchange
+               :                    +- CometProject
+               :                       +- CometFilter
+               :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+               +- CometSort
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometNativeScan parquet spark_catalog.default.catalog_sales
+                                 :     +- ReusedSubquery
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 31 out of 33 eligible operators (93%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q97.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q97.native_iceberg_compat/extended.txt
@@ -1,0 +1,37 @@
+CometNativeColumnarToRow
++- CometHashAggregate
+   +- CometExchange
+      +- CometHashAggregate
+         +- CometProject
+            +- CometSortMergeJoin
+               :- CometSort
+               :  +- CometHashAggregate
+               :     +- CometExchange
+               :        +- CometHashAggregate
+               :           +- CometProject
+               :              +- CometBroadcastHashJoin
+               :                 :- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                 :     +- SubqueryBroadcast
+               :                 :        +- BroadcastExchange
+               :                 :           +- CometNativeColumnarToRow
+               :                 :              +- CometProject
+               :                 :                 +- CometFilter
+               :                 :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 +- CometBroadcastExchange
+               :                    +- CometProject
+               :                       +- CometFilter
+               :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               +- CometSort
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometProject
+                              +- CometBroadcastHashJoin
+                                 :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                                 :     +- ReusedSubquery
+                                 +- CometBroadcastExchange
+                                    +- CometProject
+                                       +- CometFilter
+                                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 30 out of 33 eligible operators (90%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q98.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q98.native_datafusion/extended.txt
@@ -1,0 +1,33 @@
+CometNativeColumnarToRow
++- CometProject
+   +- CometSort
+      +- CometColumnarExchange
+         +- Project
+            +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               +- CometNativeColumnarToRow
+                  +- CometSort
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometExchange
+                              +- CometHashAggregate
+                                 +- CometProject
+                                    +- CometBroadcastHashJoin
+                                       :- CometProject
+                                       :  +- CometBroadcastHashJoin
+                                       :     :- CometFilter
+                                       :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                       :     :        +- CometSubqueryBroadcast
+                                       :     :           +- CometBroadcastExchange
+                                       :     :              +- CometProject
+                                       :     :                 +- CometFilter
+                                       :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       :     +- CometBroadcastExchange
+                                       :        +- CometProject
+                                       :           +- CometFilter
+                                       :              +- CometNativeScan parquet spark_catalog.default.item
+                                       +- CometBroadcastExchange
+                                          +- CometProject
+                                             +- CometFilter
+                                                +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 26 out of 29 eligible operators (89%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q98.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q98.native_iceberg_compat/extended.txt
@@ -1,0 +1,34 @@
+CometNativeColumnarToRow
++- CometProject
+   +- CometSort
+      +- CometColumnarExchange
+         +- Project
+            +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               +- CometNativeColumnarToRow
+                  +- CometSort
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometExchange
+                              +- CometHashAggregate
+                                 +- CometProject
+                                    +- CometBroadcastHashJoin
+                                       :- CometProject
+                                       :  +- CometBroadcastHashJoin
+                                       :     :- CometFilter
+                                       :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                       :     :        +- SubqueryBroadcast
+                                       :     :           +- BroadcastExchange
+                                       :     :              +- CometNativeColumnarToRow
+                                       :     :                 +- CometProject
+                                       :     :                    +- CometFilter
+                                       :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       :     +- CometBroadcastExchange
+                                       :        +- CometProject
+                                       :           +- CometFilter
+                                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                       +- CometBroadcastExchange
+                                          +- CometProject
+                                             +- CometFilter
+                                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 25 out of 29 eligible operators (86%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q99.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q99.native_datafusion/extended.txt
@@ -1,0 +1,31 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometFilter
+                  :     :     :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometFilter
+                  :     :     :           +- CometNativeScan parquet spark_catalog.default.warehouse
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometNativeScan parquet spark_catalog.default.ship_mode
+                  :     +- CometBroadcastExchange
+                  :        +- CometFilter
+                  :           +- CometNativeScan parquet spark_catalog.default.call_center
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 28 out of 28 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q99.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_2/q99.native_iceberg_compat/extended.txt
@@ -1,0 +1,31 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometProject
+                  :     :     :  +- CometBroadcastHashJoin
+                  :     :     :     :- CometFilter
+                  :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                  :     :     :     +- CometBroadcastExchange
+                  :     :     :        +- CometFilter
+                  :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.warehouse
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometProject
+                  :     :           +- CometFilter
+                  :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.ship_mode
+                  :     +- CometBroadcastExchange
+                  :        +- CometFilter
+                  :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.call_center
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 28 out of 28 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q10a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q10a.native_datafusion/extended.txt
@@ -1,0 +1,55 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometBroadcastHashJoin
+                  :     :     :  :- CometFilter
+                  :     :     :  :  +- CometNativeScan parquet spark_catalog.default.customer
+                  :     :     :  +- CometBroadcastExchange
+                  :     :     :     +- CometProject
+                  :     :     :        +- CometBroadcastHashJoin
+                  :     :     :           :- CometNativeScan parquet spark_catalog.default.store_sales
+                  :     :     :           :     +- CometSubqueryBroadcast
+                  :     :     :           :        +- CometBroadcastExchange
+                  :     :     :           :           +- CometProject
+                  :     :     :           :              +- CometFilter
+                  :     :     :           :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     :           +- CometBroadcastExchange
+                  :     :     :              +- CometProject
+                  :     :     :                 +- CometFilter
+                  :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometUnion
+                  :     :           :- CometProject
+                  :     :           :  +- CometBroadcastHashJoin
+                  :     :           :     :- CometNativeScan parquet spark_catalog.default.web_sales
+                  :     :           :     :     +- ReusedSubquery
+                  :     :           :     +- CometBroadcastExchange
+                  :     :           :        +- CometProject
+                  :     :           :           +- CometFilter
+                  :     :           :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :           +- CometProject
+                  :     :              +- CometBroadcastHashJoin
+                  :     :                 :- CometNativeScan parquet spark_catalog.default.catalog_sales
+                  :     :                 :     +- ReusedSubquery
+                  :     :                 +- CometBroadcastExchange
+                  :     :                    +- CometProject
+                  :     :                       +- CometFilter
+                  :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.customer_demographics
+
+Comet accelerated 49 out of 52 eligible operators (94%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q10a.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q10a.native_iceberg_compat/extended.txt
@@ -1,0 +1,56 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometBroadcastHashJoin
+                  :     :     :  :- CometFilter
+                  :     :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                  :     :     :  +- CometBroadcastExchange
+                  :     :     :     +- CometProject
+                  :     :     :        +- CometBroadcastHashJoin
+                  :     :     :           :- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :     :     :           :     +- SubqueryBroadcast
+                  :     :     :           :        +- BroadcastExchange
+                  :     :     :           :           +- CometNativeColumnarToRow
+                  :     :     :           :              +- CometProject
+                  :     :     :           :                 +- CometFilter
+                  :     :     :           :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     :           +- CometBroadcastExchange
+                  :     :     :              +- CometProject
+                  :     :     :                 +- CometFilter
+                  :     :     :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometUnion
+                  :     :           :- CometProject
+                  :     :           :  +- CometBroadcastHashJoin
+                  :     :           :     :- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                  :     :           :     :     +- ReusedSubquery
+                  :     :           :     +- CometBroadcastExchange
+                  :     :           :        +- CometProject
+                  :     :           :           +- CometFilter
+                  :     :           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :           +- CometProject
+                  :     :              +- CometBroadcastHashJoin
+                  :     :                 :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                  :     :                 :     +- ReusedSubquery
+                  :     :                 +- CometBroadcastExchange
+                  :     :                    +- CometProject
+                  :     :                       +- CometFilter
+                  :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+
+Comet accelerated 48 out of 52 eligible operators (92%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q11.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q11.native_datafusion/extended.txt
@@ -1,0 +1,88 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometBroadcastHashJoin
+         :     :  :- CometFilter
+         :     :  :  +- CometHashAggregate
+         :     :  :     +- CometExchange
+         :     :  :        +- CometHashAggregate
+         :     :  :           +- CometProject
+         :     :  :              +- CometBroadcastHashJoin
+         :     :  :                 :- CometProject
+         :     :  :                 :  +- CometBroadcastHashJoin
+         :     :  :                 :     :- CometProject
+         :     :  :                 :     :  +- CometFilter
+         :     :  :                 :     :     +- CometNativeScan parquet spark_catalog.default.customer
+         :     :  :                 :     +- CometBroadcastExchange
+         :     :  :                 :        +- CometFilter
+         :     :  :                 :           +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     :  :                 :                 +- CometSubqueryBroadcast
+         :     :  :                 :                    +- CometBroadcastExchange
+         :     :  :                 :                       +- CometFilter
+         :     :  :                 :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :  :                 +- CometBroadcastExchange
+         :     :  :                    +- CometFilter
+         :     :  :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :  +- CometBroadcastExchange
+         :     :     +- CometHashAggregate
+         :     :        +- CometExchange
+         :     :           +- CometHashAggregate
+         :     :              +- CometProject
+         :     :                 +- CometBroadcastHashJoin
+         :     :                    :- CometProject
+         :     :                    :  +- CometBroadcastHashJoin
+         :     :                    :     :- CometProject
+         :     :                    :     :  +- CometFilter
+         :     :                    :     :     +- CometNativeScan parquet spark_catalog.default.customer
+         :     :                    :     +- CometBroadcastExchange
+         :     :                    :        +- CometFilter
+         :     :                    :           +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     :                    :                 +- CometSubqueryBroadcast
+         :     :                    :                    +- CometBroadcastExchange
+         :     :                    :                       +- CometFilter
+         :     :                    :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :                    +- CometBroadcastExchange
+         :     :                       +- CometFilter
+         :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     +- CometBroadcastExchange
+         :        +- CometFilter
+         :           +- CometHashAggregate
+         :              +- CometExchange
+         :                 +- CometHashAggregate
+         :                    +- CometProject
+         :                       +- CometBroadcastHashJoin
+         :                          :- CometProject
+         :                          :  +- CometBroadcastHashJoin
+         :                          :     :- CometProject
+         :                          :     :  +- CometFilter
+         :                          :     :     +- CometNativeScan parquet spark_catalog.default.customer
+         :                          :     +- CometBroadcastExchange
+         :                          :        +- CometFilter
+         :                          :           +- CometNativeScan parquet spark_catalog.default.web_sales
+         :                          :                 +- ReusedSubquery
+         :                          +- CometBroadcastExchange
+         :                             +- CometFilter
+         :                                +- CometNativeScan parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometFilter
+                           :     :     +- CometNativeScan parquet spark_catalog.default.customer
+                           :     +- CometBroadcastExchange
+                           :        +- CometFilter
+                           :           +- CometNativeScan parquet spark_catalog.default.web_sales
+                           :                 +- ReusedSubquery
+                           +- CometBroadcastExchange
+                              +- CometFilter
+                                 +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 81 out of 85 eligible operators (95%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q11.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q11.native_iceberg_compat/extended.txt
@@ -1,0 +1,90 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometBroadcastHashJoin
+         :     :  :- CometFilter
+         :     :  :  +- CometHashAggregate
+         :     :  :     +- CometExchange
+         :     :  :        +- CometHashAggregate
+         :     :  :           +- CometProject
+         :     :  :              +- CometBroadcastHashJoin
+         :     :  :                 :- CometProject
+         :     :  :                 :  +- CometBroadcastHashJoin
+         :     :  :                 :     :- CometProject
+         :     :  :                 :     :  +- CometFilter
+         :     :  :                 :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         :     :  :                 :     +- CometBroadcastExchange
+         :     :  :                 :        +- CometFilter
+         :     :  :                 :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     :  :                 :                 +- SubqueryBroadcast
+         :     :  :                 :                    +- BroadcastExchange
+         :     :  :                 :                       +- CometNativeColumnarToRow
+         :     :  :                 :                          +- CometFilter
+         :     :  :                 :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :  :                 +- CometBroadcastExchange
+         :     :  :                    +- CometFilter
+         :     :  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :  +- CometBroadcastExchange
+         :     :     +- CometHashAggregate
+         :     :        +- CometExchange
+         :     :           +- CometHashAggregate
+         :     :              +- CometProject
+         :     :                 +- CometBroadcastHashJoin
+         :     :                    :- CometProject
+         :     :                    :  +- CometBroadcastHashJoin
+         :     :                    :     :- CometProject
+         :     :                    :     :  +- CometFilter
+         :     :                    :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         :     :                    :     +- CometBroadcastExchange
+         :     :                    :        +- CometFilter
+         :     :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     :                    :                 +- SubqueryBroadcast
+         :     :                    :                    +- BroadcastExchange
+         :     :                    :                       +- CometNativeColumnarToRow
+         :     :                    :                          +- CometFilter
+         :     :                    :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :                    +- CometBroadcastExchange
+         :     :                       +- CometFilter
+         :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     +- CometBroadcastExchange
+         :        +- CometFilter
+         :           +- CometHashAggregate
+         :              +- CometExchange
+         :                 +- CometHashAggregate
+         :                    +- CometProject
+         :                       +- CometBroadcastHashJoin
+         :                          :- CometProject
+         :                          :  +- CometBroadcastHashJoin
+         :                          :     :- CometProject
+         :                          :     :  +- CometFilter
+         :                          :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         :                          :     +- CometBroadcastExchange
+         :                          :        +- CometFilter
+         :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+         :                          :                 +- ReusedSubquery
+         :                          +- CometBroadcastExchange
+         :                             +- CometFilter
+         :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometFilter
+                           :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                           :     +- CometBroadcastExchange
+                           :        +- CometFilter
+                           :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                           :                 +- ReusedSubquery
+                           +- CometBroadcastExchange
+                              +- CometFilter
+                                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 79 out of 85 eligible operators (92%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q12.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q12.native_datafusion/extended.txt
@@ -1,0 +1,30 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometBroadcastHashJoin
+                              :     :- CometFilter
+                              :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                              :     :        +- CometSubqueryBroadcast
+                              :     :           +- CometBroadcastExchange
+                              :     :              +- CometProject
+                              :     :                 +- CometFilter
+                              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :     +- CometBroadcastExchange
+                              :        +- CometProject
+                              :           +- CometFilter
+                              :              +- CometNativeScan parquet spark_catalog.default.item
+                              +- CometBroadcastExchange
+                                 +- CometProject
+                                    +- CometFilter
+                                       +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 23 out of 27 eligible operators (85%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q12.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q12.native_iceberg_compat/extended.txt
@@ -1,0 +1,31 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometBroadcastHashJoin
+                              :     :- CometFilter
+                              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                              :     :        +- SubqueryBroadcast
+                              :     :           +- BroadcastExchange
+                              :     :              +- CometNativeColumnarToRow
+                              :     :                 +- CometProject
+                              :     :                    +- CometFilter
+                              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :     +- CometBroadcastExchange
+                              :        +- CometProject
+                              :           +- CometFilter
+                              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                              +- CometBroadcastExchange
+                                 +- CometProject
+                                    +- CometFilter
+                                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 22 out of 27 eligible operators (81%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q14.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q14.native_datafusion/extended.txt
@@ -1,0 +1,345 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometBroadcastHashJoin
+      :- CometFilter
+      :  :  +- Subquery
+      :  :     +- CometNativeColumnarToRow
+      :  :        +- CometHashAggregate
+      :  :           +- CometExchange
+      :  :              +- CometHashAggregate
+      :  :                 +- CometUnion
+      :  :                    :- CometProject
+      :  :                    :  +- CometBroadcastHashJoin
+      :  :                    :     :- CometNativeScan parquet spark_catalog.default.store_sales
+      :  :                    :     :     +- ReusedSubquery
+      :  :                    :     +- CometBroadcastExchange
+      :  :                    :        +- CometProject
+      :  :                    :           +- CometFilter
+      :  :                    :              +- CometNativeScan parquet spark_catalog.default.date_dim
+      :  :                    :- CometProject
+      :  :                    :  +- CometBroadcastHashJoin
+      :  :                    :     :- CometNativeScan parquet spark_catalog.default.catalog_sales
+      :  :                    :     :     +- ReusedSubquery
+      :  :                    :     +- CometBroadcastExchange
+      :  :                    :        +- CometProject
+      :  :                    :           +- CometFilter
+      :  :                    :              +- CometNativeScan parquet spark_catalog.default.date_dim
+      :  :                    +- CometProject
+      :  :                       +- CometBroadcastHashJoin
+      :  :                          :- CometNativeScan parquet spark_catalog.default.web_sales
+      :  :                          :     +- ReusedSubquery
+      :  :                          +- CometBroadcastExchange
+      :  :                             +- CometProject
+      :  :                                +- CometFilter
+      :  :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+      :  +- CometHashAggregate
+      :     +- CometExchange
+      :        +- CometHashAggregate
+      :           +- CometProject
+      :              +- CometBroadcastHashJoin
+      :                 :- CometProject
+      :                 :  +- CometBroadcastHashJoin
+      :                 :     :- CometBroadcastHashJoin
+      :                 :     :  :- CometFilter
+      :                 :     :  :  +- CometNativeScan parquet spark_catalog.default.store_sales
+      :                 :     :  :        +- CometSubqueryBroadcast
+      :                 :     :  :           +- CometBroadcastExchange
+      :                 :     :  :              +- CometProject
+      :                 :     :  :                 +- CometFilter
+      :                 :     :  :                    :  +- ReusedSubquery
+      :                 :     :  :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 :     :  :                          +- Subquery
+      :                 :     :  :                             +- CometNativeColumnarToRow
+      :                 :     :  :                                +- CometProject
+      :                 :     :  :                                   +- CometFilter
+      :                 :     :  :                                      +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 :     :  +- CometBroadcastExchange
+      :                 :     :     +- CometProject
+      :                 :     :        +- CometBroadcastHashJoin
+      :                 :     :           :- CometFilter
+      :                 :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+      :                 :     :           +- CometBroadcastExchange
+      :                 :     :              +- CometBroadcastHashJoin
+      :                 :     :                 :- CometHashAggregate
+      :                 :     :                 :  +- CometExchange
+      :                 :     :                 :     +- CometHashAggregate
+      :                 :     :                 :        +- CometProject
+      :                 :     :                 :           +- CometBroadcastHashJoin
+      :                 :     :                 :              :- CometProject
+      :                 :     :                 :              :  +- CometBroadcastHashJoin
+      :                 :     :                 :              :     :- CometFilter
+      :                 :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+      :                 :     :                 :              :     :        +- CometSubqueryBroadcast
+      :                 :     :                 :              :     :           +- CometBroadcastExchange
+      :                 :     :                 :              :     :              +- CometProject
+      :                 :     :                 :              :     :                 +- CometFilter
+      :                 :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 :     :                 :              :     +- CometBroadcastExchange
+      :                 :     :                 :              :        +- CometBroadcastHashJoin
+      :                 :     :                 :              :           :- CometFilter
+      :                 :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+      :                 :     :                 :              :           +- CometBroadcastExchange
+      :                 :     :                 :              :              +- CometProject
+      :                 :     :                 :              :                 +- CometBroadcastHashJoin
+      :                 :     :                 :              :                    :- CometProject
+      :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+      :                 :     :                 :              :                    :     :- CometFilter
+      :                 :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+      :                 :     :                 :              :                    :     :        +- ReusedSubquery
+      :                 :     :                 :              :                    :     +- CometBroadcastExchange
+      :                 :     :                 :              :                    :        +- CometFilter
+      :                 :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+      :                 :     :                 :              :                    +- CometBroadcastExchange
+      :                 :     :                 :              :                       +- CometProject
+      :                 :     :                 :              :                          +- CometFilter
+      :                 :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 :     :                 :              +- CometBroadcastExchange
+      :                 :     :                 :                 +- CometProject
+      :                 :     :                 :                    +- CometFilter
+      :                 :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 :     :                 +- CometBroadcastExchange
+      :                 :     :                    +- CometProject
+      :                 :     :                       +- CometBroadcastHashJoin
+      :                 :     :                          :- CometProject
+      :                 :     :                          :  +- CometBroadcastHashJoin
+      :                 :     :                          :     :- CometFilter
+      :                 :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+      :                 :     :                          :     :        +- ReusedSubquery
+      :                 :     :                          :     +- CometBroadcastExchange
+      :                 :     :                          :        +- CometFilter
+      :                 :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+      :                 :     :                          +- CometBroadcastExchange
+      :                 :     :                             +- CometProject
+      :                 :     :                                +- CometFilter
+      :                 :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 :     +- CometBroadcastExchange
+      :                 :        +- CometBroadcastHashJoin
+      :                 :           :- CometFilter
+      :                 :           :  +- CometNativeScan parquet spark_catalog.default.item
+      :                 :           +- CometBroadcastExchange
+      :                 :              +- CometProject
+      :                 :                 +- CometBroadcastHashJoin
+      :                 :                    :- CometFilter
+      :                 :                    :  +- CometNativeScan parquet spark_catalog.default.item
+      :                 :                    +- CometBroadcastExchange
+      :                 :                       +- CometBroadcastHashJoin
+      :                 :                          :- CometHashAggregate
+      :                 :                          :  +- CometExchange
+      :                 :                          :     +- CometHashAggregate
+      :                 :                          :        +- CometProject
+      :                 :                          :           +- CometBroadcastHashJoin
+      :                 :                          :              :- CometProject
+      :                 :                          :              :  +- CometBroadcastHashJoin
+      :                 :                          :              :     :- CometFilter
+      :                 :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+      :                 :                          :              :     :        +- CometSubqueryBroadcast
+      :                 :                          :              :     :           +- CometBroadcastExchange
+      :                 :                          :              :     :              +- CometProject
+      :                 :                          :              :     :                 +- CometFilter
+      :                 :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 :                          :              :     +- CometBroadcastExchange
+      :                 :                          :              :        +- CometBroadcastHashJoin
+      :                 :                          :              :           :- CometFilter
+      :                 :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+      :                 :                          :              :           +- CometBroadcastExchange
+      :                 :                          :              :              +- CometProject
+      :                 :                          :              :                 +- CometBroadcastHashJoin
+      :                 :                          :              :                    :- CometProject
+      :                 :                          :              :                    :  +- CometBroadcastHashJoin
+      :                 :                          :              :                    :     :- CometFilter
+      :                 :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+      :                 :                          :              :                    :     :        +- ReusedSubquery
+      :                 :                          :              :                    :     +- CometBroadcastExchange
+      :                 :                          :              :                    :        +- CometFilter
+      :                 :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+      :                 :                          :              :                    +- CometBroadcastExchange
+      :                 :                          :              :                       +- CometProject
+      :                 :                          :              :                          +- CometFilter
+      :                 :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 :                          :              +- CometBroadcastExchange
+      :                 :                          :                 +- CometProject
+      :                 :                          :                    +- CometFilter
+      :                 :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 :                          +- CometBroadcastExchange
+      :                 :                             +- CometProject
+      :                 :                                +- CometBroadcastHashJoin
+      :                 :                                   :- CometProject
+      :                 :                                   :  +- CometBroadcastHashJoin
+      :                 :                                   :     :- CometFilter
+      :                 :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+      :                 :                                   :     :        +- ReusedSubquery
+      :                 :                                   :     +- CometBroadcastExchange
+      :                 :                                   :        +- CometFilter
+      :                 :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+      :                 :                                   +- CometBroadcastExchange
+      :                 :                                      +- CometProject
+      :                 :                                         +- CometFilter
+      :                 :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                 +- CometBroadcastExchange
+      :                    +- CometProject
+      :                       +- CometFilter
+      :                          :  +- ReusedSubquery
+      :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                                +- Subquery
+      :                                   +- CometNativeColumnarToRow
+      :                                      +- CometProject
+      :                                         +- CometFilter
+      :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+      +- CometBroadcastExchange
+         +- CometFilter
+            :  +- ReusedSubquery
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometBroadcastHashJoin
+                           :     :  :- CometFilter
+                           :     :  :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                           :     :  :        +- CometSubqueryBroadcast
+                           :     :  :           +- CometBroadcastExchange
+                           :     :  :              +- CometProject
+                           :     :  :                 +- CometFilter
+                           :     :  :                    :  +- ReusedSubquery
+                           :     :  :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     :  :                          +- Subquery
+                           :     :  :                             +- CometNativeColumnarToRow
+                           :     :  :                                +- CometProject
+                           :     :  :                                   +- CometFilter
+                           :     :  :                                      +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     :  +- CometBroadcastExchange
+                           :     :     +- CometProject
+                           :     :        +- CometBroadcastHashJoin
+                           :     :           :- CometFilter
+                           :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+                           :     :           +- CometBroadcastExchange
+                           :     :              +- CometBroadcastHashJoin
+                           :     :                 :- CometHashAggregate
+                           :     :                 :  +- CometExchange
+                           :     :                 :     +- CometHashAggregate
+                           :     :                 :        +- CometProject
+                           :     :                 :           +- CometBroadcastHashJoin
+                           :     :                 :              :- CometProject
+                           :     :                 :              :  +- CometBroadcastHashJoin
+                           :     :                 :              :     :- CometFilter
+                           :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                           :     :                 :              :     :        +- CometSubqueryBroadcast
+                           :     :                 :              :     :           +- CometBroadcastExchange
+                           :     :                 :              :     :              +- CometProject
+                           :     :                 :              :     :                 +- CometFilter
+                           :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     :                 :              :     +- CometBroadcastExchange
+                           :     :                 :              :        +- CometBroadcastHashJoin
+                           :     :                 :              :           :- CometFilter
+                           :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+                           :     :                 :              :           +- CometBroadcastExchange
+                           :     :                 :              :              +- CometProject
+                           :     :                 :              :                 +- CometBroadcastHashJoin
+                           :     :                 :              :                    :- CometProject
+                           :     :                 :              :                    :  +- CometBroadcastHashJoin
+                           :     :                 :              :                    :     :- CometFilter
+                           :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                           :     :                 :              :                    :     :        +- ReusedSubquery
+                           :     :                 :              :                    :     +- CometBroadcastExchange
+                           :     :                 :              :                    :        +- CometFilter
+                           :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+                           :     :                 :              :                    +- CometBroadcastExchange
+                           :     :                 :              :                       +- CometProject
+                           :     :                 :              :                          +- CometFilter
+                           :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     :                 :              +- CometBroadcastExchange
+                           :     :                 :                 +- CometProject
+                           :     :                 :                    +- CometFilter
+                           :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     :                 +- CometBroadcastExchange
+                           :     :                    +- CometProject
+                           :     :                       +- CometBroadcastHashJoin
+                           :     :                          :- CometProject
+                           :     :                          :  +- CometBroadcastHashJoin
+                           :     :                          :     :- CometFilter
+                           :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                           :     :                          :     :        +- ReusedSubquery
+                           :     :                          :     +- CometBroadcastExchange
+                           :     :                          :        +- CometFilter
+                           :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+                           :     :                          +- CometBroadcastExchange
+                           :     :                             +- CometProject
+                           :     :                                +- CometFilter
+                           :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :     +- CometBroadcastExchange
+                           :        +- CometBroadcastHashJoin
+                           :           :- CometFilter
+                           :           :  +- CometNativeScan parquet spark_catalog.default.item
+                           :           +- CometBroadcastExchange
+                           :              +- CometProject
+                           :                 +- CometBroadcastHashJoin
+                           :                    :- CometFilter
+                           :                    :  +- CometNativeScan parquet spark_catalog.default.item
+                           :                    +- CometBroadcastExchange
+                           :                       +- CometBroadcastHashJoin
+                           :                          :- CometHashAggregate
+                           :                          :  +- CometExchange
+                           :                          :     +- CometHashAggregate
+                           :                          :        +- CometProject
+                           :                          :           +- CometBroadcastHashJoin
+                           :                          :              :- CometProject
+                           :                          :              :  +- CometBroadcastHashJoin
+                           :                          :              :     :- CometFilter
+                           :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                           :                          :              :     :        +- CometSubqueryBroadcast
+                           :                          :              :     :           +- CometBroadcastExchange
+                           :                          :              :     :              +- CometProject
+                           :                          :              :     :                 +- CometFilter
+                           :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :                          :              :     +- CometBroadcastExchange
+                           :                          :              :        +- CometBroadcastHashJoin
+                           :                          :              :           :- CometFilter
+                           :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+                           :                          :              :           +- CometBroadcastExchange
+                           :                          :              :              +- CometProject
+                           :                          :              :                 +- CometBroadcastHashJoin
+                           :                          :              :                    :- CometProject
+                           :                          :              :                    :  +- CometBroadcastHashJoin
+                           :                          :              :                    :     :- CometFilter
+                           :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                           :                          :              :                    :     :        +- ReusedSubquery
+                           :                          :              :                    :     +- CometBroadcastExchange
+                           :                          :              :                    :        +- CometFilter
+                           :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+                           :                          :              :                    +- CometBroadcastExchange
+                           :                          :              :                       +- CometProject
+                           :                          :              :                          +- CometFilter
+                           :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :                          :              +- CometBroadcastExchange
+                           :                          :                 +- CometProject
+                           :                          :                    +- CometFilter
+                           :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :                          +- CometBroadcastExchange
+                           :                             +- CometProject
+                           :                                +- CometBroadcastHashJoin
+                           :                                   :- CometProject
+                           :                                   :  +- CometBroadcastHashJoin
+                           :                                   :     :- CometFilter
+                           :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                           :                                   :     :        +- ReusedSubquery
+                           :                                   :     +- CometBroadcastExchange
+                           :                                   :        +- CometFilter
+                           :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+                           :                                   +- CometBroadcastExchange
+                           :                                      +- CometProject
+                           :                                         +- CometFilter
+                           :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+                           +- CometBroadcastExchange
+                              +- CometProject
+                                 +- CometFilter
+                                    :  +- ReusedSubquery
+                                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                          +- Subquery
+                                             +- CometNativeColumnarToRow
+                                                +- CometProject
+                                                   +- CometFilter
+                                                      +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 310 out of 337 eligible operators (91%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q14.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q14.native_iceberg_compat/extended.txt
@@ -1,0 +1,343 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometBroadcastHashJoin
+      :- CometFilter
+      :  :  +- Subquery
+      :  :     +- CometNativeColumnarToRow
+      :  :        +- CometHashAggregate
+      :  :           +- CometExchange
+      :  :              +- CometHashAggregate
+      :  :                 +- CometUnion
+      :  :                    :- CometProject
+      :  :                    :  +- CometBroadcastHashJoin
+      :  :                    :     :- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+      :  :                    :     :     +- ReusedSubquery
+      :  :                    :     +- CometBroadcastExchange
+      :  :                    :        +- CometProject
+      :  :                    :           +- CometFilter
+      :  :                    :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :  :                    :- CometProject
+      :  :                    :  +- CometBroadcastHashJoin
+      :  :                    :     :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+      :  :                    :     :     +- ReusedSubquery
+      :  :                    :     +- CometBroadcastExchange
+      :  :                    :        +- CometProject
+      :  :                    :           +- CometFilter
+      :  :                    :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :  :                    +- CometProject
+      :  :                       +- CometBroadcastHashJoin
+      :  :                          :- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+      :  :                          :     +- ReusedSubquery
+      :  :                          +- CometBroadcastExchange
+      :  :                             +- CometProject
+      :  :                                +- CometFilter
+      :  :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :  +- CometHashAggregate
+      :     +- CometExchange
+      :        +- CometHashAggregate
+      :           +- CometProject
+      :              +- CometBroadcastHashJoin
+      :                 :- CometProject
+      :                 :  +- CometBroadcastHashJoin
+      :                 :     :- CometBroadcastHashJoin
+      :                 :     :  :- CometFilter
+      :                 :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+      :                 :     :  :        +- SubqueryBroadcast
+      :                 :     :  :           +- BroadcastExchange
+      :                 :     :  :              +- CometNativeColumnarToRow
+      :                 :     :  :                 +- CometProject
+      :                 :     :  :                    +- CometFilter
+      :                 :     :  :                       :  +- ReusedSubquery
+      :                 :     :  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 :     :  :                             +- Subquery
+      :                 :     :  :                                +- CometNativeColumnarToRow
+      :                 :     :  :                                   +- CometProject
+      :                 :     :  :                                      +- CometFilter
+      :                 :     :  :                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 :     :  +- CometBroadcastExchange
+      :                 :     :     +- CometProject
+      :                 :     :        +- CometBroadcastHashJoin
+      :                 :     :           :- CometFilter
+      :                 :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                 :     :           +- CometBroadcastExchange
+      :                 :     :              +- CometBroadcastHashJoin
+      :                 :     :                 :- CometHashAggregate
+      :                 :     :                 :  +- CometExchange
+      :                 :     :                 :     +- CometHashAggregate
+      :                 :     :                 :        +- CometProject
+      :                 :     :                 :           +- CometBroadcastHashJoin
+      :                 :     :                 :              :- CometProject
+      :                 :     :                 :              :  +- CometBroadcastHashJoin
+      :                 :     :                 :              :     :- CometFilter
+      :                 :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+      :                 :     :                 :              :     :        +- SubqueryBroadcast
+      :                 :     :                 :              :     :           +- BroadcastExchange
+      :                 :     :                 :              :     :              +- CometNativeColumnarToRow
+      :                 :     :                 :              :     :                 +- CometProject
+      :                 :     :                 :              :     :                    +- CometFilter
+      :                 :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 :     :                 :              :     +- CometBroadcastExchange
+      :                 :     :                 :              :        +- CometBroadcastHashJoin
+      :                 :     :                 :              :           :- CometFilter
+      :                 :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                 :     :                 :              :           +- CometBroadcastExchange
+      :                 :     :                 :              :              +- CometProject
+      :                 :     :                 :              :                 +- CometBroadcastHashJoin
+      :                 :     :                 :              :                    :- CometProject
+      :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+      :                 :     :                 :              :                    :     :- CometFilter
+      :                 :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+      :                 :     :                 :              :                    :     :        +- ReusedSubquery
+      :                 :     :                 :              :                    :     +- CometBroadcastExchange
+      :                 :     :                 :              :                    :        +- CometFilter
+      :                 :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                 :     :                 :              :                    +- CometBroadcastExchange
+      :                 :     :                 :              :                       +- CometProject
+      :                 :     :                 :              :                          +- CometFilter
+      :                 :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 :     :                 :              +- CometBroadcastExchange
+      :                 :     :                 :                 +- CometProject
+      :                 :     :                 :                    +- CometFilter
+      :                 :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 :     :                 +- CometBroadcastExchange
+      :                 :     :                    +- CometProject
+      :                 :     :                       +- CometBroadcastHashJoin
+      :                 :     :                          :- CometProject
+      :                 :     :                          :  +- CometBroadcastHashJoin
+      :                 :     :                          :     :- CometFilter
+      :                 :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+      :                 :     :                          :     :        +- ReusedSubquery
+      :                 :     :                          :     +- CometBroadcastExchange
+      :                 :     :                          :        +- CometFilter
+      :                 :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                 :     :                          +- CometBroadcastExchange
+      :                 :     :                             +- CometProject
+      :                 :     :                                +- CometFilter
+      :                 :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 :     +- CometBroadcastExchange
+      :                 :        +- CometBroadcastHashJoin
+      :                 :           :- CometFilter
+      :                 :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                 :           +- CometBroadcastExchange
+      :                 :              +- CometProject
+      :                 :                 +- CometBroadcastHashJoin
+      :                 :                    :- CometFilter
+      :                 :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                 :                    +- CometBroadcastExchange
+      :                 :                       +- CometBroadcastHashJoin
+      :                 :                          :- CometHashAggregate
+      :                 :                          :  +- CometExchange
+      :                 :                          :     +- CometHashAggregate
+      :                 :                          :        +- CometProject
+      :                 :                          :           +- CometBroadcastHashJoin
+      :                 :                          :              :- CometProject
+      :                 :                          :              :  +- CometBroadcastHashJoin
+      :                 :                          :              :     :- CometFilter
+      :                 :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+      :                 :                          :              :     :        +- SubqueryBroadcast
+      :                 :                          :              :     :           +- BroadcastExchange
+      :                 :                          :              :     :              +- CometNativeColumnarToRow
+      :                 :                          :              :     :                 +- CometProject
+      :                 :                          :              :     :                    +- CometFilter
+      :                 :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 :                          :              :     +- CometBroadcastExchange
+      :                 :                          :              :        +- CometBroadcastHashJoin
+      :                 :                          :              :           :- CometFilter
+      :                 :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                 :                          :              :           +- CometBroadcastExchange
+      :                 :                          :              :              +- CometProject
+      :                 :                          :              :                 +- CometBroadcastHashJoin
+      :                 :                          :              :                    :- CometProject
+      :                 :                          :              :                    :  +- CometBroadcastHashJoin
+      :                 :                          :              :                    :     :- CometFilter
+      :                 :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+      :                 :                          :              :                    :     :        +- ReusedSubquery
+      :                 :                          :              :                    :     +- CometBroadcastExchange
+      :                 :                          :              :                    :        +- CometFilter
+      :                 :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                 :                          :              :                    +- CometBroadcastExchange
+      :                 :                          :              :                       +- CometProject
+      :                 :                          :              :                          +- CometFilter
+      :                 :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 :                          :              +- CometBroadcastExchange
+      :                 :                          :                 +- CometProject
+      :                 :                          :                    +- CometFilter
+      :                 :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 :                          +- CometBroadcastExchange
+      :                 :                             +- CometProject
+      :                 :                                +- CometBroadcastHashJoin
+      :                 :                                   :- CometProject
+      :                 :                                   :  +- CometBroadcastHashJoin
+      :                 :                                   :     :- CometFilter
+      :                 :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+      :                 :                                   :     :        +- ReusedSubquery
+      :                 :                                   :     +- CometBroadcastExchange
+      :                 :                                   :        +- CometFilter
+      :                 :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                 :                                   +- CometBroadcastExchange
+      :                 :                                      +- CometProject
+      :                 :                                         +- CometFilter
+      :                 :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                 +- CometBroadcastExchange
+      :                    +- CometProject
+      :                       +- CometFilter
+      :                          :  +- ReusedSubquery
+      :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                                +- ReusedSubquery
+      +- CometBroadcastExchange
+         +- CometFilter
+            :  +- ReusedSubquery
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometBroadcastHashJoin
+                           :     :  :- CometFilter
+                           :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                           :     :  :        +- SubqueryBroadcast
+                           :     :  :           +- BroadcastExchange
+                           :     :  :              +- CometNativeColumnarToRow
+                           :     :  :                 +- CometProject
+                           :     :  :                    +- CometFilter
+                           :     :  :                       :  +- ReusedSubquery
+                           :     :  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     :  :                             +- Subquery
+                           :     :  :                                +- CometNativeColumnarToRow
+                           :     :  :                                   +- CometProject
+                           :     :  :                                      +- CometFilter
+                           :     :  :                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     :  +- CometBroadcastExchange
+                           :     :     +- CometProject
+                           :     :        +- CometBroadcastHashJoin
+                           :     :           :- CometFilter
+                           :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :     :           +- CometBroadcastExchange
+                           :     :              +- CometBroadcastHashJoin
+                           :     :                 :- CometHashAggregate
+                           :     :                 :  +- CometExchange
+                           :     :                 :     +- CometHashAggregate
+                           :     :                 :        +- CometProject
+                           :     :                 :           +- CometBroadcastHashJoin
+                           :     :                 :              :- CometProject
+                           :     :                 :              :  +- CometBroadcastHashJoin
+                           :     :                 :              :     :- CometFilter
+                           :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                           :     :                 :              :     :        +- SubqueryBroadcast
+                           :     :                 :              :     :           +- BroadcastExchange
+                           :     :                 :              :     :              +- CometNativeColumnarToRow
+                           :     :                 :              :     :                 +- CometProject
+                           :     :                 :              :     :                    +- CometFilter
+                           :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     :                 :              :     +- CometBroadcastExchange
+                           :     :                 :              :        +- CometBroadcastHashJoin
+                           :     :                 :              :           :- CometFilter
+                           :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :     :                 :              :           +- CometBroadcastExchange
+                           :     :                 :              :              +- CometProject
+                           :     :                 :              :                 +- CometBroadcastHashJoin
+                           :     :                 :              :                    :- CometProject
+                           :     :                 :              :                    :  +- CometBroadcastHashJoin
+                           :     :                 :              :                    :     :- CometFilter
+                           :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                           :     :                 :              :                    :     :        +- ReusedSubquery
+                           :     :                 :              :                    :     +- CometBroadcastExchange
+                           :     :                 :              :                    :        +- CometFilter
+                           :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :     :                 :              :                    +- CometBroadcastExchange
+                           :     :                 :              :                       +- CometProject
+                           :     :                 :              :                          +- CometFilter
+                           :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     :                 :              +- CometBroadcastExchange
+                           :     :                 :                 +- CometProject
+                           :     :                 :                    +- CometFilter
+                           :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     :                 +- CometBroadcastExchange
+                           :     :                    +- CometProject
+                           :     :                       +- CometBroadcastHashJoin
+                           :     :                          :- CometProject
+                           :     :                          :  +- CometBroadcastHashJoin
+                           :     :                          :     :- CometFilter
+                           :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                           :     :                          :     :        +- ReusedSubquery
+                           :     :                          :     +- CometBroadcastExchange
+                           :     :                          :        +- CometFilter
+                           :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :     :                          +- CometBroadcastExchange
+                           :     :                             +- CometProject
+                           :     :                                +- CometFilter
+                           :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :     +- CometBroadcastExchange
+                           :        +- CometBroadcastHashJoin
+                           :           :- CometFilter
+                           :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :           +- CometBroadcastExchange
+                           :              +- CometProject
+                           :                 +- CometBroadcastHashJoin
+                           :                    :- CometFilter
+                           :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :                    +- CometBroadcastExchange
+                           :                       +- CometBroadcastHashJoin
+                           :                          :- CometHashAggregate
+                           :                          :  +- CometExchange
+                           :                          :     +- CometHashAggregate
+                           :                          :        +- CometProject
+                           :                          :           +- CometBroadcastHashJoin
+                           :                          :              :- CometProject
+                           :                          :              :  +- CometBroadcastHashJoin
+                           :                          :              :     :- CometFilter
+                           :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                           :                          :              :     :        +- SubqueryBroadcast
+                           :                          :              :     :           +- BroadcastExchange
+                           :                          :              :     :              +- CometNativeColumnarToRow
+                           :                          :              :     :                 +- CometProject
+                           :                          :              :     :                    +- CometFilter
+                           :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :                          :              :     +- CometBroadcastExchange
+                           :                          :              :        +- CometBroadcastHashJoin
+                           :                          :              :           :- CometFilter
+                           :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :                          :              :           +- CometBroadcastExchange
+                           :                          :              :              +- CometProject
+                           :                          :              :                 +- CometBroadcastHashJoin
+                           :                          :              :                    :- CometProject
+                           :                          :              :                    :  +- CometBroadcastHashJoin
+                           :                          :              :                    :     :- CometFilter
+                           :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                           :                          :              :                    :     :        +- ReusedSubquery
+                           :                          :              :                    :     +- CometBroadcastExchange
+                           :                          :              :                    :        +- CometFilter
+                           :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :                          :              :                    +- CometBroadcastExchange
+                           :                          :              :                       +- CometProject
+                           :                          :              :                          +- CometFilter
+                           :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :                          :              +- CometBroadcastExchange
+                           :                          :                 +- CometProject
+                           :                          :                    +- CometFilter
+                           :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :                          +- CometBroadcastExchange
+                           :                             +- CometProject
+                           :                                +- CometBroadcastHashJoin
+                           :                                   :- CometProject
+                           :                                   :  +- CometBroadcastHashJoin
+                           :                                   :     :- CometFilter
+                           :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                           :                                   :     :        +- ReusedSubquery
+                           :                                   :     +- CometBroadcastExchange
+                           :                                   :        +- CometFilter
+                           :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :                                   +- CometBroadcastExchange
+                           :                                      +- CometProject
+                           :                                         +- CometFilter
+                           :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           +- CometBroadcastExchange
+                              +- CometProject
+                                 +- CometFilter
+                                    :  +- ReusedSubquery
+                                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                          +- ReusedSubquery
+
+Comet accelerated 298 out of 331 eligible operators (90%). Final plan contains 10 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q14a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q14a.native_datafusion/extended.txt
@@ -1,0 +1,2173 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometUnion
+               :- CometHashAggregate
+               :  +- CometHashAggregate
+               :     +- CometUnion
+               :        :- CometFilter
+               :        :  :  +- Subquery
+               :        :  :     +- CometNativeColumnarToRow
+               :        :  :        +- CometHashAggregate
+               :        :  :           +- CometExchange
+               :        :  :              +- CometHashAggregate
+               :        :  :                 +- CometUnion
+               :        :  :                    :- CometProject
+               :        :  :                    :  +- CometBroadcastHashJoin
+               :        :  :                    :     :- CometNativeScan parquet spark_catalog.default.store_sales
+               :        :  :                    :     :     +- ReusedSubquery
+               :        :  :                    :     +- CometBroadcastExchange
+               :        :  :                    :        +- CometProject
+               :        :  :                    :           +- CometFilter
+               :        :  :                    :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :  :                    :- CometProject
+               :        :  :                    :  +- CometBroadcastHashJoin
+               :        :  :                    :     :- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :        :  :                    :     :     +- CometSubqueryBroadcast
+               :        :  :                    :     :        +- CometBroadcastExchange
+               :        :  :                    :     :           +- CometProject
+               :        :  :                    :     :              +- CometFilter
+               :        :  :                    :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :  :                    :     +- CometBroadcastExchange
+               :        :  :                    :        +- CometProject
+               :        :  :                    :           +- CometFilter
+               :        :  :                    :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :  :                    +- CometProject
+               :        :  :                       +- CometBroadcastHashJoin
+               :        :  :                          :- CometNativeScan parquet spark_catalog.default.web_sales
+               :        :  :                          :     +- ReusedSubquery
+               :        :  :                          +- CometBroadcastExchange
+               :        :  :                             +- CometProject
+               :        :  :                                +- CometFilter
+               :        :  :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :  +- CometHashAggregate
+               :        :     +- CometExchange
+               :        :        +- CometHashAggregate
+               :        :           +- CometProject
+               :        :              +- CometBroadcastHashJoin
+               :        :                 :- CometProject
+               :        :                 :  +- CometBroadcastHashJoin
+               :        :                 :     :- CometBroadcastHashJoin
+               :        :                 :     :  :- CometFilter
+               :        :                 :     :  :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :        :                 :     :  :        +- CometSubqueryBroadcast
+               :        :                 :     :  :           +- CometBroadcastExchange
+               :        :                 :     :  :              +- CometProject
+               :        :                 :     :  :                 +- CometFilter
+               :        :                 :     :  :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :                 :     :  +- CometBroadcastExchange
+               :        :                 :     :     +- CometProject
+               :        :                 :     :        +- CometBroadcastHashJoin
+               :        :                 :     :           :- CometFilter
+               :        :                 :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :        :                 :     :           +- CometBroadcastExchange
+               :        :                 :     :              +- CometBroadcastHashJoin
+               :        :                 :     :                 :- CometHashAggregate
+               :        :                 :     :                 :  +- CometExchange
+               :        :                 :     :                 :     +- CometHashAggregate
+               :        :                 :     :                 :        +- CometProject
+               :        :                 :     :                 :           +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :- CometProject
+               :        :                 :     :                 :              :  +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :     :- CometFilter
+               :        :                 :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :        :                 :     :                 :              :     :        +- CometSubqueryBroadcast
+               :        :                 :     :                 :              :     :           +- CometBroadcastExchange
+               :        :                 :     :                 :              :     :              +- CometProject
+               :        :                 :     :                 :              :     :                 +- CometFilter
+               :        :                 :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :                 :     :                 :              :     +- CometBroadcastExchange
+               :        :                 :     :                 :              :        +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :           :- CometFilter
+               :        :                 :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :        :                 :     :                 :              :           +- CometBroadcastExchange
+               :        :                 :     :                 :              :              +- CometProject
+               :        :                 :     :                 :              :                 +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :                    :- CometProject
+               :        :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :                    :     :- CometFilter
+               :        :                 :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :        :                 :     :                 :              :                    :     :        +- ReusedSubquery
+               :        :                 :     :                 :              :                    :     +- CometBroadcastExchange
+               :        :                 :     :                 :              :                    :        +- CometFilter
+               :        :                 :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :        :                 :     :                 :              :                    +- CometBroadcastExchange
+               :        :                 :     :                 :              :                       +- CometProject
+               :        :                 :     :                 :              :                          +- CometFilter
+               :        :                 :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :                 :     :                 :              +- CometBroadcastExchange
+               :        :                 :     :                 :                 +- CometProject
+               :        :                 :     :                 :                    +- CometFilter
+               :        :                 :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :                 :     :                 +- CometBroadcastExchange
+               :        :                 :     :                    +- CometProject
+               :        :                 :     :                       +- CometBroadcastHashJoin
+               :        :                 :     :                          :- CometProject
+               :        :                 :     :                          :  +- CometBroadcastHashJoin
+               :        :                 :     :                          :     :- CometFilter
+               :        :                 :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :        :                 :     :                          :     :        +- ReusedSubquery
+               :        :                 :     :                          :     +- CometBroadcastExchange
+               :        :                 :     :                          :        +- CometFilter
+               :        :                 :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+               :        :                 :     :                          +- CometBroadcastExchange
+               :        :                 :     :                             +- CometProject
+               :        :                 :     :                                +- CometFilter
+               :        :                 :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :                 :     +- CometBroadcastExchange
+               :        :                 :        +- CometBroadcastHashJoin
+               :        :                 :           :- CometFilter
+               :        :                 :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :        :                 :           +- CometBroadcastExchange
+               :        :                 :              +- CometProject
+               :        :                 :                 +- CometBroadcastHashJoin
+               :        :                 :                    :- CometFilter
+               :        :                 :                    :  +- CometNativeScan parquet spark_catalog.default.item
+               :        :                 :                    +- CometBroadcastExchange
+               :        :                 :                       +- CometBroadcastHashJoin
+               :        :                 :                          :- CometHashAggregate
+               :        :                 :                          :  +- CometExchange
+               :        :                 :                          :     +- CometHashAggregate
+               :        :                 :                          :        +- CometProject
+               :        :                 :                          :           +- CometBroadcastHashJoin
+               :        :                 :                          :              :- CometProject
+               :        :                 :                          :              :  +- CometBroadcastHashJoin
+               :        :                 :                          :              :     :- CometFilter
+               :        :                 :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :        :                 :                          :              :     :        +- CometSubqueryBroadcast
+               :        :                 :                          :              :     :           +- CometBroadcastExchange
+               :        :                 :                          :              :     :              +- CometProject
+               :        :                 :                          :              :     :                 +- CometFilter
+               :        :                 :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :                 :                          :              :     +- CometBroadcastExchange
+               :        :                 :                          :              :        +- CometBroadcastHashJoin
+               :        :                 :                          :              :           :- CometFilter
+               :        :                 :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :        :                 :                          :              :           +- CometBroadcastExchange
+               :        :                 :                          :              :              +- CometProject
+               :        :                 :                          :              :                 +- CometBroadcastHashJoin
+               :        :                 :                          :              :                    :- CometProject
+               :        :                 :                          :              :                    :  +- CometBroadcastHashJoin
+               :        :                 :                          :              :                    :     :- CometFilter
+               :        :                 :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :        :                 :                          :              :                    :     :        +- ReusedSubquery
+               :        :                 :                          :              :                    :     +- CometBroadcastExchange
+               :        :                 :                          :              :                    :        +- CometFilter
+               :        :                 :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :        :                 :                          :              :                    +- CometBroadcastExchange
+               :        :                 :                          :              :                       +- CometProject
+               :        :                 :                          :              :                          +- CometFilter
+               :        :                 :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :                 :                          :              +- CometBroadcastExchange
+               :        :                 :                          :                 +- CometProject
+               :        :                 :                          :                    +- CometFilter
+               :        :                 :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :                 :                          +- CometBroadcastExchange
+               :        :                 :                             +- CometProject
+               :        :                 :                                +- CometBroadcastHashJoin
+               :        :                 :                                   :- CometProject
+               :        :                 :                                   :  +- CometBroadcastHashJoin
+               :        :                 :                                   :     :- CometFilter
+               :        :                 :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :        :                 :                                   :     :        +- ReusedSubquery
+               :        :                 :                                   :     +- CometBroadcastExchange
+               :        :                 :                                   :        +- CometFilter
+               :        :                 :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+               :        :                 :                                   +- CometBroadcastExchange
+               :        :                 :                                      +- CometProject
+               :        :                 :                                         +- CometFilter
+               :        :                 :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :                 +- CometBroadcastExchange
+               :        :                    +- CometProject
+               :        :                       +- CometFilter
+               :        :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :- CometFilter
+               :        :  :  +- ReusedSubquery
+               :        :  +- CometHashAggregate
+               :        :     +- CometExchange
+               :        :        +- CometHashAggregate
+               :        :           +- CometProject
+               :        :              +- CometBroadcastHashJoin
+               :        :                 :- CometProject
+               :        :                 :  +- CometBroadcastHashJoin
+               :        :                 :     :- CometBroadcastHashJoin
+               :        :                 :     :  :- CometFilter
+               :        :                 :     :  :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :        :                 :     :  :        +- ReusedSubquery
+               :        :                 :     :  +- CometBroadcastExchange
+               :        :                 :     :     +- CometProject
+               :        :                 :     :        +- CometBroadcastHashJoin
+               :        :                 :     :           :- CometFilter
+               :        :                 :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :        :                 :     :           +- CometBroadcastExchange
+               :        :                 :     :              +- CometBroadcastHashJoin
+               :        :                 :     :                 :- CometHashAggregate
+               :        :                 :     :                 :  +- CometExchange
+               :        :                 :     :                 :     +- CometHashAggregate
+               :        :                 :     :                 :        +- CometProject
+               :        :                 :     :                 :           +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :- CometProject
+               :        :                 :     :                 :              :  +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :     :- CometFilter
+               :        :                 :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :        :                 :     :                 :              :     :        +- CometSubqueryBroadcast
+               :        :                 :     :                 :              :     :           +- CometBroadcastExchange
+               :        :                 :     :                 :              :     :              +- CometProject
+               :        :                 :     :                 :              :     :                 +- CometFilter
+               :        :                 :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :                 :     :                 :              :     +- CometBroadcastExchange
+               :        :                 :     :                 :              :        +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :           :- CometFilter
+               :        :                 :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :        :                 :     :                 :              :           +- CometBroadcastExchange
+               :        :                 :     :                 :              :              +- CometProject
+               :        :                 :     :                 :              :                 +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :                    :- CometProject
+               :        :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :                    :     :- CometFilter
+               :        :                 :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :        :                 :     :                 :              :                    :     :        +- ReusedSubquery
+               :        :                 :     :                 :              :                    :     +- CometBroadcastExchange
+               :        :                 :     :                 :              :                    :        +- CometFilter
+               :        :                 :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :        :                 :     :                 :              :                    +- CometBroadcastExchange
+               :        :                 :     :                 :              :                       +- CometProject
+               :        :                 :     :                 :              :                          +- CometFilter
+               :        :                 :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :                 :     :                 :              +- CometBroadcastExchange
+               :        :                 :     :                 :                 +- CometProject
+               :        :                 :     :                 :                    +- CometFilter
+               :        :                 :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :                 :     :                 +- CometBroadcastExchange
+               :        :                 :     :                    +- CometProject
+               :        :                 :     :                       +- CometBroadcastHashJoin
+               :        :                 :     :                          :- CometProject
+               :        :                 :     :                          :  +- CometBroadcastHashJoin
+               :        :                 :     :                          :     :- CometFilter
+               :        :                 :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :        :                 :     :                          :     :        +- ReusedSubquery
+               :        :                 :     :                          :     +- CometBroadcastExchange
+               :        :                 :     :                          :        +- CometFilter
+               :        :                 :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+               :        :                 :     :                          +- CometBroadcastExchange
+               :        :                 :     :                             +- CometProject
+               :        :                 :     :                                +- CometFilter
+               :        :                 :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :                 :     +- CometBroadcastExchange
+               :        :                 :        +- CometBroadcastHashJoin
+               :        :                 :           :- CometFilter
+               :        :                 :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :        :                 :           +- CometBroadcastExchange
+               :        :                 :              +- CometProject
+               :        :                 :                 +- CometBroadcastHashJoin
+               :        :                 :                    :- CometFilter
+               :        :                 :                    :  +- CometNativeScan parquet spark_catalog.default.item
+               :        :                 :                    +- CometBroadcastExchange
+               :        :                 :                       +- CometBroadcastHashJoin
+               :        :                 :                          :- CometHashAggregate
+               :        :                 :                          :  +- CometExchange
+               :        :                 :                          :     +- CometHashAggregate
+               :        :                 :                          :        +- CometProject
+               :        :                 :                          :           +- CometBroadcastHashJoin
+               :        :                 :                          :              :- CometProject
+               :        :                 :                          :              :  +- CometBroadcastHashJoin
+               :        :                 :                          :              :     :- CometFilter
+               :        :                 :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :        :                 :                          :              :     :        +- CometSubqueryBroadcast
+               :        :                 :                          :              :     :           +- CometBroadcastExchange
+               :        :                 :                          :              :     :              +- CometProject
+               :        :                 :                          :              :     :                 +- CometFilter
+               :        :                 :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :                 :                          :              :     +- CometBroadcastExchange
+               :        :                 :                          :              :        +- CometBroadcastHashJoin
+               :        :                 :                          :              :           :- CometFilter
+               :        :                 :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :        :                 :                          :              :           +- CometBroadcastExchange
+               :        :                 :                          :              :              +- CometProject
+               :        :                 :                          :              :                 +- CometBroadcastHashJoin
+               :        :                 :                          :              :                    :- CometProject
+               :        :                 :                          :              :                    :  +- CometBroadcastHashJoin
+               :        :                 :                          :              :                    :     :- CometFilter
+               :        :                 :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :        :                 :                          :              :                    :     :        +- ReusedSubquery
+               :        :                 :                          :              :                    :     +- CometBroadcastExchange
+               :        :                 :                          :              :                    :        +- CometFilter
+               :        :                 :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :        :                 :                          :              :                    +- CometBroadcastExchange
+               :        :                 :                          :              :                       +- CometProject
+               :        :                 :                          :              :                          +- CometFilter
+               :        :                 :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :                 :                          :              +- CometBroadcastExchange
+               :        :                 :                          :                 +- CometProject
+               :        :                 :                          :                    +- CometFilter
+               :        :                 :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :                 :                          +- CometBroadcastExchange
+               :        :                 :                             +- CometProject
+               :        :                 :                                +- CometBroadcastHashJoin
+               :        :                 :                                   :- CometProject
+               :        :                 :                                   :  +- CometBroadcastHashJoin
+               :        :                 :                                   :     :- CometFilter
+               :        :                 :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :        :                 :                                   :     :        +- ReusedSubquery
+               :        :                 :                                   :     +- CometBroadcastExchange
+               :        :                 :                                   :        +- CometFilter
+               :        :                 :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+               :        :                 :                                   +- CometBroadcastExchange
+               :        :                 :                                      +- CometProject
+               :        :                 :                                         +- CometFilter
+               :        :                 :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        :                 +- CometBroadcastExchange
+               :        :                    +- CometProject
+               :        :                       +- CometFilter
+               :        :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+               :        +- CometFilter
+               :           :  +- ReusedSubquery
+               :           +- CometHashAggregate
+               :              +- CometExchange
+               :                 +- CometHashAggregate
+               :                    +- CometProject
+               :                       +- CometBroadcastHashJoin
+               :                          :- CometProject
+               :                          :  +- CometBroadcastHashJoin
+               :                          :     :- CometBroadcastHashJoin
+               :                          :     :  :- CometFilter
+               :                          :     :  :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                          :     :  :        +- ReusedSubquery
+               :                          :     :  +- CometBroadcastExchange
+               :                          :     :     +- CometProject
+               :                          :     :        +- CometBroadcastHashJoin
+               :                          :     :           :- CometFilter
+               :                          :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                          :     :           +- CometBroadcastExchange
+               :                          :     :              +- CometBroadcastHashJoin
+               :                          :     :                 :- CometHashAggregate
+               :                          :     :                 :  +- CometExchange
+               :                          :     :                 :     +- CometHashAggregate
+               :                          :     :                 :        +- CometProject
+               :                          :     :                 :           +- CometBroadcastHashJoin
+               :                          :     :                 :              :- CometProject
+               :                          :     :                 :              :  +- CometBroadcastHashJoin
+               :                          :     :                 :              :     :- CometFilter
+               :                          :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                          :     :                 :              :     :        +- CometSubqueryBroadcast
+               :                          :     :                 :              :     :           +- CometBroadcastExchange
+               :                          :     :                 :              :     :              +- CometProject
+               :                          :     :                 :              :     :                 +- CometFilter
+               :                          :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                          :     :                 :              :     +- CometBroadcastExchange
+               :                          :     :                 :              :        +- CometBroadcastHashJoin
+               :                          :     :                 :              :           :- CometFilter
+               :                          :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                          :     :                 :              :           +- CometBroadcastExchange
+               :                          :     :                 :              :              +- CometProject
+               :                          :     :                 :              :                 +- CometBroadcastHashJoin
+               :                          :     :                 :              :                    :- CometProject
+               :                          :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                          :     :                 :              :                    :     :- CometFilter
+               :                          :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                          :     :                 :              :                    :     :        +- ReusedSubquery
+               :                          :     :                 :              :                    :     +- CometBroadcastExchange
+               :                          :     :                 :              :                    :        +- CometFilter
+               :                          :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                          :     :                 :              :                    +- CometBroadcastExchange
+               :                          :     :                 :              :                       +- CometProject
+               :                          :     :                 :              :                          +- CometFilter
+               :                          :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                          :     :                 :              +- CometBroadcastExchange
+               :                          :     :                 :                 +- CometProject
+               :                          :     :                 :                    +- CometFilter
+               :                          :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                          :     :                 +- CometBroadcastExchange
+               :                          :     :                    +- CometProject
+               :                          :     :                       +- CometBroadcastHashJoin
+               :                          :     :                          :- CometProject
+               :                          :     :                          :  +- CometBroadcastHashJoin
+               :                          :     :                          :     :- CometFilter
+               :                          :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                          :     :                          :     :        +- ReusedSubquery
+               :                          :     :                          :     +- CometBroadcastExchange
+               :                          :     :                          :        +- CometFilter
+               :                          :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+               :                          :     :                          +- CometBroadcastExchange
+               :                          :     :                             +- CometProject
+               :                          :     :                                +- CometFilter
+               :                          :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                          :     +- CometBroadcastExchange
+               :                          :        +- CometBroadcastHashJoin
+               :                          :           :- CometFilter
+               :                          :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                          :           +- CometBroadcastExchange
+               :                          :              +- CometProject
+               :                          :                 +- CometBroadcastHashJoin
+               :                          :                    :- CometFilter
+               :                          :                    :  +- CometNativeScan parquet spark_catalog.default.item
+               :                          :                    +- CometBroadcastExchange
+               :                          :                       +- CometBroadcastHashJoin
+               :                          :                          :- CometHashAggregate
+               :                          :                          :  +- CometExchange
+               :                          :                          :     +- CometHashAggregate
+               :                          :                          :        +- CometProject
+               :                          :                          :           +- CometBroadcastHashJoin
+               :                          :                          :              :- CometProject
+               :                          :                          :              :  +- CometBroadcastHashJoin
+               :                          :                          :              :     :- CometFilter
+               :                          :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                          :                          :              :     :        +- CometSubqueryBroadcast
+               :                          :                          :              :     :           +- CometBroadcastExchange
+               :                          :                          :              :     :              +- CometProject
+               :                          :                          :              :     :                 +- CometFilter
+               :                          :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                          :                          :              :     +- CometBroadcastExchange
+               :                          :                          :              :        +- CometBroadcastHashJoin
+               :                          :                          :              :           :- CometFilter
+               :                          :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                          :                          :              :           +- CometBroadcastExchange
+               :                          :                          :              :              +- CometProject
+               :                          :                          :              :                 +- CometBroadcastHashJoin
+               :                          :                          :              :                    :- CometProject
+               :                          :                          :              :                    :  +- CometBroadcastHashJoin
+               :                          :                          :              :                    :     :- CometFilter
+               :                          :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                          :                          :              :                    :     :        +- ReusedSubquery
+               :                          :                          :              :                    :     +- CometBroadcastExchange
+               :                          :                          :              :                    :        +- CometFilter
+               :                          :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                          :                          :              :                    +- CometBroadcastExchange
+               :                          :                          :              :                       +- CometProject
+               :                          :                          :              :                          +- CometFilter
+               :                          :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                          :                          :              +- CometBroadcastExchange
+               :                          :                          :                 +- CometProject
+               :                          :                          :                    +- CometFilter
+               :                          :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                          :                          +- CometBroadcastExchange
+               :                          :                             +- CometProject
+               :                          :                                +- CometBroadcastHashJoin
+               :                          :                                   :- CometProject
+               :                          :                                   :  +- CometBroadcastHashJoin
+               :                          :                                   :     :- CometFilter
+               :                          :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                          :                                   :     :        +- ReusedSubquery
+               :                          :                                   :     +- CometBroadcastExchange
+               :                          :                                   :        +- CometFilter
+               :                          :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+               :                          :                                   +- CometBroadcastExchange
+               :                          :                                      +- CometProject
+               :                          :                                         +- CometFilter
+               :                          :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                          +- CometBroadcastExchange
+               :                             +- CometProject
+               :                                +- CometFilter
+               :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+               :- CometHashAggregate
+               :  +- CometExchange
+               :     +- CometHashAggregate
+               :        +- CometHashAggregate
+               :           +- CometHashAggregate
+               :              +- CometUnion
+               :                 :- CometFilter
+               :                 :  :  +- ReusedSubquery
+               :                 :  +- CometHashAggregate
+               :                 :     +- CometExchange
+               :                 :        +- CometHashAggregate
+               :                 :           +- CometProject
+               :                 :              +- CometBroadcastHashJoin
+               :                 :                 :- CometProject
+               :                 :                 :  +- CometBroadcastHashJoin
+               :                 :                 :     :- CometBroadcastHashJoin
+               :                 :                 :     :  :- CometFilter
+               :                 :                 :     :  :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                 :                 :     :  :        +- CometSubqueryBroadcast
+               :                 :                 :     :  :           +- CometBroadcastExchange
+               :                 :                 :     :  :              +- CometProject
+               :                 :                 :     :  :                 +- CometFilter
+               :                 :                 :     :  :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :  +- CometBroadcastExchange
+               :                 :                 :     :     +- CometProject
+               :                 :                 :     :        +- CometBroadcastHashJoin
+               :                 :                 :     :           :- CometFilter
+               :                 :                 :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :           +- CometBroadcastExchange
+               :                 :                 :     :              +- CometBroadcastHashJoin
+               :                 :                 :     :                 :- CometHashAggregate
+               :                 :                 :     :                 :  +- CometExchange
+               :                 :                 :     :                 :     +- CometHashAggregate
+               :                 :                 :     :                 :        +- CometProject
+               :                 :                 :     :                 :           +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :- CometProject
+               :                 :                 :     :                 :              :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :     :- CometFilter
+               :                 :                 :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                 :                 :     :                 :              :     :        +- CometSubqueryBroadcast
+               :                 :                 :     :                 :              :     :           +- CometBroadcastExchange
+               :                 :                 :     :                 :              :     :              +- CometProject
+               :                 :                 :     :                 :              :     :                 +- CometFilter
+               :                 :                 :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :        +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :           :- CometFilter
+               :                 :                 :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :           +- CometBroadcastExchange
+               :                 :                 :     :                 :              :              +- CometProject
+               :                 :                 :     :                 :              :                 +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :- CometProject
+               :                 :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :     :- CometFilter
+               :                 :                 :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                 :                 :     :                 :              :                    :     :        +- ReusedSubquery
+               :                 :                 :     :                 :              :                    :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                    :        +- CometFilter
+               :                 :                 :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :                    +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                       +- CometProject
+               :                 :                 :     :                 :              :                          +- CometFilter
+               :                 :                 :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              +- CometBroadcastExchange
+               :                 :                 :     :                 :                 +- CometProject
+               :                 :                 :     :                 :                    +- CometFilter
+               :                 :                 :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 +- CometBroadcastExchange
+               :                 :                 :     :                    +- CometProject
+               :                 :                 :     :                       +- CometBroadcastHashJoin
+               :                 :                 :     :                          :- CometProject
+               :                 :                 :     :                          :  +- CometBroadcastHashJoin
+               :                 :                 :     :                          :     :- CometFilter
+               :                 :                 :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                 :                 :     :                          :     :        +- ReusedSubquery
+               :                 :                 :     :                          :     +- CometBroadcastExchange
+               :                 :                 :     :                          :        +- CometFilter
+               :                 :                 :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :                          +- CometBroadcastExchange
+               :                 :                 :     :                             +- CometProject
+               :                 :                 :     :                                +- CometFilter
+               :                 :                 :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     +- CometBroadcastExchange
+               :                 :                 :        +- CometBroadcastHashJoin
+               :                 :                 :           :- CometFilter
+               :                 :                 :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :           +- CometBroadcastExchange
+               :                 :                 :              +- CometProject
+               :                 :                 :                 +- CometBroadcastHashJoin
+               :                 :                 :                    :- CometFilter
+               :                 :                 :                    :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                    +- CometBroadcastExchange
+               :                 :                 :                       +- CometBroadcastHashJoin
+               :                 :                 :                          :- CometHashAggregate
+               :                 :                 :                          :  +- CometExchange
+               :                 :                 :                          :     +- CometHashAggregate
+               :                 :                 :                          :        +- CometProject
+               :                 :                 :                          :           +- CometBroadcastHashJoin
+               :                 :                 :                          :              :- CometProject
+               :                 :                 :                          :              :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :     :- CometFilter
+               :                 :                 :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                 :                 :                          :              :     :        +- CometSubqueryBroadcast
+               :                 :                 :                          :              :     :           +- CometBroadcastExchange
+               :                 :                 :                          :              :     :              +- CometProject
+               :                 :                 :                          :              :     :                 +- CometFilter
+               :                 :                 :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              :     +- CometBroadcastExchange
+               :                 :                 :                          :              :        +- CometBroadcastHashJoin
+               :                 :                 :                          :              :           :- CometFilter
+               :                 :                 :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                          :              :           +- CometBroadcastExchange
+               :                 :                 :                          :              :              +- CometProject
+               :                 :                 :                          :              :                 +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :- CometProject
+               :                 :                 :                          :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :     :- CometFilter
+               :                 :                 :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                 :                 :                          :              :                    :     :        +- ReusedSubquery
+               :                 :                 :                          :              :                    :     +- CometBroadcastExchange
+               :                 :                 :                          :              :                    :        +- CometFilter
+               :                 :                 :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                          :              :                    +- CometBroadcastExchange
+               :                 :                 :                          :              :                       +- CometProject
+               :                 :                 :                          :              :                          +- CometFilter
+               :                 :                 :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              +- CometBroadcastExchange
+               :                 :                 :                          :                 +- CometProject
+               :                 :                 :                          :                    +- CometFilter
+               :                 :                 :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :                          +- CometBroadcastExchange
+               :                 :                 :                             +- CometProject
+               :                 :                 :                                +- CometBroadcastHashJoin
+               :                 :                 :                                   :- CometProject
+               :                 :                 :                                   :  +- CometBroadcastHashJoin
+               :                 :                 :                                   :     :- CometFilter
+               :                 :                 :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                 :                 :                                   :     :        +- ReusedSubquery
+               :                 :                 :                                   :     +- CometBroadcastExchange
+               :                 :                 :                                   :        +- CometFilter
+               :                 :                 :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                                   +- CometBroadcastExchange
+               :                 :                 :                                      +- CometProject
+               :                 :                 :                                         +- CometFilter
+               :                 :                 :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 +- CometBroadcastExchange
+               :                 :                    +- CometProject
+               :                 :                       +- CometFilter
+               :                 :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :- CometFilter
+               :                 :  :  +- ReusedSubquery
+               :                 :  +- CometHashAggregate
+               :                 :     +- CometExchange
+               :                 :        +- CometHashAggregate
+               :                 :           +- CometProject
+               :                 :              +- CometBroadcastHashJoin
+               :                 :                 :- CometProject
+               :                 :                 :  +- CometBroadcastHashJoin
+               :                 :                 :     :- CometBroadcastHashJoin
+               :                 :                 :     :  :- CometFilter
+               :                 :                 :     :  :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                 :                 :     :  :        +- ReusedSubquery
+               :                 :                 :     :  +- CometBroadcastExchange
+               :                 :                 :     :     +- CometProject
+               :                 :                 :     :        +- CometBroadcastHashJoin
+               :                 :                 :     :           :- CometFilter
+               :                 :                 :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :           +- CometBroadcastExchange
+               :                 :                 :     :              +- CometBroadcastHashJoin
+               :                 :                 :     :                 :- CometHashAggregate
+               :                 :                 :     :                 :  +- CometExchange
+               :                 :                 :     :                 :     +- CometHashAggregate
+               :                 :                 :     :                 :        +- CometProject
+               :                 :                 :     :                 :           +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :- CometProject
+               :                 :                 :     :                 :              :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :     :- CometFilter
+               :                 :                 :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                 :                 :     :                 :              :     :        +- CometSubqueryBroadcast
+               :                 :                 :     :                 :              :     :           +- CometBroadcastExchange
+               :                 :                 :     :                 :              :     :              +- CometProject
+               :                 :                 :     :                 :              :     :                 +- CometFilter
+               :                 :                 :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :        +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :           :- CometFilter
+               :                 :                 :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :           +- CometBroadcastExchange
+               :                 :                 :     :                 :              :              +- CometProject
+               :                 :                 :     :                 :              :                 +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :- CometProject
+               :                 :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :     :- CometFilter
+               :                 :                 :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                 :                 :     :                 :              :                    :     :        +- ReusedSubquery
+               :                 :                 :     :                 :              :                    :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                    :        +- CometFilter
+               :                 :                 :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :                    +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                       +- CometProject
+               :                 :                 :     :                 :              :                          +- CometFilter
+               :                 :                 :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              +- CometBroadcastExchange
+               :                 :                 :     :                 :                 +- CometProject
+               :                 :                 :     :                 :                    +- CometFilter
+               :                 :                 :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 +- CometBroadcastExchange
+               :                 :                 :     :                    +- CometProject
+               :                 :                 :     :                       +- CometBroadcastHashJoin
+               :                 :                 :     :                          :- CometProject
+               :                 :                 :     :                          :  +- CometBroadcastHashJoin
+               :                 :                 :     :                          :     :- CometFilter
+               :                 :                 :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                 :                 :     :                          :     :        +- ReusedSubquery
+               :                 :                 :     :                          :     +- CometBroadcastExchange
+               :                 :                 :     :                          :        +- CometFilter
+               :                 :                 :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :                          +- CometBroadcastExchange
+               :                 :                 :     :                             +- CometProject
+               :                 :                 :     :                                +- CometFilter
+               :                 :                 :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     +- CometBroadcastExchange
+               :                 :                 :        +- CometBroadcastHashJoin
+               :                 :                 :           :- CometFilter
+               :                 :                 :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :           +- CometBroadcastExchange
+               :                 :                 :              +- CometProject
+               :                 :                 :                 +- CometBroadcastHashJoin
+               :                 :                 :                    :- CometFilter
+               :                 :                 :                    :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                    +- CometBroadcastExchange
+               :                 :                 :                       +- CometBroadcastHashJoin
+               :                 :                 :                          :- CometHashAggregate
+               :                 :                 :                          :  +- CometExchange
+               :                 :                 :                          :     +- CometHashAggregate
+               :                 :                 :                          :        +- CometProject
+               :                 :                 :                          :           +- CometBroadcastHashJoin
+               :                 :                 :                          :              :- CometProject
+               :                 :                 :                          :              :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :     :- CometFilter
+               :                 :                 :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                 :                 :                          :              :     :        +- CometSubqueryBroadcast
+               :                 :                 :                          :              :     :           +- CometBroadcastExchange
+               :                 :                 :                          :              :     :              +- CometProject
+               :                 :                 :                          :              :     :                 +- CometFilter
+               :                 :                 :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              :     +- CometBroadcastExchange
+               :                 :                 :                          :              :        +- CometBroadcastHashJoin
+               :                 :                 :                          :              :           :- CometFilter
+               :                 :                 :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                          :              :           +- CometBroadcastExchange
+               :                 :                 :                          :              :              +- CometProject
+               :                 :                 :                          :              :                 +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :- CometProject
+               :                 :                 :                          :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :     :- CometFilter
+               :                 :                 :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                 :                 :                          :              :                    :     :        +- ReusedSubquery
+               :                 :                 :                          :              :                    :     +- CometBroadcastExchange
+               :                 :                 :                          :              :                    :        +- CometFilter
+               :                 :                 :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                          :              :                    +- CometBroadcastExchange
+               :                 :                 :                          :              :                       +- CometProject
+               :                 :                 :                          :              :                          +- CometFilter
+               :                 :                 :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              +- CometBroadcastExchange
+               :                 :                 :                          :                 +- CometProject
+               :                 :                 :                          :                    +- CometFilter
+               :                 :                 :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :                          +- CometBroadcastExchange
+               :                 :                 :                             +- CometProject
+               :                 :                 :                                +- CometBroadcastHashJoin
+               :                 :                 :                                   :- CometProject
+               :                 :                 :                                   :  +- CometBroadcastHashJoin
+               :                 :                 :                                   :     :- CometFilter
+               :                 :                 :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                 :                 :                                   :     :        +- ReusedSubquery
+               :                 :                 :                                   :     +- CometBroadcastExchange
+               :                 :                 :                                   :        +- CometFilter
+               :                 :                 :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                                   +- CometBroadcastExchange
+               :                 :                 :                                      +- CometProject
+               :                 :                 :                                         +- CometFilter
+               :                 :                 :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 +- CometBroadcastExchange
+               :                 :                    +- CometProject
+               :                 :                       +- CometFilter
+               :                 :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 +- CometFilter
+               :                    :  +- ReusedSubquery
+               :                    +- CometHashAggregate
+               :                       +- CometExchange
+               :                          +- CometHashAggregate
+               :                             +- CometProject
+               :                                +- CometBroadcastHashJoin
+               :                                   :- CometProject
+               :                                   :  +- CometBroadcastHashJoin
+               :                                   :     :- CometBroadcastHashJoin
+               :                                   :     :  :- CometFilter
+               :                                   :     :  :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                                   :     :  :        +- ReusedSubquery
+               :                                   :     :  +- CometBroadcastExchange
+               :                                   :     :     +- CometProject
+               :                                   :     :        +- CometBroadcastHashJoin
+               :                                   :     :           :- CometFilter
+               :                                   :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :     :           +- CometBroadcastExchange
+               :                                   :     :              +- CometBroadcastHashJoin
+               :                                   :     :                 :- CometHashAggregate
+               :                                   :     :                 :  +- CometExchange
+               :                                   :     :                 :     +- CometHashAggregate
+               :                                   :     :                 :        +- CometProject
+               :                                   :     :                 :           +- CometBroadcastHashJoin
+               :                                   :     :                 :              :- CometProject
+               :                                   :     :                 :              :  +- CometBroadcastHashJoin
+               :                                   :     :                 :              :     :- CometFilter
+               :                                   :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                                   :     :                 :              :     :        +- CometSubqueryBroadcast
+               :                                   :     :                 :              :     :           +- CometBroadcastExchange
+               :                                   :     :                 :              :     :              +- CometProject
+               :                                   :     :                 :              :     :                 +- CometFilter
+               :                                   :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :     :                 :              :     +- CometBroadcastExchange
+               :                                   :     :                 :              :        +- CometBroadcastHashJoin
+               :                                   :     :                 :              :           :- CometFilter
+               :                                   :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :     :                 :              :           +- CometBroadcastExchange
+               :                                   :     :                 :              :              +- CometProject
+               :                                   :     :                 :              :                 +- CometBroadcastHashJoin
+               :                                   :     :                 :              :                    :- CometProject
+               :                                   :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                                   :     :                 :              :                    :     :- CometFilter
+               :                                   :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                                   :     :                 :              :                    :     :        +- ReusedSubquery
+               :                                   :     :                 :              :                    :     +- CometBroadcastExchange
+               :                                   :     :                 :              :                    :        +- CometFilter
+               :                                   :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :     :                 :              :                    +- CometBroadcastExchange
+               :                                   :     :                 :              :                       +- CometProject
+               :                                   :     :                 :              :                          +- CometFilter
+               :                                   :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :     :                 :              +- CometBroadcastExchange
+               :                                   :     :                 :                 +- CometProject
+               :                                   :     :                 :                    +- CometFilter
+               :                                   :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :     :                 +- CometBroadcastExchange
+               :                                   :     :                    +- CometProject
+               :                                   :     :                       +- CometBroadcastHashJoin
+               :                                   :     :                          :- CometProject
+               :                                   :     :                          :  +- CometBroadcastHashJoin
+               :                                   :     :                          :     :- CometFilter
+               :                                   :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                                   :     :                          :     :        +- ReusedSubquery
+               :                                   :     :                          :     +- CometBroadcastExchange
+               :                                   :     :                          :        +- CometFilter
+               :                                   :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :     :                          +- CometBroadcastExchange
+               :                                   :     :                             +- CometProject
+               :                                   :     :                                +- CometFilter
+               :                                   :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :     +- CometBroadcastExchange
+               :                                   :        +- CometBroadcastHashJoin
+               :                                   :           :- CometFilter
+               :                                   :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :           +- CometBroadcastExchange
+               :                                   :              +- CometProject
+               :                                   :                 +- CometBroadcastHashJoin
+               :                                   :                    :- CometFilter
+               :                                   :                    :  +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :                    +- CometBroadcastExchange
+               :                                   :                       +- CometBroadcastHashJoin
+               :                                   :                          :- CometHashAggregate
+               :                                   :                          :  +- CometExchange
+               :                                   :                          :     +- CometHashAggregate
+               :                                   :                          :        +- CometProject
+               :                                   :                          :           +- CometBroadcastHashJoin
+               :                                   :                          :              :- CometProject
+               :                                   :                          :              :  +- CometBroadcastHashJoin
+               :                                   :                          :              :     :- CometFilter
+               :                                   :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                                   :                          :              :     :        +- CometSubqueryBroadcast
+               :                                   :                          :              :     :           +- CometBroadcastExchange
+               :                                   :                          :              :     :              +- CometProject
+               :                                   :                          :              :     :                 +- CometFilter
+               :                                   :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :                          :              :     +- CometBroadcastExchange
+               :                                   :                          :              :        +- CometBroadcastHashJoin
+               :                                   :                          :              :           :- CometFilter
+               :                                   :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :                          :              :           +- CometBroadcastExchange
+               :                                   :                          :              :              +- CometProject
+               :                                   :                          :              :                 +- CometBroadcastHashJoin
+               :                                   :                          :              :                    :- CometProject
+               :                                   :                          :              :                    :  +- CometBroadcastHashJoin
+               :                                   :                          :              :                    :     :- CometFilter
+               :                                   :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                                   :                          :              :                    :     :        +- ReusedSubquery
+               :                                   :                          :              :                    :     +- CometBroadcastExchange
+               :                                   :                          :              :                    :        +- CometFilter
+               :                                   :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :                          :              :                    +- CometBroadcastExchange
+               :                                   :                          :              :                       +- CometProject
+               :                                   :                          :              :                          +- CometFilter
+               :                                   :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :                          :              +- CometBroadcastExchange
+               :                                   :                          :                 +- CometProject
+               :                                   :                          :                    +- CometFilter
+               :                                   :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :                          +- CometBroadcastExchange
+               :                                   :                             +- CometProject
+               :                                   :                                +- CometBroadcastHashJoin
+               :                                   :                                   :- CometProject
+               :                                   :                                   :  +- CometBroadcastHashJoin
+               :                                   :                                   :     :- CometFilter
+               :                                   :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                                   :                                   :     :        +- ReusedSubquery
+               :                                   :                                   :     +- CometBroadcastExchange
+               :                                   :                                   :        +- CometFilter
+               :                                   :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :                                   +- CometBroadcastExchange
+               :                                   :                                      +- CometProject
+               :                                   :                                         +- CometFilter
+               :                                   :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   +- CometBroadcastExchange
+               :                                      +- CometProject
+               :                                         +- CometFilter
+               :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+               :- CometHashAggregate
+               :  +- CometExchange
+               :     +- CometHashAggregate
+               :        +- CometHashAggregate
+               :           +- CometHashAggregate
+               :              +- CometUnion
+               :                 :- CometFilter
+               :                 :  :  +- ReusedSubquery
+               :                 :  +- CometHashAggregate
+               :                 :     +- CometExchange
+               :                 :        +- CometHashAggregate
+               :                 :           +- CometProject
+               :                 :              +- CometBroadcastHashJoin
+               :                 :                 :- CometProject
+               :                 :                 :  +- CometBroadcastHashJoin
+               :                 :                 :     :- CometBroadcastHashJoin
+               :                 :                 :     :  :- CometFilter
+               :                 :                 :     :  :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                 :                 :     :  :        +- CometSubqueryBroadcast
+               :                 :                 :     :  :           +- CometBroadcastExchange
+               :                 :                 :     :  :              +- CometProject
+               :                 :                 :     :  :                 +- CometFilter
+               :                 :                 :     :  :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :  +- CometBroadcastExchange
+               :                 :                 :     :     +- CometProject
+               :                 :                 :     :        +- CometBroadcastHashJoin
+               :                 :                 :     :           :- CometFilter
+               :                 :                 :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :           +- CometBroadcastExchange
+               :                 :                 :     :              +- CometBroadcastHashJoin
+               :                 :                 :     :                 :- CometHashAggregate
+               :                 :                 :     :                 :  +- CometExchange
+               :                 :                 :     :                 :     +- CometHashAggregate
+               :                 :                 :     :                 :        +- CometProject
+               :                 :                 :     :                 :           +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :- CometProject
+               :                 :                 :     :                 :              :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :     :- CometFilter
+               :                 :                 :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                 :                 :     :                 :              :     :        +- CometSubqueryBroadcast
+               :                 :                 :     :                 :              :     :           +- CometBroadcastExchange
+               :                 :                 :     :                 :              :     :              +- CometProject
+               :                 :                 :     :                 :              :     :                 +- CometFilter
+               :                 :                 :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :        +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :           :- CometFilter
+               :                 :                 :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :           +- CometBroadcastExchange
+               :                 :                 :     :                 :              :              +- CometProject
+               :                 :                 :     :                 :              :                 +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :- CometProject
+               :                 :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :     :- CometFilter
+               :                 :                 :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                 :                 :     :                 :              :                    :     :        +- ReusedSubquery
+               :                 :                 :     :                 :              :                    :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                    :        +- CometFilter
+               :                 :                 :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :                    +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                       +- CometProject
+               :                 :                 :     :                 :              :                          +- CometFilter
+               :                 :                 :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              +- CometBroadcastExchange
+               :                 :                 :     :                 :                 +- CometProject
+               :                 :                 :     :                 :                    +- CometFilter
+               :                 :                 :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 +- CometBroadcastExchange
+               :                 :                 :     :                    +- CometProject
+               :                 :                 :     :                       +- CometBroadcastHashJoin
+               :                 :                 :     :                          :- CometProject
+               :                 :                 :     :                          :  +- CometBroadcastHashJoin
+               :                 :                 :     :                          :     :- CometFilter
+               :                 :                 :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                 :                 :     :                          :     :        +- ReusedSubquery
+               :                 :                 :     :                          :     +- CometBroadcastExchange
+               :                 :                 :     :                          :        +- CometFilter
+               :                 :                 :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :                          +- CometBroadcastExchange
+               :                 :                 :     :                             +- CometProject
+               :                 :                 :     :                                +- CometFilter
+               :                 :                 :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     +- CometBroadcastExchange
+               :                 :                 :        +- CometBroadcastHashJoin
+               :                 :                 :           :- CometFilter
+               :                 :                 :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :           +- CometBroadcastExchange
+               :                 :                 :              +- CometProject
+               :                 :                 :                 +- CometBroadcastHashJoin
+               :                 :                 :                    :- CometFilter
+               :                 :                 :                    :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                    +- CometBroadcastExchange
+               :                 :                 :                       +- CometBroadcastHashJoin
+               :                 :                 :                          :- CometHashAggregate
+               :                 :                 :                          :  +- CometExchange
+               :                 :                 :                          :     +- CometHashAggregate
+               :                 :                 :                          :        +- CometProject
+               :                 :                 :                          :           +- CometBroadcastHashJoin
+               :                 :                 :                          :              :- CometProject
+               :                 :                 :                          :              :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :     :- CometFilter
+               :                 :                 :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                 :                 :                          :              :     :        +- CometSubqueryBroadcast
+               :                 :                 :                          :              :     :           +- CometBroadcastExchange
+               :                 :                 :                          :              :     :              +- CometProject
+               :                 :                 :                          :              :     :                 +- CometFilter
+               :                 :                 :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              :     +- CometBroadcastExchange
+               :                 :                 :                          :              :        +- CometBroadcastHashJoin
+               :                 :                 :                          :              :           :- CometFilter
+               :                 :                 :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                          :              :           +- CometBroadcastExchange
+               :                 :                 :                          :              :              +- CometProject
+               :                 :                 :                          :              :                 +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :- CometProject
+               :                 :                 :                          :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :     :- CometFilter
+               :                 :                 :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                 :                 :                          :              :                    :     :        +- ReusedSubquery
+               :                 :                 :                          :              :                    :     +- CometBroadcastExchange
+               :                 :                 :                          :              :                    :        +- CometFilter
+               :                 :                 :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                          :              :                    +- CometBroadcastExchange
+               :                 :                 :                          :              :                       +- CometProject
+               :                 :                 :                          :              :                          +- CometFilter
+               :                 :                 :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              +- CometBroadcastExchange
+               :                 :                 :                          :                 +- CometProject
+               :                 :                 :                          :                    +- CometFilter
+               :                 :                 :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :                          +- CometBroadcastExchange
+               :                 :                 :                             +- CometProject
+               :                 :                 :                                +- CometBroadcastHashJoin
+               :                 :                 :                                   :- CometProject
+               :                 :                 :                                   :  +- CometBroadcastHashJoin
+               :                 :                 :                                   :     :- CometFilter
+               :                 :                 :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                 :                 :                                   :     :        +- ReusedSubquery
+               :                 :                 :                                   :     +- CometBroadcastExchange
+               :                 :                 :                                   :        +- CometFilter
+               :                 :                 :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                                   +- CometBroadcastExchange
+               :                 :                 :                                      +- CometProject
+               :                 :                 :                                         +- CometFilter
+               :                 :                 :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 +- CometBroadcastExchange
+               :                 :                    +- CometProject
+               :                 :                       +- CometFilter
+               :                 :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :- CometFilter
+               :                 :  :  +- ReusedSubquery
+               :                 :  +- CometHashAggregate
+               :                 :     +- CometExchange
+               :                 :        +- CometHashAggregate
+               :                 :           +- CometProject
+               :                 :              +- CometBroadcastHashJoin
+               :                 :                 :- CometProject
+               :                 :                 :  +- CometBroadcastHashJoin
+               :                 :                 :     :- CometBroadcastHashJoin
+               :                 :                 :     :  :- CometFilter
+               :                 :                 :     :  :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                 :                 :     :  :        +- ReusedSubquery
+               :                 :                 :     :  +- CometBroadcastExchange
+               :                 :                 :     :     +- CometProject
+               :                 :                 :     :        +- CometBroadcastHashJoin
+               :                 :                 :     :           :- CometFilter
+               :                 :                 :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :           +- CometBroadcastExchange
+               :                 :                 :     :              +- CometBroadcastHashJoin
+               :                 :                 :     :                 :- CometHashAggregate
+               :                 :                 :     :                 :  +- CometExchange
+               :                 :                 :     :                 :     +- CometHashAggregate
+               :                 :                 :     :                 :        +- CometProject
+               :                 :                 :     :                 :           +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :- CometProject
+               :                 :                 :     :                 :              :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :     :- CometFilter
+               :                 :                 :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                 :                 :     :                 :              :     :        +- CometSubqueryBroadcast
+               :                 :                 :     :                 :              :     :           +- CometBroadcastExchange
+               :                 :                 :     :                 :              :     :              +- CometProject
+               :                 :                 :     :                 :              :     :                 +- CometFilter
+               :                 :                 :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :        +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :           :- CometFilter
+               :                 :                 :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :           +- CometBroadcastExchange
+               :                 :                 :     :                 :              :              +- CometProject
+               :                 :                 :     :                 :              :                 +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :- CometProject
+               :                 :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :     :- CometFilter
+               :                 :                 :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                 :                 :     :                 :              :                    :     :        +- ReusedSubquery
+               :                 :                 :     :                 :              :                    :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                    :        +- CometFilter
+               :                 :                 :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :                    +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                       +- CometProject
+               :                 :                 :     :                 :              :                          +- CometFilter
+               :                 :                 :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              +- CometBroadcastExchange
+               :                 :                 :     :                 :                 +- CometProject
+               :                 :                 :     :                 :                    +- CometFilter
+               :                 :                 :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 +- CometBroadcastExchange
+               :                 :                 :     :                    +- CometProject
+               :                 :                 :     :                       +- CometBroadcastHashJoin
+               :                 :                 :     :                          :- CometProject
+               :                 :                 :     :                          :  +- CometBroadcastHashJoin
+               :                 :                 :     :                          :     :- CometFilter
+               :                 :                 :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                 :                 :     :                          :     :        +- ReusedSubquery
+               :                 :                 :     :                          :     +- CometBroadcastExchange
+               :                 :                 :     :                          :        +- CometFilter
+               :                 :                 :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :                          +- CometBroadcastExchange
+               :                 :                 :     :                             +- CometProject
+               :                 :                 :     :                                +- CometFilter
+               :                 :                 :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     +- CometBroadcastExchange
+               :                 :                 :        +- CometBroadcastHashJoin
+               :                 :                 :           :- CometFilter
+               :                 :                 :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :           +- CometBroadcastExchange
+               :                 :                 :              +- CometProject
+               :                 :                 :                 +- CometBroadcastHashJoin
+               :                 :                 :                    :- CometFilter
+               :                 :                 :                    :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                    +- CometBroadcastExchange
+               :                 :                 :                       +- CometBroadcastHashJoin
+               :                 :                 :                          :- CometHashAggregate
+               :                 :                 :                          :  +- CometExchange
+               :                 :                 :                          :     +- CometHashAggregate
+               :                 :                 :                          :        +- CometProject
+               :                 :                 :                          :           +- CometBroadcastHashJoin
+               :                 :                 :                          :              :- CometProject
+               :                 :                 :                          :              :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :     :- CometFilter
+               :                 :                 :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                 :                 :                          :              :     :        +- CometSubqueryBroadcast
+               :                 :                 :                          :              :     :           +- CometBroadcastExchange
+               :                 :                 :                          :              :     :              +- CometProject
+               :                 :                 :                          :              :     :                 +- CometFilter
+               :                 :                 :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              :     +- CometBroadcastExchange
+               :                 :                 :                          :              :        +- CometBroadcastHashJoin
+               :                 :                 :                          :              :           :- CometFilter
+               :                 :                 :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                          :              :           +- CometBroadcastExchange
+               :                 :                 :                          :              :              +- CometProject
+               :                 :                 :                          :              :                 +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :- CometProject
+               :                 :                 :                          :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :     :- CometFilter
+               :                 :                 :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                 :                 :                          :              :                    :     :        +- ReusedSubquery
+               :                 :                 :                          :              :                    :     +- CometBroadcastExchange
+               :                 :                 :                          :              :                    :        +- CometFilter
+               :                 :                 :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                          :              :                    +- CometBroadcastExchange
+               :                 :                 :                          :              :                       +- CometProject
+               :                 :                 :                          :              :                          +- CometFilter
+               :                 :                 :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              +- CometBroadcastExchange
+               :                 :                 :                          :                 +- CometProject
+               :                 :                 :                          :                    +- CometFilter
+               :                 :                 :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :                          +- CometBroadcastExchange
+               :                 :                 :                             +- CometProject
+               :                 :                 :                                +- CometBroadcastHashJoin
+               :                 :                 :                                   :- CometProject
+               :                 :                 :                                   :  +- CometBroadcastHashJoin
+               :                 :                 :                                   :     :- CometFilter
+               :                 :                 :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                 :                 :                                   :     :        +- ReusedSubquery
+               :                 :                 :                                   :     +- CometBroadcastExchange
+               :                 :                 :                                   :        +- CometFilter
+               :                 :                 :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                                   +- CometBroadcastExchange
+               :                 :                 :                                      +- CometProject
+               :                 :                 :                                         +- CometFilter
+               :                 :                 :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 +- CometBroadcastExchange
+               :                 :                    +- CometProject
+               :                 :                       +- CometFilter
+               :                 :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 +- CometFilter
+               :                    :  +- ReusedSubquery
+               :                    +- CometHashAggregate
+               :                       +- CometExchange
+               :                          +- CometHashAggregate
+               :                             +- CometProject
+               :                                +- CometBroadcastHashJoin
+               :                                   :- CometProject
+               :                                   :  +- CometBroadcastHashJoin
+               :                                   :     :- CometBroadcastHashJoin
+               :                                   :     :  :- CometFilter
+               :                                   :     :  :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                                   :     :  :        +- ReusedSubquery
+               :                                   :     :  +- CometBroadcastExchange
+               :                                   :     :     +- CometProject
+               :                                   :     :        +- CometBroadcastHashJoin
+               :                                   :     :           :- CometFilter
+               :                                   :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :     :           +- CometBroadcastExchange
+               :                                   :     :              +- CometBroadcastHashJoin
+               :                                   :     :                 :- CometHashAggregate
+               :                                   :     :                 :  +- CometExchange
+               :                                   :     :                 :     +- CometHashAggregate
+               :                                   :     :                 :        +- CometProject
+               :                                   :     :                 :           +- CometBroadcastHashJoin
+               :                                   :     :                 :              :- CometProject
+               :                                   :     :                 :              :  +- CometBroadcastHashJoin
+               :                                   :     :                 :              :     :- CometFilter
+               :                                   :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                                   :     :                 :              :     :        +- CometSubqueryBroadcast
+               :                                   :     :                 :              :     :           +- CometBroadcastExchange
+               :                                   :     :                 :              :     :              +- CometProject
+               :                                   :     :                 :              :     :                 +- CometFilter
+               :                                   :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :     :                 :              :     +- CometBroadcastExchange
+               :                                   :     :                 :              :        +- CometBroadcastHashJoin
+               :                                   :     :                 :              :           :- CometFilter
+               :                                   :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :     :                 :              :           +- CometBroadcastExchange
+               :                                   :     :                 :              :              +- CometProject
+               :                                   :     :                 :              :                 +- CometBroadcastHashJoin
+               :                                   :     :                 :              :                    :- CometProject
+               :                                   :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                                   :     :                 :              :                    :     :- CometFilter
+               :                                   :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                                   :     :                 :              :                    :     :        +- ReusedSubquery
+               :                                   :     :                 :              :                    :     +- CometBroadcastExchange
+               :                                   :     :                 :              :                    :        +- CometFilter
+               :                                   :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :     :                 :              :                    +- CometBroadcastExchange
+               :                                   :     :                 :              :                       +- CometProject
+               :                                   :     :                 :              :                          +- CometFilter
+               :                                   :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :     :                 :              +- CometBroadcastExchange
+               :                                   :     :                 :                 +- CometProject
+               :                                   :     :                 :                    +- CometFilter
+               :                                   :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :     :                 +- CometBroadcastExchange
+               :                                   :     :                    +- CometProject
+               :                                   :     :                       +- CometBroadcastHashJoin
+               :                                   :     :                          :- CometProject
+               :                                   :     :                          :  +- CometBroadcastHashJoin
+               :                                   :     :                          :     :- CometFilter
+               :                                   :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                                   :     :                          :     :        +- ReusedSubquery
+               :                                   :     :                          :     +- CometBroadcastExchange
+               :                                   :     :                          :        +- CometFilter
+               :                                   :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :     :                          +- CometBroadcastExchange
+               :                                   :     :                             +- CometProject
+               :                                   :     :                                +- CometFilter
+               :                                   :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :     +- CometBroadcastExchange
+               :                                   :        +- CometBroadcastHashJoin
+               :                                   :           :- CometFilter
+               :                                   :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :           +- CometBroadcastExchange
+               :                                   :              +- CometProject
+               :                                   :                 +- CometBroadcastHashJoin
+               :                                   :                    :- CometFilter
+               :                                   :                    :  +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :                    +- CometBroadcastExchange
+               :                                   :                       +- CometBroadcastHashJoin
+               :                                   :                          :- CometHashAggregate
+               :                                   :                          :  +- CometExchange
+               :                                   :                          :     +- CometHashAggregate
+               :                                   :                          :        +- CometProject
+               :                                   :                          :           +- CometBroadcastHashJoin
+               :                                   :                          :              :- CometProject
+               :                                   :                          :              :  +- CometBroadcastHashJoin
+               :                                   :                          :              :     :- CometFilter
+               :                                   :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                                   :                          :              :     :        +- CometSubqueryBroadcast
+               :                                   :                          :              :     :           +- CometBroadcastExchange
+               :                                   :                          :              :     :              +- CometProject
+               :                                   :                          :              :     :                 +- CometFilter
+               :                                   :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :                          :              :     +- CometBroadcastExchange
+               :                                   :                          :              :        +- CometBroadcastHashJoin
+               :                                   :                          :              :           :- CometFilter
+               :                                   :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :                          :              :           +- CometBroadcastExchange
+               :                                   :                          :              :              +- CometProject
+               :                                   :                          :              :                 +- CometBroadcastHashJoin
+               :                                   :                          :              :                    :- CometProject
+               :                                   :                          :              :                    :  +- CometBroadcastHashJoin
+               :                                   :                          :              :                    :     :- CometFilter
+               :                                   :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                                   :                          :              :                    :     :        +- ReusedSubquery
+               :                                   :                          :              :                    :     +- CometBroadcastExchange
+               :                                   :                          :              :                    :        +- CometFilter
+               :                                   :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :                          :              :                    +- CometBroadcastExchange
+               :                                   :                          :              :                       +- CometProject
+               :                                   :                          :              :                          +- CometFilter
+               :                                   :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :                          :              +- CometBroadcastExchange
+               :                                   :                          :                 +- CometProject
+               :                                   :                          :                    +- CometFilter
+               :                                   :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :                          +- CometBroadcastExchange
+               :                                   :                             +- CometProject
+               :                                   :                                +- CometBroadcastHashJoin
+               :                                   :                                   :- CometProject
+               :                                   :                                   :  +- CometBroadcastHashJoin
+               :                                   :                                   :     :- CometFilter
+               :                                   :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                                   :                                   :     :        +- ReusedSubquery
+               :                                   :                                   :     +- CometBroadcastExchange
+               :                                   :                                   :        +- CometFilter
+               :                                   :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :                                   +- CometBroadcastExchange
+               :                                   :                                      +- CometProject
+               :                                   :                                         +- CometFilter
+               :                                   :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   +- CometBroadcastExchange
+               :                                      +- CometProject
+               :                                         +- CometFilter
+               :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+               :- CometHashAggregate
+               :  +- CometExchange
+               :     +- CometHashAggregate
+               :        +- CometHashAggregate
+               :           +- CometHashAggregate
+               :              +- CometUnion
+               :                 :- CometFilter
+               :                 :  :  +- ReusedSubquery
+               :                 :  +- CometHashAggregate
+               :                 :     +- CometExchange
+               :                 :        +- CometHashAggregate
+               :                 :           +- CometProject
+               :                 :              +- CometBroadcastHashJoin
+               :                 :                 :- CometProject
+               :                 :                 :  +- CometBroadcastHashJoin
+               :                 :                 :     :- CometBroadcastHashJoin
+               :                 :                 :     :  :- CometFilter
+               :                 :                 :     :  :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                 :                 :     :  :        +- CometSubqueryBroadcast
+               :                 :                 :     :  :           +- CometBroadcastExchange
+               :                 :                 :     :  :              +- CometProject
+               :                 :                 :     :  :                 +- CometFilter
+               :                 :                 :     :  :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :  +- CometBroadcastExchange
+               :                 :                 :     :     +- CometProject
+               :                 :                 :     :        +- CometBroadcastHashJoin
+               :                 :                 :     :           :- CometFilter
+               :                 :                 :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :           +- CometBroadcastExchange
+               :                 :                 :     :              +- CometBroadcastHashJoin
+               :                 :                 :     :                 :- CometHashAggregate
+               :                 :                 :     :                 :  +- CometExchange
+               :                 :                 :     :                 :     +- CometHashAggregate
+               :                 :                 :     :                 :        +- CometProject
+               :                 :                 :     :                 :           +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :- CometProject
+               :                 :                 :     :                 :              :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :     :- CometFilter
+               :                 :                 :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                 :                 :     :                 :              :     :        +- CometSubqueryBroadcast
+               :                 :                 :     :                 :              :     :           +- CometBroadcastExchange
+               :                 :                 :     :                 :              :     :              +- CometProject
+               :                 :                 :     :                 :              :     :                 +- CometFilter
+               :                 :                 :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :        +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :           :- CometFilter
+               :                 :                 :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :           +- CometBroadcastExchange
+               :                 :                 :     :                 :              :              +- CometProject
+               :                 :                 :     :                 :              :                 +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :- CometProject
+               :                 :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :     :- CometFilter
+               :                 :                 :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                 :                 :     :                 :              :                    :     :        +- ReusedSubquery
+               :                 :                 :     :                 :              :                    :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                    :        +- CometFilter
+               :                 :                 :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :                    +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                       +- CometProject
+               :                 :                 :     :                 :              :                          +- CometFilter
+               :                 :                 :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              +- CometBroadcastExchange
+               :                 :                 :     :                 :                 +- CometProject
+               :                 :                 :     :                 :                    +- CometFilter
+               :                 :                 :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 +- CometBroadcastExchange
+               :                 :                 :     :                    +- CometProject
+               :                 :                 :     :                       +- CometBroadcastHashJoin
+               :                 :                 :     :                          :- CometProject
+               :                 :                 :     :                          :  +- CometBroadcastHashJoin
+               :                 :                 :     :                          :     :- CometFilter
+               :                 :                 :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                 :                 :     :                          :     :        +- ReusedSubquery
+               :                 :                 :     :                          :     +- CometBroadcastExchange
+               :                 :                 :     :                          :        +- CometFilter
+               :                 :                 :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :                          +- CometBroadcastExchange
+               :                 :                 :     :                             +- CometProject
+               :                 :                 :     :                                +- CometFilter
+               :                 :                 :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     +- CometBroadcastExchange
+               :                 :                 :        +- CometBroadcastHashJoin
+               :                 :                 :           :- CometFilter
+               :                 :                 :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :           +- CometBroadcastExchange
+               :                 :                 :              +- CometProject
+               :                 :                 :                 +- CometBroadcastHashJoin
+               :                 :                 :                    :- CometFilter
+               :                 :                 :                    :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                    +- CometBroadcastExchange
+               :                 :                 :                       +- CometBroadcastHashJoin
+               :                 :                 :                          :- CometHashAggregate
+               :                 :                 :                          :  +- CometExchange
+               :                 :                 :                          :     +- CometHashAggregate
+               :                 :                 :                          :        +- CometProject
+               :                 :                 :                          :           +- CometBroadcastHashJoin
+               :                 :                 :                          :              :- CometProject
+               :                 :                 :                          :              :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :     :- CometFilter
+               :                 :                 :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                 :                 :                          :              :     :        +- CometSubqueryBroadcast
+               :                 :                 :                          :              :     :           +- CometBroadcastExchange
+               :                 :                 :                          :              :     :              +- CometProject
+               :                 :                 :                          :              :     :                 +- CometFilter
+               :                 :                 :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              :     +- CometBroadcastExchange
+               :                 :                 :                          :              :        +- CometBroadcastHashJoin
+               :                 :                 :                          :              :           :- CometFilter
+               :                 :                 :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                          :              :           +- CometBroadcastExchange
+               :                 :                 :                          :              :              +- CometProject
+               :                 :                 :                          :              :                 +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :- CometProject
+               :                 :                 :                          :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :     :- CometFilter
+               :                 :                 :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                 :                 :                          :              :                    :     :        +- ReusedSubquery
+               :                 :                 :                          :              :                    :     +- CometBroadcastExchange
+               :                 :                 :                          :              :                    :        +- CometFilter
+               :                 :                 :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                          :              :                    +- CometBroadcastExchange
+               :                 :                 :                          :              :                       +- CometProject
+               :                 :                 :                          :              :                          +- CometFilter
+               :                 :                 :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              +- CometBroadcastExchange
+               :                 :                 :                          :                 +- CometProject
+               :                 :                 :                          :                    +- CometFilter
+               :                 :                 :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :                          +- CometBroadcastExchange
+               :                 :                 :                             +- CometProject
+               :                 :                 :                                +- CometBroadcastHashJoin
+               :                 :                 :                                   :- CometProject
+               :                 :                 :                                   :  +- CometBroadcastHashJoin
+               :                 :                 :                                   :     :- CometFilter
+               :                 :                 :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                 :                 :                                   :     :        +- ReusedSubquery
+               :                 :                 :                                   :     +- CometBroadcastExchange
+               :                 :                 :                                   :        +- CometFilter
+               :                 :                 :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                                   +- CometBroadcastExchange
+               :                 :                 :                                      +- CometProject
+               :                 :                 :                                         +- CometFilter
+               :                 :                 :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 +- CometBroadcastExchange
+               :                 :                    +- CometProject
+               :                 :                       +- CometFilter
+               :                 :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :- CometFilter
+               :                 :  :  +- ReusedSubquery
+               :                 :  +- CometHashAggregate
+               :                 :     +- CometExchange
+               :                 :        +- CometHashAggregate
+               :                 :           +- CometProject
+               :                 :              +- CometBroadcastHashJoin
+               :                 :                 :- CometProject
+               :                 :                 :  +- CometBroadcastHashJoin
+               :                 :                 :     :- CometBroadcastHashJoin
+               :                 :                 :     :  :- CometFilter
+               :                 :                 :     :  :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                 :                 :     :  :        +- ReusedSubquery
+               :                 :                 :     :  +- CometBroadcastExchange
+               :                 :                 :     :     +- CometProject
+               :                 :                 :     :        +- CometBroadcastHashJoin
+               :                 :                 :     :           :- CometFilter
+               :                 :                 :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :           +- CometBroadcastExchange
+               :                 :                 :     :              +- CometBroadcastHashJoin
+               :                 :                 :     :                 :- CometHashAggregate
+               :                 :                 :     :                 :  +- CometExchange
+               :                 :                 :     :                 :     +- CometHashAggregate
+               :                 :                 :     :                 :        +- CometProject
+               :                 :                 :     :                 :           +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :- CometProject
+               :                 :                 :     :                 :              :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :     :- CometFilter
+               :                 :                 :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                 :                 :     :                 :              :     :        +- CometSubqueryBroadcast
+               :                 :                 :     :                 :              :     :           +- CometBroadcastExchange
+               :                 :                 :     :                 :              :     :              +- CometProject
+               :                 :                 :     :                 :              :     :                 +- CometFilter
+               :                 :                 :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :        +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :           :- CometFilter
+               :                 :                 :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :           +- CometBroadcastExchange
+               :                 :                 :     :                 :              :              +- CometProject
+               :                 :                 :     :                 :              :                 +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :- CometProject
+               :                 :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :     :- CometFilter
+               :                 :                 :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                 :                 :     :                 :              :                    :     :        +- ReusedSubquery
+               :                 :                 :     :                 :              :                    :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                    :        +- CometFilter
+               :                 :                 :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :                    +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                       +- CometProject
+               :                 :                 :     :                 :              :                          +- CometFilter
+               :                 :                 :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              +- CometBroadcastExchange
+               :                 :                 :     :                 :                 +- CometProject
+               :                 :                 :     :                 :                    +- CometFilter
+               :                 :                 :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 +- CometBroadcastExchange
+               :                 :                 :     :                    +- CometProject
+               :                 :                 :     :                       +- CometBroadcastHashJoin
+               :                 :                 :     :                          :- CometProject
+               :                 :                 :     :                          :  +- CometBroadcastHashJoin
+               :                 :                 :     :                          :     :- CometFilter
+               :                 :                 :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                 :                 :     :                          :     :        +- ReusedSubquery
+               :                 :                 :     :                          :     +- CometBroadcastExchange
+               :                 :                 :     :                          :        +- CometFilter
+               :                 :                 :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :     :                          +- CometBroadcastExchange
+               :                 :                 :     :                             +- CometProject
+               :                 :                 :     :                                +- CometFilter
+               :                 :                 :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :     +- CometBroadcastExchange
+               :                 :                 :        +- CometBroadcastHashJoin
+               :                 :                 :           :- CometFilter
+               :                 :                 :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :           +- CometBroadcastExchange
+               :                 :                 :              +- CometProject
+               :                 :                 :                 +- CometBroadcastHashJoin
+               :                 :                 :                    :- CometFilter
+               :                 :                 :                    :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                    +- CometBroadcastExchange
+               :                 :                 :                       +- CometBroadcastHashJoin
+               :                 :                 :                          :- CometHashAggregate
+               :                 :                 :                          :  +- CometExchange
+               :                 :                 :                          :     +- CometHashAggregate
+               :                 :                 :                          :        +- CometProject
+               :                 :                 :                          :           +- CometBroadcastHashJoin
+               :                 :                 :                          :              :- CometProject
+               :                 :                 :                          :              :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :     :- CometFilter
+               :                 :                 :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                 :                 :                          :              :     :        +- CometSubqueryBroadcast
+               :                 :                 :                          :              :     :           +- CometBroadcastExchange
+               :                 :                 :                          :              :     :              +- CometProject
+               :                 :                 :                          :              :     :                 +- CometFilter
+               :                 :                 :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              :     +- CometBroadcastExchange
+               :                 :                 :                          :              :        +- CometBroadcastHashJoin
+               :                 :                 :                          :              :           :- CometFilter
+               :                 :                 :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                          :              :           +- CometBroadcastExchange
+               :                 :                 :                          :              :              +- CometProject
+               :                 :                 :                          :              :                 +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :- CometProject
+               :                 :                 :                          :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :     :- CometFilter
+               :                 :                 :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                 :                 :                          :              :                    :     :        +- ReusedSubquery
+               :                 :                 :                          :              :                    :     +- CometBroadcastExchange
+               :                 :                 :                          :              :                    :        +- CometFilter
+               :                 :                 :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                          :              :                    +- CometBroadcastExchange
+               :                 :                 :                          :              :                       +- CometProject
+               :                 :                 :                          :              :                          +- CometFilter
+               :                 :                 :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              +- CometBroadcastExchange
+               :                 :                 :                          :                 +- CometProject
+               :                 :                 :                          :                    +- CometFilter
+               :                 :                 :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 :                          +- CometBroadcastExchange
+               :                 :                 :                             +- CometProject
+               :                 :                 :                                +- CometBroadcastHashJoin
+               :                 :                 :                                   :- CometProject
+               :                 :                 :                                   :  +- CometBroadcastHashJoin
+               :                 :                 :                                   :     :- CometFilter
+               :                 :                 :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                 :                 :                                   :     :        +- ReusedSubquery
+               :                 :                 :                                   :     +- CometBroadcastExchange
+               :                 :                 :                                   :        +- CometFilter
+               :                 :                 :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+               :                 :                 :                                   +- CometBroadcastExchange
+               :                 :                 :                                      +- CometProject
+               :                 :                 :                                         +- CometFilter
+               :                 :                 :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 :                 +- CometBroadcastExchange
+               :                 :                    +- CometProject
+               :                 :                       +- CometFilter
+               :                 :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                 +- CometFilter
+               :                    :  +- ReusedSubquery
+               :                    +- CometHashAggregate
+               :                       +- CometExchange
+               :                          +- CometHashAggregate
+               :                             +- CometProject
+               :                                +- CometBroadcastHashJoin
+               :                                   :- CometProject
+               :                                   :  +- CometBroadcastHashJoin
+               :                                   :     :- CometBroadcastHashJoin
+               :                                   :     :  :- CometFilter
+               :                                   :     :  :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                                   :     :  :        +- ReusedSubquery
+               :                                   :     :  +- CometBroadcastExchange
+               :                                   :     :     +- CometProject
+               :                                   :     :        +- CometBroadcastHashJoin
+               :                                   :     :           :- CometFilter
+               :                                   :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :     :           +- CometBroadcastExchange
+               :                                   :     :              +- CometBroadcastHashJoin
+               :                                   :     :                 :- CometHashAggregate
+               :                                   :     :                 :  +- CometExchange
+               :                                   :     :                 :     +- CometHashAggregate
+               :                                   :     :                 :        +- CometProject
+               :                                   :     :                 :           +- CometBroadcastHashJoin
+               :                                   :     :                 :              :- CometProject
+               :                                   :     :                 :              :  +- CometBroadcastHashJoin
+               :                                   :     :                 :              :     :- CometFilter
+               :                                   :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                                   :     :                 :              :     :        +- CometSubqueryBroadcast
+               :                                   :     :                 :              :     :           +- CometBroadcastExchange
+               :                                   :     :                 :              :     :              +- CometProject
+               :                                   :     :                 :              :     :                 +- CometFilter
+               :                                   :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :     :                 :              :     +- CometBroadcastExchange
+               :                                   :     :                 :              :        +- CometBroadcastHashJoin
+               :                                   :     :                 :              :           :- CometFilter
+               :                                   :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :     :                 :              :           +- CometBroadcastExchange
+               :                                   :     :                 :              :              +- CometProject
+               :                                   :     :                 :              :                 +- CometBroadcastHashJoin
+               :                                   :     :                 :              :                    :- CometProject
+               :                                   :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                                   :     :                 :              :                    :     :- CometFilter
+               :                                   :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                                   :     :                 :              :                    :     :        +- ReusedSubquery
+               :                                   :     :                 :              :                    :     +- CometBroadcastExchange
+               :                                   :     :                 :              :                    :        +- CometFilter
+               :                                   :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :     :                 :              :                    +- CometBroadcastExchange
+               :                                   :     :                 :              :                       +- CometProject
+               :                                   :     :                 :              :                          +- CometFilter
+               :                                   :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :     :                 :              +- CometBroadcastExchange
+               :                                   :     :                 :                 +- CometProject
+               :                                   :     :                 :                    +- CometFilter
+               :                                   :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :     :                 +- CometBroadcastExchange
+               :                                   :     :                    +- CometProject
+               :                                   :     :                       +- CometBroadcastHashJoin
+               :                                   :     :                          :- CometProject
+               :                                   :     :                          :  +- CometBroadcastHashJoin
+               :                                   :     :                          :     :- CometFilter
+               :                                   :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                                   :     :                          :     :        +- ReusedSubquery
+               :                                   :     :                          :     +- CometBroadcastExchange
+               :                                   :     :                          :        +- CometFilter
+               :                                   :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :     :                          +- CometBroadcastExchange
+               :                                   :     :                             +- CometProject
+               :                                   :     :                                +- CometFilter
+               :                                   :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :     +- CometBroadcastExchange
+               :                                   :        +- CometBroadcastHashJoin
+               :                                   :           :- CometFilter
+               :                                   :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :           +- CometBroadcastExchange
+               :                                   :              +- CometProject
+               :                                   :                 +- CometBroadcastHashJoin
+               :                                   :                    :- CometFilter
+               :                                   :                    :  +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :                    +- CometBroadcastExchange
+               :                                   :                       +- CometBroadcastHashJoin
+               :                                   :                          :- CometHashAggregate
+               :                                   :                          :  +- CometExchange
+               :                                   :                          :     +- CometHashAggregate
+               :                                   :                          :        +- CometProject
+               :                                   :                          :           +- CometBroadcastHashJoin
+               :                                   :                          :              :- CometProject
+               :                                   :                          :              :  +- CometBroadcastHashJoin
+               :                                   :                          :              :     :- CometFilter
+               :                                   :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                                   :                          :              :     :        +- CometSubqueryBroadcast
+               :                                   :                          :              :     :           +- CometBroadcastExchange
+               :                                   :                          :              :     :              +- CometProject
+               :                                   :                          :              :     :                 +- CometFilter
+               :                                   :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :                          :              :     +- CometBroadcastExchange
+               :                                   :                          :              :        +- CometBroadcastHashJoin
+               :                                   :                          :              :           :- CometFilter
+               :                                   :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :                          :              :           +- CometBroadcastExchange
+               :                                   :                          :              :              +- CometProject
+               :                                   :                          :              :                 +- CometBroadcastHashJoin
+               :                                   :                          :              :                    :- CometProject
+               :                                   :                          :              :                    :  +- CometBroadcastHashJoin
+               :                                   :                          :              :                    :     :- CometFilter
+               :                                   :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                                   :                          :              :                    :     :        +- ReusedSubquery
+               :                                   :                          :              :                    :     +- CometBroadcastExchange
+               :                                   :                          :              :                    :        +- CometFilter
+               :                                   :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :                          :              :                    +- CometBroadcastExchange
+               :                                   :                          :              :                       +- CometProject
+               :                                   :                          :              :                          +- CometFilter
+               :                                   :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :                          :              +- CometBroadcastExchange
+               :                                   :                          :                 +- CometProject
+               :                                   :                          :                    +- CometFilter
+               :                                   :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :                          +- CometBroadcastExchange
+               :                                   :                             +- CometProject
+               :                                   :                                +- CometBroadcastHashJoin
+               :                                   :                                   :- CometProject
+               :                                   :                                   :  +- CometBroadcastHashJoin
+               :                                   :                                   :     :- CometFilter
+               :                                   :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                                   :                                   :     :        +- ReusedSubquery
+               :                                   :                                   :     +- CometBroadcastExchange
+               :                                   :                                   :        +- CometFilter
+               :                                   :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+               :                                   :                                   +- CometBroadcastExchange
+               :                                   :                                      +- CometProject
+               :                                   :                                         +- CometFilter
+               :                                   :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   +- CometBroadcastExchange
+               :                                      +- CometProject
+               :                                         +- CometFilter
+               :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometHashAggregate
+                           +- CometHashAggregate
+                              +- CometUnion
+                                 :- CometFilter
+                                 :  :  +- ReusedSubquery
+                                 :  +- CometHashAggregate
+                                 :     +- CometExchange
+                                 :        +- CometHashAggregate
+                                 :           +- CometProject
+                                 :              +- CometBroadcastHashJoin
+                                 :                 :- CometProject
+                                 :                 :  +- CometBroadcastHashJoin
+                                 :                 :     :- CometBroadcastHashJoin
+                                 :                 :     :  :- CometFilter
+                                 :                 :     :  :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                 :                 :     :  :        +- CometSubqueryBroadcast
+                                 :                 :     :  :           +- CometBroadcastExchange
+                                 :                 :     :  :              +- CometProject
+                                 :                 :     :  :                 +- CometFilter
+                                 :                 :     :  :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :                 :     :  +- CometBroadcastExchange
+                                 :                 :     :     +- CometProject
+                                 :                 :     :        +- CometBroadcastHashJoin
+                                 :                 :     :           :- CometFilter
+                                 :                 :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+                                 :                 :     :           +- CometBroadcastExchange
+                                 :                 :     :              +- CometBroadcastHashJoin
+                                 :                 :     :                 :- CometHashAggregate
+                                 :                 :     :                 :  +- CometExchange
+                                 :                 :     :                 :     +- CometHashAggregate
+                                 :                 :     :                 :        +- CometProject
+                                 :                 :     :                 :           +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :- CometProject
+                                 :                 :     :                 :              :  +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :     :- CometFilter
+                                 :                 :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                 :                 :     :                 :              :     :        +- CometSubqueryBroadcast
+                                 :                 :     :                 :              :     :           +- CometBroadcastExchange
+                                 :                 :     :                 :              :     :              +- CometProject
+                                 :                 :     :                 :              :     :                 +- CometFilter
+                                 :                 :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :                 :     :                 :              :     +- CometBroadcastExchange
+                                 :                 :     :                 :              :        +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :           :- CometFilter
+                                 :                 :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+                                 :                 :     :                 :              :           +- CometBroadcastExchange
+                                 :                 :     :                 :              :              +- CometProject
+                                 :                 :     :                 :              :                 +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :                    :- CometProject
+                                 :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :                    :     :- CometFilter
+                                 :                 :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                                 :                 :     :                 :              :                    :     :        +- ReusedSubquery
+                                 :                 :     :                 :              :                    :     +- CometBroadcastExchange
+                                 :                 :     :                 :              :                    :        +- CometFilter
+                                 :                 :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+                                 :                 :     :                 :              :                    +- CometBroadcastExchange
+                                 :                 :     :                 :              :                       +- CometProject
+                                 :                 :     :                 :              :                          +- CometFilter
+                                 :                 :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :                 :     :                 :              +- CometBroadcastExchange
+                                 :                 :     :                 :                 +- CometProject
+                                 :                 :     :                 :                    +- CometFilter
+                                 :                 :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :                 :     :                 +- CometBroadcastExchange
+                                 :                 :     :                    +- CometProject
+                                 :                 :     :                       +- CometBroadcastHashJoin
+                                 :                 :     :                          :- CometProject
+                                 :                 :     :                          :  +- CometBroadcastHashJoin
+                                 :                 :     :                          :     :- CometFilter
+                                 :                 :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                                 :                 :     :                          :     :        +- ReusedSubquery
+                                 :                 :     :                          :     +- CometBroadcastExchange
+                                 :                 :     :                          :        +- CometFilter
+                                 :                 :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+                                 :                 :     :                          +- CometBroadcastExchange
+                                 :                 :     :                             +- CometProject
+                                 :                 :     :                                +- CometFilter
+                                 :                 :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :                 :     +- CometBroadcastExchange
+                                 :                 :        +- CometBroadcastHashJoin
+                                 :                 :           :- CometFilter
+                                 :                 :           :  +- CometNativeScan parquet spark_catalog.default.item
+                                 :                 :           +- CometBroadcastExchange
+                                 :                 :              +- CometProject
+                                 :                 :                 +- CometBroadcastHashJoin
+                                 :                 :                    :- CometFilter
+                                 :                 :                    :  +- CometNativeScan parquet spark_catalog.default.item
+                                 :                 :                    +- CometBroadcastExchange
+                                 :                 :                       +- CometBroadcastHashJoin
+                                 :                 :                          :- CometHashAggregate
+                                 :                 :                          :  +- CometExchange
+                                 :                 :                          :     +- CometHashAggregate
+                                 :                 :                          :        +- CometProject
+                                 :                 :                          :           +- CometBroadcastHashJoin
+                                 :                 :                          :              :- CometProject
+                                 :                 :                          :              :  +- CometBroadcastHashJoin
+                                 :                 :                          :              :     :- CometFilter
+                                 :                 :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                 :                 :                          :              :     :        +- CometSubqueryBroadcast
+                                 :                 :                          :              :     :           +- CometBroadcastExchange
+                                 :                 :                          :              :     :              +- CometProject
+                                 :                 :                          :              :     :                 +- CometFilter
+                                 :                 :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :                 :                          :              :     +- CometBroadcastExchange
+                                 :                 :                          :              :        +- CometBroadcastHashJoin
+                                 :                 :                          :              :           :- CometFilter
+                                 :                 :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+                                 :                 :                          :              :           +- CometBroadcastExchange
+                                 :                 :                          :              :              +- CometProject
+                                 :                 :                          :              :                 +- CometBroadcastHashJoin
+                                 :                 :                          :              :                    :- CometProject
+                                 :                 :                          :              :                    :  +- CometBroadcastHashJoin
+                                 :                 :                          :              :                    :     :- CometFilter
+                                 :                 :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                                 :                 :                          :              :                    :     :        +- ReusedSubquery
+                                 :                 :                          :              :                    :     +- CometBroadcastExchange
+                                 :                 :                          :              :                    :        +- CometFilter
+                                 :                 :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+                                 :                 :                          :              :                    +- CometBroadcastExchange
+                                 :                 :                          :              :                       +- CometProject
+                                 :                 :                          :              :                          +- CometFilter
+                                 :                 :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :                 :                          :              +- CometBroadcastExchange
+                                 :                 :                          :                 +- CometProject
+                                 :                 :                          :                    +- CometFilter
+                                 :                 :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :                 :                          +- CometBroadcastExchange
+                                 :                 :                             +- CometProject
+                                 :                 :                                +- CometBroadcastHashJoin
+                                 :                 :                                   :- CometProject
+                                 :                 :                                   :  +- CometBroadcastHashJoin
+                                 :                 :                                   :     :- CometFilter
+                                 :                 :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                                 :                 :                                   :     :        +- ReusedSubquery
+                                 :                 :                                   :     +- CometBroadcastExchange
+                                 :                 :                                   :        +- CometFilter
+                                 :                 :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+                                 :                 :                                   +- CometBroadcastExchange
+                                 :                 :                                      +- CometProject
+                                 :                 :                                         +- CometFilter
+                                 :                 :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :                 +- CometBroadcastExchange
+                                 :                    +- CometProject
+                                 :                       +- CometFilter
+                                 :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :- CometFilter
+                                 :  :  +- ReusedSubquery
+                                 :  +- CometHashAggregate
+                                 :     +- CometExchange
+                                 :        +- CometHashAggregate
+                                 :           +- CometProject
+                                 :              +- CometBroadcastHashJoin
+                                 :                 :- CometProject
+                                 :                 :  +- CometBroadcastHashJoin
+                                 :                 :     :- CometBroadcastHashJoin
+                                 :                 :     :  :- CometFilter
+                                 :                 :     :  :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                                 :                 :     :  :        +- ReusedSubquery
+                                 :                 :     :  +- CometBroadcastExchange
+                                 :                 :     :     +- CometProject
+                                 :                 :     :        +- CometBroadcastHashJoin
+                                 :                 :     :           :- CometFilter
+                                 :                 :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+                                 :                 :     :           +- CometBroadcastExchange
+                                 :                 :     :              +- CometBroadcastHashJoin
+                                 :                 :     :                 :- CometHashAggregate
+                                 :                 :     :                 :  +- CometExchange
+                                 :                 :     :                 :     +- CometHashAggregate
+                                 :                 :     :                 :        +- CometProject
+                                 :                 :     :                 :           +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :- CometProject
+                                 :                 :     :                 :              :  +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :     :- CometFilter
+                                 :                 :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                 :                 :     :                 :              :     :        +- CometSubqueryBroadcast
+                                 :                 :     :                 :              :     :           +- CometBroadcastExchange
+                                 :                 :     :                 :              :     :              +- CometProject
+                                 :                 :     :                 :              :     :                 +- CometFilter
+                                 :                 :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :                 :     :                 :              :     +- CometBroadcastExchange
+                                 :                 :     :                 :              :        +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :           :- CometFilter
+                                 :                 :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+                                 :                 :     :                 :              :           +- CometBroadcastExchange
+                                 :                 :     :                 :              :              +- CometProject
+                                 :                 :     :                 :              :                 +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :                    :- CometProject
+                                 :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :                    :     :- CometFilter
+                                 :                 :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                                 :                 :     :                 :              :                    :     :        +- ReusedSubquery
+                                 :                 :     :                 :              :                    :     +- CometBroadcastExchange
+                                 :                 :     :                 :              :                    :        +- CometFilter
+                                 :                 :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+                                 :                 :     :                 :              :                    +- CometBroadcastExchange
+                                 :                 :     :                 :              :                       +- CometProject
+                                 :                 :     :                 :              :                          +- CometFilter
+                                 :                 :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :                 :     :                 :              +- CometBroadcastExchange
+                                 :                 :     :                 :                 +- CometProject
+                                 :                 :     :                 :                    +- CometFilter
+                                 :                 :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :                 :     :                 +- CometBroadcastExchange
+                                 :                 :     :                    +- CometProject
+                                 :                 :     :                       +- CometBroadcastHashJoin
+                                 :                 :     :                          :- CometProject
+                                 :                 :     :                          :  +- CometBroadcastHashJoin
+                                 :                 :     :                          :     :- CometFilter
+                                 :                 :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                                 :                 :     :                          :     :        +- ReusedSubquery
+                                 :                 :     :                          :     +- CometBroadcastExchange
+                                 :                 :     :                          :        +- CometFilter
+                                 :                 :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+                                 :                 :     :                          +- CometBroadcastExchange
+                                 :                 :     :                             +- CometProject
+                                 :                 :     :                                +- CometFilter
+                                 :                 :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :                 :     +- CometBroadcastExchange
+                                 :                 :        +- CometBroadcastHashJoin
+                                 :                 :           :- CometFilter
+                                 :                 :           :  +- CometNativeScan parquet spark_catalog.default.item
+                                 :                 :           +- CometBroadcastExchange
+                                 :                 :              +- CometProject
+                                 :                 :                 +- CometBroadcastHashJoin
+                                 :                 :                    :- CometFilter
+                                 :                 :                    :  +- CometNativeScan parquet spark_catalog.default.item
+                                 :                 :                    +- CometBroadcastExchange
+                                 :                 :                       +- CometBroadcastHashJoin
+                                 :                 :                          :- CometHashAggregate
+                                 :                 :                          :  +- CometExchange
+                                 :                 :                          :     +- CometHashAggregate
+                                 :                 :                          :        +- CometProject
+                                 :                 :                          :           +- CometBroadcastHashJoin
+                                 :                 :                          :              :- CometProject
+                                 :                 :                          :              :  +- CometBroadcastHashJoin
+                                 :                 :                          :              :     :- CometFilter
+                                 :                 :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                 :                 :                          :              :     :        +- CometSubqueryBroadcast
+                                 :                 :                          :              :     :           +- CometBroadcastExchange
+                                 :                 :                          :              :     :              +- CometProject
+                                 :                 :                          :              :     :                 +- CometFilter
+                                 :                 :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :                 :                          :              :     +- CometBroadcastExchange
+                                 :                 :                          :              :        +- CometBroadcastHashJoin
+                                 :                 :                          :              :           :- CometFilter
+                                 :                 :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+                                 :                 :                          :              :           +- CometBroadcastExchange
+                                 :                 :                          :              :              +- CometProject
+                                 :                 :                          :              :                 +- CometBroadcastHashJoin
+                                 :                 :                          :              :                    :- CometProject
+                                 :                 :                          :              :                    :  +- CometBroadcastHashJoin
+                                 :                 :                          :              :                    :     :- CometFilter
+                                 :                 :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                                 :                 :                          :              :                    :     :        +- ReusedSubquery
+                                 :                 :                          :              :                    :     +- CometBroadcastExchange
+                                 :                 :                          :              :                    :        +- CometFilter
+                                 :                 :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+                                 :                 :                          :              :                    +- CometBroadcastExchange
+                                 :                 :                          :              :                       +- CometProject
+                                 :                 :                          :              :                          +- CometFilter
+                                 :                 :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :                 :                          :              +- CometBroadcastExchange
+                                 :                 :                          :                 +- CometProject
+                                 :                 :                          :                    +- CometFilter
+                                 :                 :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :                 :                          +- CometBroadcastExchange
+                                 :                 :                             +- CometProject
+                                 :                 :                                +- CometBroadcastHashJoin
+                                 :                 :                                   :- CometProject
+                                 :                 :                                   :  +- CometBroadcastHashJoin
+                                 :                 :                                   :     :- CometFilter
+                                 :                 :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                                 :                 :                                   :     :        +- ReusedSubquery
+                                 :                 :                                   :     +- CometBroadcastExchange
+                                 :                 :                                   :        +- CometFilter
+                                 :                 :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+                                 :                 :                                   +- CometBroadcastExchange
+                                 :                 :                                      +- CometProject
+                                 :                 :                                         +- CometFilter
+                                 :                 :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 :                 +- CometBroadcastExchange
+                                 :                    +- CometProject
+                                 :                       +- CometFilter
+                                 :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+                                 +- CometFilter
+                                    :  +- ReusedSubquery
+                                    +- CometHashAggregate
+                                       +- CometExchange
+                                          +- CometHashAggregate
+                                             +- CometProject
+                                                +- CometBroadcastHashJoin
+                                                   :- CometProject
+                                                   :  +- CometBroadcastHashJoin
+                                                   :     :- CometBroadcastHashJoin
+                                                   :     :  :- CometFilter
+                                                   :     :  :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                                                   :     :  :        +- ReusedSubquery
+                                                   :     :  +- CometBroadcastExchange
+                                                   :     :     +- CometProject
+                                                   :     :        +- CometBroadcastHashJoin
+                                                   :     :           :- CometFilter
+                                                   :     :           :  +- CometNativeScan parquet spark_catalog.default.item
+                                                   :     :           +- CometBroadcastExchange
+                                                   :     :              +- CometBroadcastHashJoin
+                                                   :     :                 :- CometHashAggregate
+                                                   :     :                 :  +- CometExchange
+                                                   :     :                 :     +- CometHashAggregate
+                                                   :     :                 :        +- CometProject
+                                                   :     :                 :           +- CometBroadcastHashJoin
+                                                   :     :                 :              :- CometProject
+                                                   :     :                 :              :  +- CometBroadcastHashJoin
+                                                   :     :                 :              :     :- CometFilter
+                                                   :     :                 :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                                   :     :                 :              :     :        +- CometSubqueryBroadcast
+                                                   :     :                 :              :     :           +- CometBroadcastExchange
+                                                   :     :                 :              :     :              +- CometProject
+                                                   :     :                 :              :     :                 +- CometFilter
+                                                   :     :                 :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                   :     :                 :              :     +- CometBroadcastExchange
+                                                   :     :                 :              :        +- CometBroadcastHashJoin
+                                                   :     :                 :              :           :- CometFilter
+                                                   :     :                 :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+                                                   :     :                 :              :           +- CometBroadcastExchange
+                                                   :     :                 :              :              +- CometProject
+                                                   :     :                 :              :                 +- CometBroadcastHashJoin
+                                                   :     :                 :              :                    :- CometProject
+                                                   :     :                 :              :                    :  +- CometBroadcastHashJoin
+                                                   :     :                 :              :                    :     :- CometFilter
+                                                   :     :                 :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                                                   :     :                 :              :                    :     :        +- ReusedSubquery
+                                                   :     :                 :              :                    :     +- CometBroadcastExchange
+                                                   :     :                 :              :                    :        +- CometFilter
+                                                   :     :                 :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+                                                   :     :                 :              :                    +- CometBroadcastExchange
+                                                   :     :                 :              :                       +- CometProject
+                                                   :     :                 :              :                          +- CometFilter
+                                                   :     :                 :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                   :     :                 :              +- CometBroadcastExchange
+                                                   :     :                 :                 +- CometProject
+                                                   :     :                 :                    +- CometFilter
+                                                   :     :                 :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                   :     :                 +- CometBroadcastExchange
+                                                   :     :                    +- CometProject
+                                                   :     :                       +- CometBroadcastHashJoin
+                                                   :     :                          :- CometProject
+                                                   :     :                          :  +- CometBroadcastHashJoin
+                                                   :     :                          :     :- CometFilter
+                                                   :     :                          :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                                                   :     :                          :     :        +- ReusedSubquery
+                                                   :     :                          :     +- CometBroadcastExchange
+                                                   :     :                          :        +- CometFilter
+                                                   :     :                          :           +- CometNativeScan parquet spark_catalog.default.item
+                                                   :     :                          +- CometBroadcastExchange
+                                                   :     :                             +- CometProject
+                                                   :     :                                +- CometFilter
+                                                   :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                   :     +- CometBroadcastExchange
+                                                   :        +- CometBroadcastHashJoin
+                                                   :           :- CometFilter
+                                                   :           :  +- CometNativeScan parquet spark_catalog.default.item
+                                                   :           +- CometBroadcastExchange
+                                                   :              +- CometProject
+                                                   :                 +- CometBroadcastHashJoin
+                                                   :                    :- CometFilter
+                                                   :                    :  +- CometNativeScan parquet spark_catalog.default.item
+                                                   :                    +- CometBroadcastExchange
+                                                   :                       +- CometBroadcastHashJoin
+                                                   :                          :- CometHashAggregate
+                                                   :                          :  +- CometExchange
+                                                   :                          :     +- CometHashAggregate
+                                                   :                          :        +- CometProject
+                                                   :                          :           +- CometBroadcastHashJoin
+                                                   :                          :              :- CometProject
+                                                   :                          :              :  +- CometBroadcastHashJoin
+                                                   :                          :              :     :- CometFilter
+                                                   :                          :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                                   :                          :              :     :        +- CometSubqueryBroadcast
+                                                   :                          :              :     :           +- CometBroadcastExchange
+                                                   :                          :              :     :              +- CometProject
+                                                   :                          :              :     :                 +- CometFilter
+                                                   :                          :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                   :                          :              :     +- CometBroadcastExchange
+                                                   :                          :              :        +- CometBroadcastHashJoin
+                                                   :                          :              :           :- CometFilter
+                                                   :                          :              :           :  +- CometNativeScan parquet spark_catalog.default.item
+                                                   :                          :              :           +- CometBroadcastExchange
+                                                   :                          :              :              +- CometProject
+                                                   :                          :              :                 +- CometBroadcastHashJoin
+                                                   :                          :              :                    :- CometProject
+                                                   :                          :              :                    :  +- CometBroadcastHashJoin
+                                                   :                          :              :                    :     :- CometFilter
+                                                   :                          :              :                    :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                                                   :                          :              :                    :     :        +- ReusedSubquery
+                                                   :                          :              :                    :     +- CometBroadcastExchange
+                                                   :                          :              :                    :        +- CometFilter
+                                                   :                          :              :                    :           +- CometNativeScan parquet spark_catalog.default.item
+                                                   :                          :              :                    +- CometBroadcastExchange
+                                                   :                          :              :                       +- CometProject
+                                                   :                          :              :                          +- CometFilter
+                                                   :                          :              :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                   :                          :              +- CometBroadcastExchange
+                                                   :                          :                 +- CometProject
+                                                   :                          :                    +- CometFilter
+                                                   :                          :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                   :                          +- CometBroadcastExchange
+                                                   :                             +- CometProject
+                                                   :                                +- CometBroadcastHashJoin
+                                                   :                                   :- CometProject
+                                                   :                                   :  +- CometBroadcastHashJoin
+                                                   :                                   :     :- CometFilter
+                                                   :                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                                                   :                                   :     :        +- ReusedSubquery
+                                                   :                                   :     +- CometBroadcastExchange
+                                                   :                                   :        +- CometFilter
+                                                   :                                   :           +- CometNativeScan parquet spark_catalog.default.item
+                                                   :                                   +- CometBroadcastExchange
+                                                   :                                      +- CometProject
+                                                   :                                         +- CometFilter
+                                                   :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                   +- CometBroadcastExchange
+                                                      +- CometProject
+                                                         +- CometFilter
+                                                            +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 2046 out of 2169 eligible operators (94%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q14a.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q14a.native_iceberg_compat/extended.txt
@@ -1,0 +1,2209 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometUnion
+               :- CometHashAggregate
+               :  +- CometHashAggregate
+               :     +- CometUnion
+               :        :- CometFilter
+               :        :  :  +- Subquery
+               :        :  :     +- CometNativeColumnarToRow
+               :        :  :        +- CometHashAggregate
+               :        :  :           +- CometExchange
+               :        :  :              +- CometHashAggregate
+               :        :  :                 +- CometUnion
+               :        :  :                    :- CometProject
+               :        :  :                    :  +- CometBroadcastHashJoin
+               :        :  :                    :     :- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :        :  :                    :     :     +- ReusedSubquery
+               :        :  :                    :     +- CometBroadcastExchange
+               :        :  :                    :        +- CometProject
+               :        :  :                    :           +- CometFilter
+               :        :  :                    :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :  :                    :- CometProject
+               :        :  :                    :  +- CometBroadcastHashJoin
+               :        :  :                    :     :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :        :  :                    :     :     +- SubqueryBroadcast
+               :        :  :                    :     :        +- BroadcastExchange
+               :        :  :                    :     :           +- CometNativeColumnarToRow
+               :        :  :                    :     :              +- CometProject
+               :        :  :                    :     :                 +- CometFilter
+               :        :  :                    :     :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :  :                    :     +- CometBroadcastExchange
+               :        :  :                    :        +- CometProject
+               :        :  :                    :           +- CometFilter
+               :        :  :                    :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :  :                    +- CometProject
+               :        :  :                       +- CometBroadcastHashJoin
+               :        :  :                          :- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :        :  :                          :     +- ReusedSubquery
+               :        :  :                          +- CometBroadcastExchange
+               :        :  :                             +- CometProject
+               :        :  :                                +- CometFilter
+               :        :  :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :  +- CometHashAggregate
+               :        :     +- CometExchange
+               :        :        +- CometHashAggregate
+               :        :           +- CometProject
+               :        :              +- CometBroadcastHashJoin
+               :        :                 :- CometProject
+               :        :                 :  +- CometBroadcastHashJoin
+               :        :                 :     :- CometBroadcastHashJoin
+               :        :                 :     :  :- CometFilter
+               :        :                 :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :        :                 :     :  :        +- SubqueryBroadcast
+               :        :                 :     :  :           +- BroadcastExchange
+               :        :                 :     :  :              +- CometNativeColumnarToRow
+               :        :                 :     :  :                 +- CometProject
+               :        :                 :     :  :                    +- CometFilter
+               :        :                 :     :  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :                 :     :  +- CometBroadcastExchange
+               :        :                 :     :     +- CometProject
+               :        :                 :     :        +- CometBroadcastHashJoin
+               :        :                 :     :           :- CometFilter
+               :        :                 :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :        :                 :     :           +- CometBroadcastExchange
+               :        :                 :     :              +- CometBroadcastHashJoin
+               :        :                 :     :                 :- CometHashAggregate
+               :        :                 :     :                 :  +- CometExchange
+               :        :                 :     :                 :     +- CometHashAggregate
+               :        :                 :     :                 :        +- CometProject
+               :        :                 :     :                 :           +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :- CometProject
+               :        :                 :     :                 :              :  +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :     :- CometFilter
+               :        :                 :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :        :                 :     :                 :              :     :        +- SubqueryBroadcast
+               :        :                 :     :                 :              :     :           +- BroadcastExchange
+               :        :                 :     :                 :              :     :              +- CometNativeColumnarToRow
+               :        :                 :     :                 :              :     :                 +- CometProject
+               :        :                 :     :                 :              :     :                    +- CometFilter
+               :        :                 :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :                 :     :                 :              :     +- CometBroadcastExchange
+               :        :                 :     :                 :              :        +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :           :- CometFilter
+               :        :                 :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :        :                 :     :                 :              :           +- CometBroadcastExchange
+               :        :                 :     :                 :              :              +- CometProject
+               :        :                 :     :                 :              :                 +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :                    :- CometProject
+               :        :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :                    :     :- CometFilter
+               :        :                 :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :        :                 :     :                 :              :                    :     :        +- ReusedSubquery
+               :        :                 :     :                 :              :                    :     +- CometBroadcastExchange
+               :        :                 :     :                 :              :                    :        +- CometFilter
+               :        :                 :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :        :                 :     :                 :              :                    +- CometBroadcastExchange
+               :        :                 :     :                 :              :                       +- CometProject
+               :        :                 :     :                 :              :                          +- CometFilter
+               :        :                 :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :                 :     :                 :              +- CometBroadcastExchange
+               :        :                 :     :                 :                 +- CometProject
+               :        :                 :     :                 :                    +- CometFilter
+               :        :                 :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :                 :     :                 +- CometBroadcastExchange
+               :        :                 :     :                    +- CometProject
+               :        :                 :     :                       +- CometBroadcastHashJoin
+               :        :                 :     :                          :- CometProject
+               :        :                 :     :                          :  +- CometBroadcastHashJoin
+               :        :                 :     :                          :     :- CometFilter
+               :        :                 :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :        :                 :     :                          :     :        +- ReusedSubquery
+               :        :                 :     :                          :     +- CometBroadcastExchange
+               :        :                 :     :                          :        +- CometFilter
+               :        :                 :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :        :                 :     :                          +- CometBroadcastExchange
+               :        :                 :     :                             +- CometProject
+               :        :                 :     :                                +- CometFilter
+               :        :                 :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :                 :     +- CometBroadcastExchange
+               :        :                 :        +- CometBroadcastHashJoin
+               :        :                 :           :- CometFilter
+               :        :                 :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :        :                 :           +- CometBroadcastExchange
+               :        :                 :              +- CometProject
+               :        :                 :                 +- CometBroadcastHashJoin
+               :        :                 :                    :- CometFilter
+               :        :                 :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :        :                 :                    +- CometBroadcastExchange
+               :        :                 :                       +- CometBroadcastHashJoin
+               :        :                 :                          :- CometHashAggregate
+               :        :                 :                          :  +- CometExchange
+               :        :                 :                          :     +- CometHashAggregate
+               :        :                 :                          :        +- CometProject
+               :        :                 :                          :           +- CometBroadcastHashJoin
+               :        :                 :                          :              :- CometProject
+               :        :                 :                          :              :  +- CometBroadcastHashJoin
+               :        :                 :                          :              :     :- CometFilter
+               :        :                 :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :        :                 :                          :              :     :        +- SubqueryBroadcast
+               :        :                 :                          :              :     :           +- BroadcastExchange
+               :        :                 :                          :              :     :              +- CometNativeColumnarToRow
+               :        :                 :                          :              :     :                 +- CometProject
+               :        :                 :                          :              :     :                    +- CometFilter
+               :        :                 :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :                 :                          :              :     +- CometBroadcastExchange
+               :        :                 :                          :              :        +- CometBroadcastHashJoin
+               :        :                 :                          :              :           :- CometFilter
+               :        :                 :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :        :                 :                          :              :           +- CometBroadcastExchange
+               :        :                 :                          :              :              +- CometProject
+               :        :                 :                          :              :                 +- CometBroadcastHashJoin
+               :        :                 :                          :              :                    :- CometProject
+               :        :                 :                          :              :                    :  +- CometBroadcastHashJoin
+               :        :                 :                          :              :                    :     :- CometFilter
+               :        :                 :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :        :                 :                          :              :                    :     :        +- ReusedSubquery
+               :        :                 :                          :              :                    :     +- CometBroadcastExchange
+               :        :                 :                          :              :                    :        +- CometFilter
+               :        :                 :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :        :                 :                          :              :                    +- CometBroadcastExchange
+               :        :                 :                          :              :                       +- CometProject
+               :        :                 :                          :              :                          +- CometFilter
+               :        :                 :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :                 :                          :              +- CometBroadcastExchange
+               :        :                 :                          :                 +- CometProject
+               :        :                 :                          :                    +- CometFilter
+               :        :                 :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :                 :                          +- CometBroadcastExchange
+               :        :                 :                             +- CometProject
+               :        :                 :                                +- CometBroadcastHashJoin
+               :        :                 :                                   :- CometProject
+               :        :                 :                                   :  +- CometBroadcastHashJoin
+               :        :                 :                                   :     :- CometFilter
+               :        :                 :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :        :                 :                                   :     :        +- ReusedSubquery
+               :        :                 :                                   :     +- CometBroadcastExchange
+               :        :                 :                                   :        +- CometFilter
+               :        :                 :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :        :                 :                                   +- CometBroadcastExchange
+               :        :                 :                                      +- CometProject
+               :        :                 :                                         +- CometFilter
+               :        :                 :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :                 +- CometBroadcastExchange
+               :        :                    +- CometProject
+               :        :                       +- CometFilter
+               :        :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :- CometFilter
+               :        :  :  +- ReusedSubquery
+               :        :  +- CometHashAggregate
+               :        :     +- CometExchange
+               :        :        +- CometHashAggregate
+               :        :           +- CometProject
+               :        :              +- CometBroadcastHashJoin
+               :        :                 :- CometProject
+               :        :                 :  +- CometBroadcastHashJoin
+               :        :                 :     :- CometBroadcastHashJoin
+               :        :                 :     :  :- CometFilter
+               :        :                 :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :        :                 :     :  :        +- ReusedSubquery
+               :        :                 :     :  +- CometBroadcastExchange
+               :        :                 :     :     +- CometProject
+               :        :                 :     :        +- CometBroadcastHashJoin
+               :        :                 :     :           :- CometFilter
+               :        :                 :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :        :                 :     :           +- CometBroadcastExchange
+               :        :                 :     :              +- CometBroadcastHashJoin
+               :        :                 :     :                 :- CometHashAggregate
+               :        :                 :     :                 :  +- CometExchange
+               :        :                 :     :                 :     +- CometHashAggregate
+               :        :                 :     :                 :        +- CometProject
+               :        :                 :     :                 :           +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :- CometProject
+               :        :                 :     :                 :              :  +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :     :- CometFilter
+               :        :                 :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :        :                 :     :                 :              :     :        +- SubqueryBroadcast
+               :        :                 :     :                 :              :     :           +- BroadcastExchange
+               :        :                 :     :                 :              :     :              +- CometNativeColumnarToRow
+               :        :                 :     :                 :              :     :                 +- CometProject
+               :        :                 :     :                 :              :     :                    +- CometFilter
+               :        :                 :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :                 :     :                 :              :     +- CometBroadcastExchange
+               :        :                 :     :                 :              :        +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :           :- CometFilter
+               :        :                 :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :        :                 :     :                 :              :           +- CometBroadcastExchange
+               :        :                 :     :                 :              :              +- CometProject
+               :        :                 :     :                 :              :                 +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :                    :- CometProject
+               :        :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :        :                 :     :                 :              :                    :     :- CometFilter
+               :        :                 :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :        :                 :     :                 :              :                    :     :        +- ReusedSubquery
+               :        :                 :     :                 :              :                    :     +- CometBroadcastExchange
+               :        :                 :     :                 :              :                    :        +- CometFilter
+               :        :                 :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :        :                 :     :                 :              :                    +- CometBroadcastExchange
+               :        :                 :     :                 :              :                       +- CometProject
+               :        :                 :     :                 :              :                          +- CometFilter
+               :        :                 :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :                 :     :                 :              +- CometBroadcastExchange
+               :        :                 :     :                 :                 +- CometProject
+               :        :                 :     :                 :                    +- CometFilter
+               :        :                 :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :                 :     :                 +- CometBroadcastExchange
+               :        :                 :     :                    +- CometProject
+               :        :                 :     :                       +- CometBroadcastHashJoin
+               :        :                 :     :                          :- CometProject
+               :        :                 :     :                          :  +- CometBroadcastHashJoin
+               :        :                 :     :                          :     :- CometFilter
+               :        :                 :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :        :                 :     :                          :     :        +- ReusedSubquery
+               :        :                 :     :                          :     +- CometBroadcastExchange
+               :        :                 :     :                          :        +- CometFilter
+               :        :                 :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :        :                 :     :                          +- CometBroadcastExchange
+               :        :                 :     :                             +- CometProject
+               :        :                 :     :                                +- CometFilter
+               :        :                 :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :                 :     +- CometBroadcastExchange
+               :        :                 :        +- CometBroadcastHashJoin
+               :        :                 :           :- CometFilter
+               :        :                 :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :        :                 :           +- CometBroadcastExchange
+               :        :                 :              +- CometProject
+               :        :                 :                 +- CometBroadcastHashJoin
+               :        :                 :                    :- CometFilter
+               :        :                 :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :        :                 :                    +- CometBroadcastExchange
+               :        :                 :                       +- CometBroadcastHashJoin
+               :        :                 :                          :- CometHashAggregate
+               :        :                 :                          :  +- CometExchange
+               :        :                 :                          :     +- CometHashAggregate
+               :        :                 :                          :        +- CometProject
+               :        :                 :                          :           +- CometBroadcastHashJoin
+               :        :                 :                          :              :- CometProject
+               :        :                 :                          :              :  +- CometBroadcastHashJoin
+               :        :                 :                          :              :     :- CometFilter
+               :        :                 :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :        :                 :                          :              :     :        +- SubqueryBroadcast
+               :        :                 :                          :              :     :           +- BroadcastExchange
+               :        :                 :                          :              :     :              +- CometNativeColumnarToRow
+               :        :                 :                          :              :     :                 +- CometProject
+               :        :                 :                          :              :     :                    +- CometFilter
+               :        :                 :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :                 :                          :              :     +- CometBroadcastExchange
+               :        :                 :                          :              :        +- CometBroadcastHashJoin
+               :        :                 :                          :              :           :- CometFilter
+               :        :                 :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :        :                 :                          :              :           +- CometBroadcastExchange
+               :        :                 :                          :              :              +- CometProject
+               :        :                 :                          :              :                 +- CometBroadcastHashJoin
+               :        :                 :                          :              :                    :- CometProject
+               :        :                 :                          :              :                    :  +- CometBroadcastHashJoin
+               :        :                 :                          :              :                    :     :- CometFilter
+               :        :                 :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :        :                 :                          :              :                    :     :        +- ReusedSubquery
+               :        :                 :                          :              :                    :     +- CometBroadcastExchange
+               :        :                 :                          :              :                    :        +- CometFilter
+               :        :                 :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :        :                 :                          :              :                    +- CometBroadcastExchange
+               :        :                 :                          :              :                       +- CometProject
+               :        :                 :                          :              :                          +- CometFilter
+               :        :                 :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :                 :                          :              +- CometBroadcastExchange
+               :        :                 :                          :                 +- CometProject
+               :        :                 :                          :                    +- CometFilter
+               :        :                 :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :                 :                          +- CometBroadcastExchange
+               :        :                 :                             +- CometProject
+               :        :                 :                                +- CometBroadcastHashJoin
+               :        :                 :                                   :- CometProject
+               :        :                 :                                   :  +- CometBroadcastHashJoin
+               :        :                 :                                   :     :- CometFilter
+               :        :                 :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :        :                 :                                   :     :        +- ReusedSubquery
+               :        :                 :                                   :     +- CometBroadcastExchange
+               :        :                 :                                   :        +- CometFilter
+               :        :                 :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :        :                 :                                   +- CometBroadcastExchange
+               :        :                 :                                      +- CometProject
+               :        :                 :                                         +- CometFilter
+               :        :                 :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        :                 +- CometBroadcastExchange
+               :        :                    +- CometProject
+               :        :                       +- CometFilter
+               :        :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :        +- CometFilter
+               :           :  +- ReusedSubquery
+               :           +- CometHashAggregate
+               :              +- CometExchange
+               :                 +- CometHashAggregate
+               :                    +- CometProject
+               :                       +- CometBroadcastHashJoin
+               :                          :- CometProject
+               :                          :  +- CometBroadcastHashJoin
+               :                          :     :- CometBroadcastHashJoin
+               :                          :     :  :- CometFilter
+               :                          :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                          :     :  :        +- ReusedSubquery
+               :                          :     :  +- CometBroadcastExchange
+               :                          :     :     +- CometProject
+               :                          :     :        +- CometBroadcastHashJoin
+               :                          :     :           :- CometFilter
+               :                          :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                          :     :           +- CometBroadcastExchange
+               :                          :     :              +- CometBroadcastHashJoin
+               :                          :     :                 :- CometHashAggregate
+               :                          :     :                 :  +- CometExchange
+               :                          :     :                 :     +- CometHashAggregate
+               :                          :     :                 :        +- CometProject
+               :                          :     :                 :           +- CometBroadcastHashJoin
+               :                          :     :                 :              :- CometProject
+               :                          :     :                 :              :  +- CometBroadcastHashJoin
+               :                          :     :                 :              :     :- CometFilter
+               :                          :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                          :     :                 :              :     :        +- SubqueryBroadcast
+               :                          :     :                 :              :     :           +- BroadcastExchange
+               :                          :     :                 :              :     :              +- CometNativeColumnarToRow
+               :                          :     :                 :              :     :                 +- CometProject
+               :                          :     :                 :              :     :                    +- CometFilter
+               :                          :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                          :     :                 :              :     +- CometBroadcastExchange
+               :                          :     :                 :              :        +- CometBroadcastHashJoin
+               :                          :     :                 :              :           :- CometFilter
+               :                          :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                          :     :                 :              :           +- CometBroadcastExchange
+               :                          :     :                 :              :              +- CometProject
+               :                          :     :                 :              :                 +- CometBroadcastHashJoin
+               :                          :     :                 :              :                    :- CometProject
+               :                          :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                          :     :                 :              :                    :     :- CometFilter
+               :                          :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                          :     :                 :              :                    :     :        +- ReusedSubquery
+               :                          :     :                 :              :                    :     +- CometBroadcastExchange
+               :                          :     :                 :              :                    :        +- CometFilter
+               :                          :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                          :     :                 :              :                    +- CometBroadcastExchange
+               :                          :     :                 :              :                       +- CometProject
+               :                          :     :                 :              :                          +- CometFilter
+               :                          :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                          :     :                 :              +- CometBroadcastExchange
+               :                          :     :                 :                 +- CometProject
+               :                          :     :                 :                    +- CometFilter
+               :                          :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                          :     :                 +- CometBroadcastExchange
+               :                          :     :                    +- CometProject
+               :                          :     :                       +- CometBroadcastHashJoin
+               :                          :     :                          :- CometProject
+               :                          :     :                          :  +- CometBroadcastHashJoin
+               :                          :     :                          :     :- CometFilter
+               :                          :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                          :     :                          :     :        +- ReusedSubquery
+               :                          :     :                          :     +- CometBroadcastExchange
+               :                          :     :                          :        +- CometFilter
+               :                          :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                          :     :                          +- CometBroadcastExchange
+               :                          :     :                             +- CometProject
+               :                          :     :                                +- CometFilter
+               :                          :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                          :     +- CometBroadcastExchange
+               :                          :        +- CometBroadcastHashJoin
+               :                          :           :- CometFilter
+               :                          :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                          :           +- CometBroadcastExchange
+               :                          :              +- CometProject
+               :                          :                 +- CometBroadcastHashJoin
+               :                          :                    :- CometFilter
+               :                          :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                          :                    +- CometBroadcastExchange
+               :                          :                       +- CometBroadcastHashJoin
+               :                          :                          :- CometHashAggregate
+               :                          :                          :  +- CometExchange
+               :                          :                          :     +- CometHashAggregate
+               :                          :                          :        +- CometProject
+               :                          :                          :           +- CometBroadcastHashJoin
+               :                          :                          :              :- CometProject
+               :                          :                          :              :  +- CometBroadcastHashJoin
+               :                          :                          :              :     :- CometFilter
+               :                          :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                          :                          :              :     :        +- SubqueryBroadcast
+               :                          :                          :              :     :           +- BroadcastExchange
+               :                          :                          :              :     :              +- CometNativeColumnarToRow
+               :                          :                          :              :     :                 +- CometProject
+               :                          :                          :              :     :                    +- CometFilter
+               :                          :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                          :                          :              :     +- CometBroadcastExchange
+               :                          :                          :              :        +- CometBroadcastHashJoin
+               :                          :                          :              :           :- CometFilter
+               :                          :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                          :                          :              :           +- CometBroadcastExchange
+               :                          :                          :              :              +- CometProject
+               :                          :                          :              :                 +- CometBroadcastHashJoin
+               :                          :                          :              :                    :- CometProject
+               :                          :                          :              :                    :  +- CometBroadcastHashJoin
+               :                          :                          :              :                    :     :- CometFilter
+               :                          :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                          :                          :              :                    :     :        +- ReusedSubquery
+               :                          :                          :              :                    :     +- CometBroadcastExchange
+               :                          :                          :              :                    :        +- CometFilter
+               :                          :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                          :                          :              :                    +- CometBroadcastExchange
+               :                          :                          :              :                       +- CometProject
+               :                          :                          :              :                          +- CometFilter
+               :                          :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                          :                          :              +- CometBroadcastExchange
+               :                          :                          :                 +- CometProject
+               :                          :                          :                    +- CometFilter
+               :                          :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                          :                          +- CometBroadcastExchange
+               :                          :                             +- CometProject
+               :                          :                                +- CometBroadcastHashJoin
+               :                          :                                   :- CometProject
+               :                          :                                   :  +- CometBroadcastHashJoin
+               :                          :                                   :     :- CometFilter
+               :                          :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                          :                                   :     :        +- ReusedSubquery
+               :                          :                                   :     +- CometBroadcastExchange
+               :                          :                                   :        +- CometFilter
+               :                          :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                          :                                   +- CometBroadcastExchange
+               :                          :                                      +- CometProject
+               :                          :                                         +- CometFilter
+               :                          :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                          +- CometBroadcastExchange
+               :                             +- CometProject
+               :                                +- CometFilter
+               :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :- CometHashAggregate
+               :  +- CometExchange
+               :     +- CometHashAggregate
+               :        +- CometHashAggregate
+               :           +- CometHashAggregate
+               :              +- CometUnion
+               :                 :- CometFilter
+               :                 :  :  +- ReusedSubquery
+               :                 :  +- CometHashAggregate
+               :                 :     +- CometExchange
+               :                 :        +- CometHashAggregate
+               :                 :           +- CometProject
+               :                 :              +- CometBroadcastHashJoin
+               :                 :                 :- CometProject
+               :                 :                 :  +- CometBroadcastHashJoin
+               :                 :                 :     :- CometBroadcastHashJoin
+               :                 :                 :     :  :- CometFilter
+               :                 :                 :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                 :                 :     :  :        +- SubqueryBroadcast
+               :                 :                 :     :  :           +- BroadcastExchange
+               :                 :                 :     :  :              +- CometNativeColumnarToRow
+               :                 :                 :     :  :                 +- CometProject
+               :                 :                 :     :  :                    +- CometFilter
+               :                 :                 :     :  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :  +- CometBroadcastExchange
+               :                 :                 :     :     +- CometProject
+               :                 :                 :     :        +- CometBroadcastHashJoin
+               :                 :                 :     :           :- CometFilter
+               :                 :                 :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :           +- CometBroadcastExchange
+               :                 :                 :     :              +- CometBroadcastHashJoin
+               :                 :                 :     :                 :- CometHashAggregate
+               :                 :                 :     :                 :  +- CometExchange
+               :                 :                 :     :                 :     +- CometHashAggregate
+               :                 :                 :     :                 :        +- CometProject
+               :                 :                 :     :                 :           +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :- CometProject
+               :                 :                 :     :                 :              :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :     :- CometFilter
+               :                 :                 :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                 :                 :     :                 :              :     :        +- SubqueryBroadcast
+               :                 :                 :     :                 :              :     :           +- BroadcastExchange
+               :                 :                 :     :                 :              :     :              +- CometNativeColumnarToRow
+               :                 :                 :     :                 :              :     :                 +- CometProject
+               :                 :                 :     :                 :              :     :                    +- CometFilter
+               :                 :                 :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :        +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :           :- CometFilter
+               :                 :                 :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :           +- CometBroadcastExchange
+               :                 :                 :     :                 :              :              +- CometProject
+               :                 :                 :     :                 :              :                 +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :- CometProject
+               :                 :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :     :- CometFilter
+               :                 :                 :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                 :                 :     :                 :              :                    :     :        +- ReusedSubquery
+               :                 :                 :     :                 :              :                    :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                    :        +- CometFilter
+               :                 :                 :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :                    +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                       +- CometProject
+               :                 :                 :     :                 :              :                          +- CometFilter
+               :                 :                 :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              +- CometBroadcastExchange
+               :                 :                 :     :                 :                 +- CometProject
+               :                 :                 :     :                 :                    +- CometFilter
+               :                 :                 :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 +- CometBroadcastExchange
+               :                 :                 :     :                    +- CometProject
+               :                 :                 :     :                       +- CometBroadcastHashJoin
+               :                 :                 :     :                          :- CometProject
+               :                 :                 :     :                          :  +- CometBroadcastHashJoin
+               :                 :                 :     :                          :     :- CometFilter
+               :                 :                 :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                 :                 :     :                          :     :        +- ReusedSubquery
+               :                 :                 :     :                          :     +- CometBroadcastExchange
+               :                 :                 :     :                          :        +- CometFilter
+               :                 :                 :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :                          +- CometBroadcastExchange
+               :                 :                 :     :                             +- CometProject
+               :                 :                 :     :                                +- CometFilter
+               :                 :                 :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     +- CometBroadcastExchange
+               :                 :                 :        +- CometBroadcastHashJoin
+               :                 :                 :           :- CometFilter
+               :                 :                 :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :           +- CometBroadcastExchange
+               :                 :                 :              +- CometProject
+               :                 :                 :                 +- CometBroadcastHashJoin
+               :                 :                 :                    :- CometFilter
+               :                 :                 :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                    +- CometBroadcastExchange
+               :                 :                 :                       +- CometBroadcastHashJoin
+               :                 :                 :                          :- CometHashAggregate
+               :                 :                 :                          :  +- CometExchange
+               :                 :                 :                          :     +- CometHashAggregate
+               :                 :                 :                          :        +- CometProject
+               :                 :                 :                          :           +- CometBroadcastHashJoin
+               :                 :                 :                          :              :- CometProject
+               :                 :                 :                          :              :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :     :- CometFilter
+               :                 :                 :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                 :                 :                          :              :     :        +- SubqueryBroadcast
+               :                 :                 :                          :              :     :           +- BroadcastExchange
+               :                 :                 :                          :              :     :              +- CometNativeColumnarToRow
+               :                 :                 :                          :              :     :                 +- CometProject
+               :                 :                 :                          :              :     :                    +- CometFilter
+               :                 :                 :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              :     +- CometBroadcastExchange
+               :                 :                 :                          :              :        +- CometBroadcastHashJoin
+               :                 :                 :                          :              :           :- CometFilter
+               :                 :                 :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                          :              :           +- CometBroadcastExchange
+               :                 :                 :                          :              :              +- CometProject
+               :                 :                 :                          :              :                 +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :- CometProject
+               :                 :                 :                          :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :     :- CometFilter
+               :                 :                 :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                 :                 :                          :              :                    :     :        +- ReusedSubquery
+               :                 :                 :                          :              :                    :     +- CometBroadcastExchange
+               :                 :                 :                          :              :                    :        +- CometFilter
+               :                 :                 :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                          :              :                    +- CometBroadcastExchange
+               :                 :                 :                          :              :                       +- CometProject
+               :                 :                 :                          :              :                          +- CometFilter
+               :                 :                 :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              +- CometBroadcastExchange
+               :                 :                 :                          :                 +- CometProject
+               :                 :                 :                          :                    +- CometFilter
+               :                 :                 :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :                          +- CometBroadcastExchange
+               :                 :                 :                             +- CometProject
+               :                 :                 :                                +- CometBroadcastHashJoin
+               :                 :                 :                                   :- CometProject
+               :                 :                 :                                   :  +- CometBroadcastHashJoin
+               :                 :                 :                                   :     :- CometFilter
+               :                 :                 :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                 :                 :                                   :     :        +- ReusedSubquery
+               :                 :                 :                                   :     +- CometBroadcastExchange
+               :                 :                 :                                   :        +- CometFilter
+               :                 :                 :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                                   +- CometBroadcastExchange
+               :                 :                 :                                      +- CometProject
+               :                 :                 :                                         +- CometFilter
+               :                 :                 :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 +- CometBroadcastExchange
+               :                 :                    +- CometProject
+               :                 :                       +- CometFilter
+               :                 :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :- CometFilter
+               :                 :  :  +- ReusedSubquery
+               :                 :  +- CometHashAggregate
+               :                 :     +- CometExchange
+               :                 :        +- CometHashAggregate
+               :                 :           +- CometProject
+               :                 :              +- CometBroadcastHashJoin
+               :                 :                 :- CometProject
+               :                 :                 :  +- CometBroadcastHashJoin
+               :                 :                 :     :- CometBroadcastHashJoin
+               :                 :                 :     :  :- CometFilter
+               :                 :                 :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                 :                 :     :  :        +- ReusedSubquery
+               :                 :                 :     :  +- CometBroadcastExchange
+               :                 :                 :     :     +- CometProject
+               :                 :                 :     :        +- CometBroadcastHashJoin
+               :                 :                 :     :           :- CometFilter
+               :                 :                 :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :           +- CometBroadcastExchange
+               :                 :                 :     :              +- CometBroadcastHashJoin
+               :                 :                 :     :                 :- CometHashAggregate
+               :                 :                 :     :                 :  +- CometExchange
+               :                 :                 :     :                 :     +- CometHashAggregate
+               :                 :                 :     :                 :        +- CometProject
+               :                 :                 :     :                 :           +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :- CometProject
+               :                 :                 :     :                 :              :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :     :- CometFilter
+               :                 :                 :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                 :                 :     :                 :              :     :        +- SubqueryBroadcast
+               :                 :                 :     :                 :              :     :           +- BroadcastExchange
+               :                 :                 :     :                 :              :     :              +- CometNativeColumnarToRow
+               :                 :                 :     :                 :              :     :                 +- CometProject
+               :                 :                 :     :                 :              :     :                    +- CometFilter
+               :                 :                 :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :        +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :           :- CometFilter
+               :                 :                 :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :           +- CometBroadcastExchange
+               :                 :                 :     :                 :              :              +- CometProject
+               :                 :                 :     :                 :              :                 +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :- CometProject
+               :                 :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :     :- CometFilter
+               :                 :                 :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                 :                 :     :                 :              :                    :     :        +- ReusedSubquery
+               :                 :                 :     :                 :              :                    :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                    :        +- CometFilter
+               :                 :                 :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :                    +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                       +- CometProject
+               :                 :                 :     :                 :              :                          +- CometFilter
+               :                 :                 :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              +- CometBroadcastExchange
+               :                 :                 :     :                 :                 +- CometProject
+               :                 :                 :     :                 :                    +- CometFilter
+               :                 :                 :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 +- CometBroadcastExchange
+               :                 :                 :     :                    +- CometProject
+               :                 :                 :     :                       +- CometBroadcastHashJoin
+               :                 :                 :     :                          :- CometProject
+               :                 :                 :     :                          :  +- CometBroadcastHashJoin
+               :                 :                 :     :                          :     :- CometFilter
+               :                 :                 :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                 :                 :     :                          :     :        +- ReusedSubquery
+               :                 :                 :     :                          :     +- CometBroadcastExchange
+               :                 :                 :     :                          :        +- CometFilter
+               :                 :                 :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :                          +- CometBroadcastExchange
+               :                 :                 :     :                             +- CometProject
+               :                 :                 :     :                                +- CometFilter
+               :                 :                 :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     +- CometBroadcastExchange
+               :                 :                 :        +- CometBroadcastHashJoin
+               :                 :                 :           :- CometFilter
+               :                 :                 :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :           +- CometBroadcastExchange
+               :                 :                 :              +- CometProject
+               :                 :                 :                 +- CometBroadcastHashJoin
+               :                 :                 :                    :- CometFilter
+               :                 :                 :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                    +- CometBroadcastExchange
+               :                 :                 :                       +- CometBroadcastHashJoin
+               :                 :                 :                          :- CometHashAggregate
+               :                 :                 :                          :  +- CometExchange
+               :                 :                 :                          :     +- CometHashAggregate
+               :                 :                 :                          :        +- CometProject
+               :                 :                 :                          :           +- CometBroadcastHashJoin
+               :                 :                 :                          :              :- CometProject
+               :                 :                 :                          :              :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :     :- CometFilter
+               :                 :                 :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                 :                 :                          :              :     :        +- SubqueryBroadcast
+               :                 :                 :                          :              :     :           +- BroadcastExchange
+               :                 :                 :                          :              :     :              +- CometNativeColumnarToRow
+               :                 :                 :                          :              :     :                 +- CometProject
+               :                 :                 :                          :              :     :                    +- CometFilter
+               :                 :                 :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              :     +- CometBroadcastExchange
+               :                 :                 :                          :              :        +- CometBroadcastHashJoin
+               :                 :                 :                          :              :           :- CometFilter
+               :                 :                 :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                          :              :           +- CometBroadcastExchange
+               :                 :                 :                          :              :              +- CometProject
+               :                 :                 :                          :              :                 +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :- CometProject
+               :                 :                 :                          :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :     :- CometFilter
+               :                 :                 :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                 :                 :                          :              :                    :     :        +- ReusedSubquery
+               :                 :                 :                          :              :                    :     +- CometBroadcastExchange
+               :                 :                 :                          :              :                    :        +- CometFilter
+               :                 :                 :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                          :              :                    +- CometBroadcastExchange
+               :                 :                 :                          :              :                       +- CometProject
+               :                 :                 :                          :              :                          +- CometFilter
+               :                 :                 :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              +- CometBroadcastExchange
+               :                 :                 :                          :                 +- CometProject
+               :                 :                 :                          :                    +- CometFilter
+               :                 :                 :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :                          +- CometBroadcastExchange
+               :                 :                 :                             +- CometProject
+               :                 :                 :                                +- CometBroadcastHashJoin
+               :                 :                 :                                   :- CometProject
+               :                 :                 :                                   :  +- CometBroadcastHashJoin
+               :                 :                 :                                   :     :- CometFilter
+               :                 :                 :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                 :                 :                                   :     :        +- ReusedSubquery
+               :                 :                 :                                   :     +- CometBroadcastExchange
+               :                 :                 :                                   :        +- CometFilter
+               :                 :                 :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                                   +- CometBroadcastExchange
+               :                 :                 :                                      +- CometProject
+               :                 :                 :                                         +- CometFilter
+               :                 :                 :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 +- CometBroadcastExchange
+               :                 :                    +- CometProject
+               :                 :                       +- CometFilter
+               :                 :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 +- CometFilter
+               :                    :  +- ReusedSubquery
+               :                    +- CometHashAggregate
+               :                       +- CometExchange
+               :                          +- CometHashAggregate
+               :                             +- CometProject
+               :                                +- CometBroadcastHashJoin
+               :                                   :- CometProject
+               :                                   :  +- CometBroadcastHashJoin
+               :                                   :     :- CometBroadcastHashJoin
+               :                                   :     :  :- CometFilter
+               :                                   :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                                   :     :  :        +- ReusedSubquery
+               :                                   :     :  +- CometBroadcastExchange
+               :                                   :     :     +- CometProject
+               :                                   :     :        +- CometBroadcastHashJoin
+               :                                   :     :           :- CometFilter
+               :                                   :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :     :           +- CometBroadcastExchange
+               :                                   :     :              +- CometBroadcastHashJoin
+               :                                   :     :                 :- CometHashAggregate
+               :                                   :     :                 :  +- CometExchange
+               :                                   :     :                 :     +- CometHashAggregate
+               :                                   :     :                 :        +- CometProject
+               :                                   :     :                 :           +- CometBroadcastHashJoin
+               :                                   :     :                 :              :- CometProject
+               :                                   :     :                 :              :  +- CometBroadcastHashJoin
+               :                                   :     :                 :              :     :- CometFilter
+               :                                   :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                                   :     :                 :              :     :        +- SubqueryBroadcast
+               :                                   :     :                 :              :     :           +- BroadcastExchange
+               :                                   :     :                 :              :     :              +- CometNativeColumnarToRow
+               :                                   :     :                 :              :     :                 +- CometProject
+               :                                   :     :                 :              :     :                    +- CometFilter
+               :                                   :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :     :                 :              :     +- CometBroadcastExchange
+               :                                   :     :                 :              :        +- CometBroadcastHashJoin
+               :                                   :     :                 :              :           :- CometFilter
+               :                                   :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :     :                 :              :           +- CometBroadcastExchange
+               :                                   :     :                 :              :              +- CometProject
+               :                                   :     :                 :              :                 +- CometBroadcastHashJoin
+               :                                   :     :                 :              :                    :- CometProject
+               :                                   :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                                   :     :                 :              :                    :     :- CometFilter
+               :                                   :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                                   :     :                 :              :                    :     :        +- ReusedSubquery
+               :                                   :     :                 :              :                    :     +- CometBroadcastExchange
+               :                                   :     :                 :              :                    :        +- CometFilter
+               :                                   :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :     :                 :              :                    +- CometBroadcastExchange
+               :                                   :     :                 :              :                       +- CometProject
+               :                                   :     :                 :              :                          +- CometFilter
+               :                                   :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :     :                 :              +- CometBroadcastExchange
+               :                                   :     :                 :                 +- CometProject
+               :                                   :     :                 :                    +- CometFilter
+               :                                   :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :     :                 +- CometBroadcastExchange
+               :                                   :     :                    +- CometProject
+               :                                   :     :                       +- CometBroadcastHashJoin
+               :                                   :     :                          :- CometProject
+               :                                   :     :                          :  +- CometBroadcastHashJoin
+               :                                   :     :                          :     :- CometFilter
+               :                                   :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                                   :     :                          :     :        +- ReusedSubquery
+               :                                   :     :                          :     +- CometBroadcastExchange
+               :                                   :     :                          :        +- CometFilter
+               :                                   :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :     :                          +- CometBroadcastExchange
+               :                                   :     :                             +- CometProject
+               :                                   :     :                                +- CometFilter
+               :                                   :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :     +- CometBroadcastExchange
+               :                                   :        +- CometBroadcastHashJoin
+               :                                   :           :- CometFilter
+               :                                   :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :           +- CometBroadcastExchange
+               :                                   :              +- CometProject
+               :                                   :                 +- CometBroadcastHashJoin
+               :                                   :                    :- CometFilter
+               :                                   :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :                    +- CometBroadcastExchange
+               :                                   :                       +- CometBroadcastHashJoin
+               :                                   :                          :- CometHashAggregate
+               :                                   :                          :  +- CometExchange
+               :                                   :                          :     +- CometHashAggregate
+               :                                   :                          :        +- CometProject
+               :                                   :                          :           +- CometBroadcastHashJoin
+               :                                   :                          :              :- CometProject
+               :                                   :                          :              :  +- CometBroadcastHashJoin
+               :                                   :                          :              :     :- CometFilter
+               :                                   :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                                   :                          :              :     :        +- SubqueryBroadcast
+               :                                   :                          :              :     :           +- BroadcastExchange
+               :                                   :                          :              :     :              +- CometNativeColumnarToRow
+               :                                   :                          :              :     :                 +- CometProject
+               :                                   :                          :              :     :                    +- CometFilter
+               :                                   :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :                          :              :     +- CometBroadcastExchange
+               :                                   :                          :              :        +- CometBroadcastHashJoin
+               :                                   :                          :              :           :- CometFilter
+               :                                   :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :                          :              :           +- CometBroadcastExchange
+               :                                   :                          :              :              +- CometProject
+               :                                   :                          :              :                 +- CometBroadcastHashJoin
+               :                                   :                          :              :                    :- CometProject
+               :                                   :                          :              :                    :  +- CometBroadcastHashJoin
+               :                                   :                          :              :                    :     :- CometFilter
+               :                                   :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                                   :                          :              :                    :     :        +- ReusedSubquery
+               :                                   :                          :              :                    :     +- CometBroadcastExchange
+               :                                   :                          :              :                    :        +- CometFilter
+               :                                   :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :                          :              :                    +- CometBroadcastExchange
+               :                                   :                          :              :                       +- CometProject
+               :                                   :                          :              :                          +- CometFilter
+               :                                   :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :                          :              +- CometBroadcastExchange
+               :                                   :                          :                 +- CometProject
+               :                                   :                          :                    +- CometFilter
+               :                                   :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :                          +- CometBroadcastExchange
+               :                                   :                             +- CometProject
+               :                                   :                                +- CometBroadcastHashJoin
+               :                                   :                                   :- CometProject
+               :                                   :                                   :  +- CometBroadcastHashJoin
+               :                                   :                                   :     :- CometFilter
+               :                                   :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                                   :                                   :     :        +- ReusedSubquery
+               :                                   :                                   :     +- CometBroadcastExchange
+               :                                   :                                   :        +- CometFilter
+               :                                   :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :                                   +- CometBroadcastExchange
+               :                                   :                                      +- CometProject
+               :                                   :                                         +- CometFilter
+               :                                   :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   +- CometBroadcastExchange
+               :                                      +- CometProject
+               :                                         +- CometFilter
+               :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :- CometHashAggregate
+               :  +- CometExchange
+               :     +- CometHashAggregate
+               :        +- CometHashAggregate
+               :           +- CometHashAggregate
+               :              +- CometUnion
+               :                 :- CometFilter
+               :                 :  :  +- ReusedSubquery
+               :                 :  +- CometHashAggregate
+               :                 :     +- CometExchange
+               :                 :        +- CometHashAggregate
+               :                 :           +- CometProject
+               :                 :              +- CometBroadcastHashJoin
+               :                 :                 :- CometProject
+               :                 :                 :  +- CometBroadcastHashJoin
+               :                 :                 :     :- CometBroadcastHashJoin
+               :                 :                 :     :  :- CometFilter
+               :                 :                 :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                 :                 :     :  :        +- SubqueryBroadcast
+               :                 :                 :     :  :           +- BroadcastExchange
+               :                 :                 :     :  :              +- CometNativeColumnarToRow
+               :                 :                 :     :  :                 +- CometProject
+               :                 :                 :     :  :                    +- CometFilter
+               :                 :                 :     :  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :  +- CometBroadcastExchange
+               :                 :                 :     :     +- CometProject
+               :                 :                 :     :        +- CometBroadcastHashJoin
+               :                 :                 :     :           :- CometFilter
+               :                 :                 :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :           +- CometBroadcastExchange
+               :                 :                 :     :              +- CometBroadcastHashJoin
+               :                 :                 :     :                 :- CometHashAggregate
+               :                 :                 :     :                 :  +- CometExchange
+               :                 :                 :     :                 :     +- CometHashAggregate
+               :                 :                 :     :                 :        +- CometProject
+               :                 :                 :     :                 :           +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :- CometProject
+               :                 :                 :     :                 :              :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :     :- CometFilter
+               :                 :                 :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                 :                 :     :                 :              :     :        +- SubqueryBroadcast
+               :                 :                 :     :                 :              :     :           +- BroadcastExchange
+               :                 :                 :     :                 :              :     :              +- CometNativeColumnarToRow
+               :                 :                 :     :                 :              :     :                 +- CometProject
+               :                 :                 :     :                 :              :     :                    +- CometFilter
+               :                 :                 :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :        +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :           :- CometFilter
+               :                 :                 :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :           +- CometBroadcastExchange
+               :                 :                 :     :                 :              :              +- CometProject
+               :                 :                 :     :                 :              :                 +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :- CometProject
+               :                 :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :     :- CometFilter
+               :                 :                 :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                 :                 :     :                 :              :                    :     :        +- ReusedSubquery
+               :                 :                 :     :                 :              :                    :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                    :        +- CometFilter
+               :                 :                 :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :                    +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                       +- CometProject
+               :                 :                 :     :                 :              :                          +- CometFilter
+               :                 :                 :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              +- CometBroadcastExchange
+               :                 :                 :     :                 :                 +- CometProject
+               :                 :                 :     :                 :                    +- CometFilter
+               :                 :                 :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 +- CometBroadcastExchange
+               :                 :                 :     :                    +- CometProject
+               :                 :                 :     :                       +- CometBroadcastHashJoin
+               :                 :                 :     :                          :- CometProject
+               :                 :                 :     :                          :  +- CometBroadcastHashJoin
+               :                 :                 :     :                          :     :- CometFilter
+               :                 :                 :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                 :                 :     :                          :     :        +- ReusedSubquery
+               :                 :                 :     :                          :     +- CometBroadcastExchange
+               :                 :                 :     :                          :        +- CometFilter
+               :                 :                 :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :                          +- CometBroadcastExchange
+               :                 :                 :     :                             +- CometProject
+               :                 :                 :     :                                +- CometFilter
+               :                 :                 :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     +- CometBroadcastExchange
+               :                 :                 :        +- CometBroadcastHashJoin
+               :                 :                 :           :- CometFilter
+               :                 :                 :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :           +- CometBroadcastExchange
+               :                 :                 :              +- CometProject
+               :                 :                 :                 +- CometBroadcastHashJoin
+               :                 :                 :                    :- CometFilter
+               :                 :                 :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                    +- CometBroadcastExchange
+               :                 :                 :                       +- CometBroadcastHashJoin
+               :                 :                 :                          :- CometHashAggregate
+               :                 :                 :                          :  +- CometExchange
+               :                 :                 :                          :     +- CometHashAggregate
+               :                 :                 :                          :        +- CometProject
+               :                 :                 :                          :           +- CometBroadcastHashJoin
+               :                 :                 :                          :              :- CometProject
+               :                 :                 :                          :              :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :     :- CometFilter
+               :                 :                 :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                 :                 :                          :              :     :        +- SubqueryBroadcast
+               :                 :                 :                          :              :     :           +- BroadcastExchange
+               :                 :                 :                          :              :     :              +- CometNativeColumnarToRow
+               :                 :                 :                          :              :     :                 +- CometProject
+               :                 :                 :                          :              :     :                    +- CometFilter
+               :                 :                 :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              :     +- CometBroadcastExchange
+               :                 :                 :                          :              :        +- CometBroadcastHashJoin
+               :                 :                 :                          :              :           :- CometFilter
+               :                 :                 :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                          :              :           +- CometBroadcastExchange
+               :                 :                 :                          :              :              +- CometProject
+               :                 :                 :                          :              :                 +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :- CometProject
+               :                 :                 :                          :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :     :- CometFilter
+               :                 :                 :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                 :                 :                          :              :                    :     :        +- ReusedSubquery
+               :                 :                 :                          :              :                    :     +- CometBroadcastExchange
+               :                 :                 :                          :              :                    :        +- CometFilter
+               :                 :                 :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                          :              :                    +- CometBroadcastExchange
+               :                 :                 :                          :              :                       +- CometProject
+               :                 :                 :                          :              :                          +- CometFilter
+               :                 :                 :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              +- CometBroadcastExchange
+               :                 :                 :                          :                 +- CometProject
+               :                 :                 :                          :                    +- CometFilter
+               :                 :                 :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :                          +- CometBroadcastExchange
+               :                 :                 :                             +- CometProject
+               :                 :                 :                                +- CometBroadcastHashJoin
+               :                 :                 :                                   :- CometProject
+               :                 :                 :                                   :  +- CometBroadcastHashJoin
+               :                 :                 :                                   :     :- CometFilter
+               :                 :                 :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                 :                 :                                   :     :        +- ReusedSubquery
+               :                 :                 :                                   :     +- CometBroadcastExchange
+               :                 :                 :                                   :        +- CometFilter
+               :                 :                 :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                                   +- CometBroadcastExchange
+               :                 :                 :                                      +- CometProject
+               :                 :                 :                                         +- CometFilter
+               :                 :                 :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 +- CometBroadcastExchange
+               :                 :                    +- CometProject
+               :                 :                       +- CometFilter
+               :                 :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :- CometFilter
+               :                 :  :  +- ReusedSubquery
+               :                 :  +- CometHashAggregate
+               :                 :     +- CometExchange
+               :                 :        +- CometHashAggregate
+               :                 :           +- CometProject
+               :                 :              +- CometBroadcastHashJoin
+               :                 :                 :- CometProject
+               :                 :                 :  +- CometBroadcastHashJoin
+               :                 :                 :     :- CometBroadcastHashJoin
+               :                 :                 :     :  :- CometFilter
+               :                 :                 :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                 :                 :     :  :        +- ReusedSubquery
+               :                 :                 :     :  +- CometBroadcastExchange
+               :                 :                 :     :     +- CometProject
+               :                 :                 :     :        +- CometBroadcastHashJoin
+               :                 :                 :     :           :- CometFilter
+               :                 :                 :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :           +- CometBroadcastExchange
+               :                 :                 :     :              +- CometBroadcastHashJoin
+               :                 :                 :     :                 :- CometHashAggregate
+               :                 :                 :     :                 :  +- CometExchange
+               :                 :                 :     :                 :     +- CometHashAggregate
+               :                 :                 :     :                 :        +- CometProject
+               :                 :                 :     :                 :           +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :- CometProject
+               :                 :                 :     :                 :              :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :     :- CometFilter
+               :                 :                 :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                 :                 :     :                 :              :     :        +- SubqueryBroadcast
+               :                 :                 :     :                 :              :     :           +- BroadcastExchange
+               :                 :                 :     :                 :              :     :              +- CometNativeColumnarToRow
+               :                 :                 :     :                 :              :     :                 +- CometProject
+               :                 :                 :     :                 :              :     :                    +- CometFilter
+               :                 :                 :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :        +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :           :- CometFilter
+               :                 :                 :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :           +- CometBroadcastExchange
+               :                 :                 :     :                 :              :              +- CometProject
+               :                 :                 :     :                 :              :                 +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :- CometProject
+               :                 :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :     :- CometFilter
+               :                 :                 :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                 :                 :     :                 :              :                    :     :        +- ReusedSubquery
+               :                 :                 :     :                 :              :                    :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                    :        +- CometFilter
+               :                 :                 :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :                    +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                       +- CometProject
+               :                 :                 :     :                 :              :                          +- CometFilter
+               :                 :                 :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              +- CometBroadcastExchange
+               :                 :                 :     :                 :                 +- CometProject
+               :                 :                 :     :                 :                    +- CometFilter
+               :                 :                 :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 +- CometBroadcastExchange
+               :                 :                 :     :                    +- CometProject
+               :                 :                 :     :                       +- CometBroadcastHashJoin
+               :                 :                 :     :                          :- CometProject
+               :                 :                 :     :                          :  +- CometBroadcastHashJoin
+               :                 :                 :     :                          :     :- CometFilter
+               :                 :                 :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                 :                 :     :                          :     :        +- ReusedSubquery
+               :                 :                 :     :                          :     +- CometBroadcastExchange
+               :                 :                 :     :                          :        +- CometFilter
+               :                 :                 :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :                          +- CometBroadcastExchange
+               :                 :                 :     :                             +- CometProject
+               :                 :                 :     :                                +- CometFilter
+               :                 :                 :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     +- CometBroadcastExchange
+               :                 :                 :        +- CometBroadcastHashJoin
+               :                 :                 :           :- CometFilter
+               :                 :                 :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :           +- CometBroadcastExchange
+               :                 :                 :              +- CometProject
+               :                 :                 :                 +- CometBroadcastHashJoin
+               :                 :                 :                    :- CometFilter
+               :                 :                 :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                    +- CometBroadcastExchange
+               :                 :                 :                       +- CometBroadcastHashJoin
+               :                 :                 :                          :- CometHashAggregate
+               :                 :                 :                          :  +- CometExchange
+               :                 :                 :                          :     +- CometHashAggregate
+               :                 :                 :                          :        +- CometProject
+               :                 :                 :                          :           +- CometBroadcastHashJoin
+               :                 :                 :                          :              :- CometProject
+               :                 :                 :                          :              :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :     :- CometFilter
+               :                 :                 :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                 :                 :                          :              :     :        +- SubqueryBroadcast
+               :                 :                 :                          :              :     :           +- BroadcastExchange
+               :                 :                 :                          :              :     :              +- CometNativeColumnarToRow
+               :                 :                 :                          :              :     :                 +- CometProject
+               :                 :                 :                          :              :     :                    +- CometFilter
+               :                 :                 :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              :     +- CometBroadcastExchange
+               :                 :                 :                          :              :        +- CometBroadcastHashJoin
+               :                 :                 :                          :              :           :- CometFilter
+               :                 :                 :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                          :              :           +- CometBroadcastExchange
+               :                 :                 :                          :              :              +- CometProject
+               :                 :                 :                          :              :                 +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :- CometProject
+               :                 :                 :                          :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :     :- CometFilter
+               :                 :                 :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                 :                 :                          :              :                    :     :        +- ReusedSubquery
+               :                 :                 :                          :              :                    :     +- CometBroadcastExchange
+               :                 :                 :                          :              :                    :        +- CometFilter
+               :                 :                 :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                          :              :                    +- CometBroadcastExchange
+               :                 :                 :                          :              :                       +- CometProject
+               :                 :                 :                          :              :                          +- CometFilter
+               :                 :                 :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              +- CometBroadcastExchange
+               :                 :                 :                          :                 +- CometProject
+               :                 :                 :                          :                    +- CometFilter
+               :                 :                 :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :                          +- CometBroadcastExchange
+               :                 :                 :                             +- CometProject
+               :                 :                 :                                +- CometBroadcastHashJoin
+               :                 :                 :                                   :- CometProject
+               :                 :                 :                                   :  +- CometBroadcastHashJoin
+               :                 :                 :                                   :     :- CometFilter
+               :                 :                 :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                 :                 :                                   :     :        +- ReusedSubquery
+               :                 :                 :                                   :     +- CometBroadcastExchange
+               :                 :                 :                                   :        +- CometFilter
+               :                 :                 :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                                   +- CometBroadcastExchange
+               :                 :                 :                                      +- CometProject
+               :                 :                 :                                         +- CometFilter
+               :                 :                 :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 +- CometBroadcastExchange
+               :                 :                    +- CometProject
+               :                 :                       +- CometFilter
+               :                 :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 +- CometFilter
+               :                    :  +- ReusedSubquery
+               :                    +- CometHashAggregate
+               :                       +- CometExchange
+               :                          +- CometHashAggregate
+               :                             +- CometProject
+               :                                +- CometBroadcastHashJoin
+               :                                   :- CometProject
+               :                                   :  +- CometBroadcastHashJoin
+               :                                   :     :- CometBroadcastHashJoin
+               :                                   :     :  :- CometFilter
+               :                                   :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                                   :     :  :        +- ReusedSubquery
+               :                                   :     :  +- CometBroadcastExchange
+               :                                   :     :     +- CometProject
+               :                                   :     :        +- CometBroadcastHashJoin
+               :                                   :     :           :- CometFilter
+               :                                   :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :     :           +- CometBroadcastExchange
+               :                                   :     :              +- CometBroadcastHashJoin
+               :                                   :     :                 :- CometHashAggregate
+               :                                   :     :                 :  +- CometExchange
+               :                                   :     :                 :     +- CometHashAggregate
+               :                                   :     :                 :        +- CometProject
+               :                                   :     :                 :           +- CometBroadcastHashJoin
+               :                                   :     :                 :              :- CometProject
+               :                                   :     :                 :              :  +- CometBroadcastHashJoin
+               :                                   :     :                 :              :     :- CometFilter
+               :                                   :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                                   :     :                 :              :     :        +- SubqueryBroadcast
+               :                                   :     :                 :              :     :           +- BroadcastExchange
+               :                                   :     :                 :              :     :              +- CometNativeColumnarToRow
+               :                                   :     :                 :              :     :                 +- CometProject
+               :                                   :     :                 :              :     :                    +- CometFilter
+               :                                   :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :     :                 :              :     +- CometBroadcastExchange
+               :                                   :     :                 :              :        +- CometBroadcastHashJoin
+               :                                   :     :                 :              :           :- CometFilter
+               :                                   :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :     :                 :              :           +- CometBroadcastExchange
+               :                                   :     :                 :              :              +- CometProject
+               :                                   :     :                 :              :                 +- CometBroadcastHashJoin
+               :                                   :     :                 :              :                    :- CometProject
+               :                                   :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                                   :     :                 :              :                    :     :- CometFilter
+               :                                   :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                                   :     :                 :              :                    :     :        +- ReusedSubquery
+               :                                   :     :                 :              :                    :     +- CometBroadcastExchange
+               :                                   :     :                 :              :                    :        +- CometFilter
+               :                                   :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :     :                 :              :                    +- CometBroadcastExchange
+               :                                   :     :                 :              :                       +- CometProject
+               :                                   :     :                 :              :                          +- CometFilter
+               :                                   :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :     :                 :              +- CometBroadcastExchange
+               :                                   :     :                 :                 +- CometProject
+               :                                   :     :                 :                    +- CometFilter
+               :                                   :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :     :                 +- CometBroadcastExchange
+               :                                   :     :                    +- CometProject
+               :                                   :     :                       +- CometBroadcastHashJoin
+               :                                   :     :                          :- CometProject
+               :                                   :     :                          :  +- CometBroadcastHashJoin
+               :                                   :     :                          :     :- CometFilter
+               :                                   :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                                   :     :                          :     :        +- ReusedSubquery
+               :                                   :     :                          :     +- CometBroadcastExchange
+               :                                   :     :                          :        +- CometFilter
+               :                                   :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :     :                          +- CometBroadcastExchange
+               :                                   :     :                             +- CometProject
+               :                                   :     :                                +- CometFilter
+               :                                   :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :     +- CometBroadcastExchange
+               :                                   :        +- CometBroadcastHashJoin
+               :                                   :           :- CometFilter
+               :                                   :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :           +- CometBroadcastExchange
+               :                                   :              +- CometProject
+               :                                   :                 +- CometBroadcastHashJoin
+               :                                   :                    :- CometFilter
+               :                                   :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :                    +- CometBroadcastExchange
+               :                                   :                       +- CometBroadcastHashJoin
+               :                                   :                          :- CometHashAggregate
+               :                                   :                          :  +- CometExchange
+               :                                   :                          :     +- CometHashAggregate
+               :                                   :                          :        +- CometProject
+               :                                   :                          :           +- CometBroadcastHashJoin
+               :                                   :                          :              :- CometProject
+               :                                   :                          :              :  +- CometBroadcastHashJoin
+               :                                   :                          :              :     :- CometFilter
+               :                                   :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                                   :                          :              :     :        +- SubqueryBroadcast
+               :                                   :                          :              :     :           +- BroadcastExchange
+               :                                   :                          :              :     :              +- CometNativeColumnarToRow
+               :                                   :                          :              :     :                 +- CometProject
+               :                                   :                          :              :     :                    +- CometFilter
+               :                                   :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :                          :              :     +- CometBroadcastExchange
+               :                                   :                          :              :        +- CometBroadcastHashJoin
+               :                                   :                          :              :           :- CometFilter
+               :                                   :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :                          :              :           +- CometBroadcastExchange
+               :                                   :                          :              :              +- CometProject
+               :                                   :                          :              :                 +- CometBroadcastHashJoin
+               :                                   :                          :              :                    :- CometProject
+               :                                   :                          :              :                    :  +- CometBroadcastHashJoin
+               :                                   :                          :              :                    :     :- CometFilter
+               :                                   :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                                   :                          :              :                    :     :        +- ReusedSubquery
+               :                                   :                          :              :                    :     +- CometBroadcastExchange
+               :                                   :                          :              :                    :        +- CometFilter
+               :                                   :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :                          :              :                    +- CometBroadcastExchange
+               :                                   :                          :              :                       +- CometProject
+               :                                   :                          :              :                          +- CometFilter
+               :                                   :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :                          :              +- CometBroadcastExchange
+               :                                   :                          :                 +- CometProject
+               :                                   :                          :                    +- CometFilter
+               :                                   :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :                          +- CometBroadcastExchange
+               :                                   :                             +- CometProject
+               :                                   :                                +- CometBroadcastHashJoin
+               :                                   :                                   :- CometProject
+               :                                   :                                   :  +- CometBroadcastHashJoin
+               :                                   :                                   :     :- CometFilter
+               :                                   :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                                   :                                   :     :        +- ReusedSubquery
+               :                                   :                                   :     +- CometBroadcastExchange
+               :                                   :                                   :        +- CometFilter
+               :                                   :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :                                   +- CometBroadcastExchange
+               :                                   :                                      +- CometProject
+               :                                   :                                         +- CometFilter
+               :                                   :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   +- CometBroadcastExchange
+               :                                      +- CometProject
+               :                                         +- CometFilter
+               :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :- CometHashAggregate
+               :  +- CometExchange
+               :     +- CometHashAggregate
+               :        +- CometHashAggregate
+               :           +- CometHashAggregate
+               :              +- CometUnion
+               :                 :- CometFilter
+               :                 :  :  +- ReusedSubquery
+               :                 :  +- CometHashAggregate
+               :                 :     +- CometExchange
+               :                 :        +- CometHashAggregate
+               :                 :           +- CometProject
+               :                 :              +- CometBroadcastHashJoin
+               :                 :                 :- CometProject
+               :                 :                 :  +- CometBroadcastHashJoin
+               :                 :                 :     :- CometBroadcastHashJoin
+               :                 :                 :     :  :- CometFilter
+               :                 :                 :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                 :                 :     :  :        +- SubqueryBroadcast
+               :                 :                 :     :  :           +- BroadcastExchange
+               :                 :                 :     :  :              +- CometNativeColumnarToRow
+               :                 :                 :     :  :                 +- CometProject
+               :                 :                 :     :  :                    +- CometFilter
+               :                 :                 :     :  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :  +- CometBroadcastExchange
+               :                 :                 :     :     +- CometProject
+               :                 :                 :     :        +- CometBroadcastHashJoin
+               :                 :                 :     :           :- CometFilter
+               :                 :                 :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :           +- CometBroadcastExchange
+               :                 :                 :     :              +- CometBroadcastHashJoin
+               :                 :                 :     :                 :- CometHashAggregate
+               :                 :                 :     :                 :  +- CometExchange
+               :                 :                 :     :                 :     +- CometHashAggregate
+               :                 :                 :     :                 :        +- CometProject
+               :                 :                 :     :                 :           +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :- CometProject
+               :                 :                 :     :                 :              :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :     :- CometFilter
+               :                 :                 :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                 :                 :     :                 :              :     :        +- SubqueryBroadcast
+               :                 :                 :     :                 :              :     :           +- BroadcastExchange
+               :                 :                 :     :                 :              :     :              +- CometNativeColumnarToRow
+               :                 :                 :     :                 :              :     :                 +- CometProject
+               :                 :                 :     :                 :              :     :                    +- CometFilter
+               :                 :                 :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :        +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :           :- CometFilter
+               :                 :                 :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :           +- CometBroadcastExchange
+               :                 :                 :     :                 :              :              +- CometProject
+               :                 :                 :     :                 :              :                 +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :- CometProject
+               :                 :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :     :- CometFilter
+               :                 :                 :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                 :                 :     :                 :              :                    :     :        +- ReusedSubquery
+               :                 :                 :     :                 :              :                    :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                    :        +- CometFilter
+               :                 :                 :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :                    +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                       +- CometProject
+               :                 :                 :     :                 :              :                          +- CometFilter
+               :                 :                 :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              +- CometBroadcastExchange
+               :                 :                 :     :                 :                 +- CometProject
+               :                 :                 :     :                 :                    +- CometFilter
+               :                 :                 :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 +- CometBroadcastExchange
+               :                 :                 :     :                    +- CometProject
+               :                 :                 :     :                       +- CometBroadcastHashJoin
+               :                 :                 :     :                          :- CometProject
+               :                 :                 :     :                          :  +- CometBroadcastHashJoin
+               :                 :                 :     :                          :     :- CometFilter
+               :                 :                 :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                 :                 :     :                          :     :        +- ReusedSubquery
+               :                 :                 :     :                          :     +- CometBroadcastExchange
+               :                 :                 :     :                          :        +- CometFilter
+               :                 :                 :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :                          +- CometBroadcastExchange
+               :                 :                 :     :                             +- CometProject
+               :                 :                 :     :                                +- CometFilter
+               :                 :                 :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     +- CometBroadcastExchange
+               :                 :                 :        +- CometBroadcastHashJoin
+               :                 :                 :           :- CometFilter
+               :                 :                 :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :           +- CometBroadcastExchange
+               :                 :                 :              +- CometProject
+               :                 :                 :                 +- CometBroadcastHashJoin
+               :                 :                 :                    :- CometFilter
+               :                 :                 :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                    +- CometBroadcastExchange
+               :                 :                 :                       +- CometBroadcastHashJoin
+               :                 :                 :                          :- CometHashAggregate
+               :                 :                 :                          :  +- CometExchange
+               :                 :                 :                          :     +- CometHashAggregate
+               :                 :                 :                          :        +- CometProject
+               :                 :                 :                          :           +- CometBroadcastHashJoin
+               :                 :                 :                          :              :- CometProject
+               :                 :                 :                          :              :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :     :- CometFilter
+               :                 :                 :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                 :                 :                          :              :     :        +- SubqueryBroadcast
+               :                 :                 :                          :              :     :           +- BroadcastExchange
+               :                 :                 :                          :              :     :              +- CometNativeColumnarToRow
+               :                 :                 :                          :              :     :                 +- CometProject
+               :                 :                 :                          :              :     :                    +- CometFilter
+               :                 :                 :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              :     +- CometBroadcastExchange
+               :                 :                 :                          :              :        +- CometBroadcastHashJoin
+               :                 :                 :                          :              :           :- CometFilter
+               :                 :                 :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                          :              :           +- CometBroadcastExchange
+               :                 :                 :                          :              :              +- CometProject
+               :                 :                 :                          :              :                 +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :- CometProject
+               :                 :                 :                          :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :     :- CometFilter
+               :                 :                 :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                 :                 :                          :              :                    :     :        +- ReusedSubquery
+               :                 :                 :                          :              :                    :     +- CometBroadcastExchange
+               :                 :                 :                          :              :                    :        +- CometFilter
+               :                 :                 :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                          :              :                    +- CometBroadcastExchange
+               :                 :                 :                          :              :                       +- CometProject
+               :                 :                 :                          :              :                          +- CometFilter
+               :                 :                 :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              +- CometBroadcastExchange
+               :                 :                 :                          :                 +- CometProject
+               :                 :                 :                          :                    +- CometFilter
+               :                 :                 :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :                          +- CometBroadcastExchange
+               :                 :                 :                             +- CometProject
+               :                 :                 :                                +- CometBroadcastHashJoin
+               :                 :                 :                                   :- CometProject
+               :                 :                 :                                   :  +- CometBroadcastHashJoin
+               :                 :                 :                                   :     :- CometFilter
+               :                 :                 :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                 :                 :                                   :     :        +- ReusedSubquery
+               :                 :                 :                                   :     +- CometBroadcastExchange
+               :                 :                 :                                   :        +- CometFilter
+               :                 :                 :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                                   +- CometBroadcastExchange
+               :                 :                 :                                      +- CometProject
+               :                 :                 :                                         +- CometFilter
+               :                 :                 :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 +- CometBroadcastExchange
+               :                 :                    +- CometProject
+               :                 :                       +- CometFilter
+               :                 :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :- CometFilter
+               :                 :  :  +- ReusedSubquery
+               :                 :  +- CometHashAggregate
+               :                 :     +- CometExchange
+               :                 :        +- CometHashAggregate
+               :                 :           +- CometProject
+               :                 :              +- CometBroadcastHashJoin
+               :                 :                 :- CometProject
+               :                 :                 :  +- CometBroadcastHashJoin
+               :                 :                 :     :- CometBroadcastHashJoin
+               :                 :                 :     :  :- CometFilter
+               :                 :                 :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                 :                 :     :  :        +- ReusedSubquery
+               :                 :                 :     :  +- CometBroadcastExchange
+               :                 :                 :     :     +- CometProject
+               :                 :                 :     :        +- CometBroadcastHashJoin
+               :                 :                 :     :           :- CometFilter
+               :                 :                 :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :           +- CometBroadcastExchange
+               :                 :                 :     :              +- CometBroadcastHashJoin
+               :                 :                 :     :                 :- CometHashAggregate
+               :                 :                 :     :                 :  +- CometExchange
+               :                 :                 :     :                 :     +- CometHashAggregate
+               :                 :                 :     :                 :        +- CometProject
+               :                 :                 :     :                 :           +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :- CometProject
+               :                 :                 :     :                 :              :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :     :- CometFilter
+               :                 :                 :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                 :                 :     :                 :              :     :        +- SubqueryBroadcast
+               :                 :                 :     :                 :              :     :           +- BroadcastExchange
+               :                 :                 :     :                 :              :     :              +- CometNativeColumnarToRow
+               :                 :                 :     :                 :              :     :                 +- CometProject
+               :                 :                 :     :                 :              :     :                    +- CometFilter
+               :                 :                 :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :        +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :           :- CometFilter
+               :                 :                 :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :           +- CometBroadcastExchange
+               :                 :                 :     :                 :              :              +- CometProject
+               :                 :                 :     :                 :              :                 +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :- CometProject
+               :                 :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :     :                 :              :                    :     :- CometFilter
+               :                 :                 :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                 :                 :     :                 :              :                    :     :        +- ReusedSubquery
+               :                 :                 :     :                 :              :                    :     +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                    :        +- CometFilter
+               :                 :                 :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :                 :              :                    +- CometBroadcastExchange
+               :                 :                 :     :                 :              :                       +- CometProject
+               :                 :                 :     :                 :              :                          +- CometFilter
+               :                 :                 :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 :              +- CometBroadcastExchange
+               :                 :                 :     :                 :                 +- CometProject
+               :                 :                 :     :                 :                    +- CometFilter
+               :                 :                 :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     :                 +- CometBroadcastExchange
+               :                 :                 :     :                    +- CometProject
+               :                 :                 :     :                       +- CometBroadcastHashJoin
+               :                 :                 :     :                          :- CometProject
+               :                 :                 :     :                          :  +- CometBroadcastHashJoin
+               :                 :                 :     :                          :     :- CometFilter
+               :                 :                 :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                 :                 :     :                          :     :        +- ReusedSubquery
+               :                 :                 :     :                          :     +- CometBroadcastExchange
+               :                 :                 :     :                          :        +- CometFilter
+               :                 :                 :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :     :                          +- CometBroadcastExchange
+               :                 :                 :     :                             +- CometProject
+               :                 :                 :     :                                +- CometFilter
+               :                 :                 :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :     +- CometBroadcastExchange
+               :                 :                 :        +- CometBroadcastHashJoin
+               :                 :                 :           :- CometFilter
+               :                 :                 :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :           +- CometBroadcastExchange
+               :                 :                 :              +- CometProject
+               :                 :                 :                 +- CometBroadcastHashJoin
+               :                 :                 :                    :- CometFilter
+               :                 :                 :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                    +- CometBroadcastExchange
+               :                 :                 :                       +- CometBroadcastHashJoin
+               :                 :                 :                          :- CometHashAggregate
+               :                 :                 :                          :  +- CometExchange
+               :                 :                 :                          :     +- CometHashAggregate
+               :                 :                 :                          :        +- CometProject
+               :                 :                 :                          :           +- CometBroadcastHashJoin
+               :                 :                 :                          :              :- CometProject
+               :                 :                 :                          :              :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :     :- CometFilter
+               :                 :                 :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                 :                 :                          :              :     :        +- SubqueryBroadcast
+               :                 :                 :                          :              :     :           +- BroadcastExchange
+               :                 :                 :                          :              :     :              +- CometNativeColumnarToRow
+               :                 :                 :                          :              :     :                 +- CometProject
+               :                 :                 :                          :              :     :                    +- CometFilter
+               :                 :                 :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              :     +- CometBroadcastExchange
+               :                 :                 :                          :              :        +- CometBroadcastHashJoin
+               :                 :                 :                          :              :           :- CometFilter
+               :                 :                 :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                          :              :           +- CometBroadcastExchange
+               :                 :                 :                          :              :              +- CometProject
+               :                 :                 :                          :              :                 +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :- CometProject
+               :                 :                 :                          :              :                    :  +- CometBroadcastHashJoin
+               :                 :                 :                          :              :                    :     :- CometFilter
+               :                 :                 :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                 :                 :                          :              :                    :     :        +- ReusedSubquery
+               :                 :                 :                          :              :                    :     +- CometBroadcastExchange
+               :                 :                 :                          :              :                    :        +- CometFilter
+               :                 :                 :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                          :              :                    +- CometBroadcastExchange
+               :                 :                 :                          :              :                       +- CometProject
+               :                 :                 :                          :              :                          +- CometFilter
+               :                 :                 :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :                          :              +- CometBroadcastExchange
+               :                 :                 :                          :                 +- CometProject
+               :                 :                 :                          :                    +- CometFilter
+               :                 :                 :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 :                          +- CometBroadcastExchange
+               :                 :                 :                             +- CometProject
+               :                 :                 :                                +- CometBroadcastHashJoin
+               :                 :                 :                                   :- CometProject
+               :                 :                 :                                   :  +- CometBroadcastHashJoin
+               :                 :                 :                                   :     :- CometFilter
+               :                 :                 :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                 :                 :                                   :     :        +- ReusedSubquery
+               :                 :                 :                                   :     +- CometBroadcastExchange
+               :                 :                 :                                   :        +- CometFilter
+               :                 :                 :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                 :                 :                                   +- CometBroadcastExchange
+               :                 :                 :                                      +- CometProject
+               :                 :                 :                                         +- CometFilter
+               :                 :                 :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 :                 +- CometBroadcastExchange
+               :                 :                    +- CometProject
+               :                 :                       +- CometFilter
+               :                 :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                 +- CometFilter
+               :                    :  +- ReusedSubquery
+               :                    +- CometHashAggregate
+               :                       +- CometExchange
+               :                          +- CometHashAggregate
+               :                             +- CometProject
+               :                                +- CometBroadcastHashJoin
+               :                                   :- CometProject
+               :                                   :  +- CometBroadcastHashJoin
+               :                                   :     :- CometBroadcastHashJoin
+               :                                   :     :  :- CometFilter
+               :                                   :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                                   :     :  :        +- ReusedSubquery
+               :                                   :     :  +- CometBroadcastExchange
+               :                                   :     :     +- CometProject
+               :                                   :     :        +- CometBroadcastHashJoin
+               :                                   :     :           :- CometFilter
+               :                                   :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :     :           +- CometBroadcastExchange
+               :                                   :     :              +- CometBroadcastHashJoin
+               :                                   :     :                 :- CometHashAggregate
+               :                                   :     :                 :  +- CometExchange
+               :                                   :     :                 :     +- CometHashAggregate
+               :                                   :     :                 :        +- CometProject
+               :                                   :     :                 :           +- CometBroadcastHashJoin
+               :                                   :     :                 :              :- CometProject
+               :                                   :     :                 :              :  +- CometBroadcastHashJoin
+               :                                   :     :                 :              :     :- CometFilter
+               :                                   :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                                   :     :                 :              :     :        +- SubqueryBroadcast
+               :                                   :     :                 :              :     :           +- BroadcastExchange
+               :                                   :     :                 :              :     :              +- CometNativeColumnarToRow
+               :                                   :     :                 :              :     :                 +- CometProject
+               :                                   :     :                 :              :     :                    +- CometFilter
+               :                                   :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :     :                 :              :     +- CometBroadcastExchange
+               :                                   :     :                 :              :        +- CometBroadcastHashJoin
+               :                                   :     :                 :              :           :- CometFilter
+               :                                   :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :     :                 :              :           +- CometBroadcastExchange
+               :                                   :     :                 :              :              +- CometProject
+               :                                   :     :                 :              :                 +- CometBroadcastHashJoin
+               :                                   :     :                 :              :                    :- CometProject
+               :                                   :     :                 :              :                    :  +- CometBroadcastHashJoin
+               :                                   :     :                 :              :                    :     :- CometFilter
+               :                                   :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                                   :     :                 :              :                    :     :        +- ReusedSubquery
+               :                                   :     :                 :              :                    :     +- CometBroadcastExchange
+               :                                   :     :                 :              :                    :        +- CometFilter
+               :                                   :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :     :                 :              :                    +- CometBroadcastExchange
+               :                                   :     :                 :              :                       +- CometProject
+               :                                   :     :                 :              :                          +- CometFilter
+               :                                   :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :     :                 :              +- CometBroadcastExchange
+               :                                   :     :                 :                 +- CometProject
+               :                                   :     :                 :                    +- CometFilter
+               :                                   :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :     :                 +- CometBroadcastExchange
+               :                                   :     :                    +- CometProject
+               :                                   :     :                       +- CometBroadcastHashJoin
+               :                                   :     :                          :- CometProject
+               :                                   :     :                          :  +- CometBroadcastHashJoin
+               :                                   :     :                          :     :- CometFilter
+               :                                   :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                                   :     :                          :     :        +- ReusedSubquery
+               :                                   :     :                          :     +- CometBroadcastExchange
+               :                                   :     :                          :        +- CometFilter
+               :                                   :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :     :                          +- CometBroadcastExchange
+               :                                   :     :                             +- CometProject
+               :                                   :     :                                +- CometFilter
+               :                                   :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :     +- CometBroadcastExchange
+               :                                   :        +- CometBroadcastHashJoin
+               :                                   :           :- CometFilter
+               :                                   :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :           +- CometBroadcastExchange
+               :                                   :              +- CometProject
+               :                                   :                 +- CometBroadcastHashJoin
+               :                                   :                    :- CometFilter
+               :                                   :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :                    +- CometBroadcastExchange
+               :                                   :                       +- CometBroadcastHashJoin
+               :                                   :                          :- CometHashAggregate
+               :                                   :                          :  +- CometExchange
+               :                                   :                          :     +- CometHashAggregate
+               :                                   :                          :        +- CometProject
+               :                                   :                          :           +- CometBroadcastHashJoin
+               :                                   :                          :              :- CometProject
+               :                                   :                          :              :  +- CometBroadcastHashJoin
+               :                                   :                          :              :     :- CometFilter
+               :                                   :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                                   :                          :              :     :        +- SubqueryBroadcast
+               :                                   :                          :              :     :           +- BroadcastExchange
+               :                                   :                          :              :     :              +- CometNativeColumnarToRow
+               :                                   :                          :              :     :                 +- CometProject
+               :                                   :                          :              :     :                    +- CometFilter
+               :                                   :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :                          :              :     +- CometBroadcastExchange
+               :                                   :                          :              :        +- CometBroadcastHashJoin
+               :                                   :                          :              :           :- CometFilter
+               :                                   :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :                          :              :           +- CometBroadcastExchange
+               :                                   :                          :              :              +- CometProject
+               :                                   :                          :              :                 +- CometBroadcastHashJoin
+               :                                   :                          :              :                    :- CometProject
+               :                                   :                          :              :                    :  +- CometBroadcastHashJoin
+               :                                   :                          :              :                    :     :- CometFilter
+               :                                   :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                                   :                          :              :                    :     :        +- ReusedSubquery
+               :                                   :                          :              :                    :     +- CometBroadcastExchange
+               :                                   :                          :              :                    :        +- CometFilter
+               :                                   :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :                          :              :                    +- CometBroadcastExchange
+               :                                   :                          :              :                       +- CometProject
+               :                                   :                          :              :                          +- CometFilter
+               :                                   :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :                          :              +- CometBroadcastExchange
+               :                                   :                          :                 +- CometProject
+               :                                   :                          :                    +- CometFilter
+               :                                   :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :                          +- CometBroadcastExchange
+               :                                   :                             +- CometProject
+               :                                   :                                +- CometBroadcastHashJoin
+               :                                   :                                   :- CometProject
+               :                                   :                                   :  +- CometBroadcastHashJoin
+               :                                   :                                   :     :- CometFilter
+               :                                   :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                                   :                                   :     :        +- ReusedSubquery
+               :                                   :                                   :     +- CometBroadcastExchange
+               :                                   :                                   :        +- CometFilter
+               :                                   :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   :                                   +- CometBroadcastExchange
+               :                                   :                                      +- CometProject
+               :                                   :                                         +- CometFilter
+               :                                   :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   +- CometBroadcastExchange
+               :                                      +- CometProject
+               :                                         +- CometFilter
+               :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometHashAggregate
+                           +- CometHashAggregate
+                              +- CometUnion
+                                 :- CometFilter
+                                 :  :  +- ReusedSubquery
+                                 :  +- CometHashAggregate
+                                 :     +- CometExchange
+                                 :        +- CometHashAggregate
+                                 :           +- CometProject
+                                 :              +- CometBroadcastHashJoin
+                                 :                 :- CometProject
+                                 :                 :  +- CometBroadcastHashJoin
+                                 :                 :     :- CometBroadcastHashJoin
+                                 :                 :     :  :- CometFilter
+                                 :                 :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                 :                 :     :  :        +- SubqueryBroadcast
+                                 :                 :     :  :           +- BroadcastExchange
+                                 :                 :     :  :              +- CometNativeColumnarToRow
+                                 :                 :     :  :                 +- CometProject
+                                 :                 :     :  :                    +- CometFilter
+                                 :                 :     :  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :                 :     :  +- CometBroadcastExchange
+                                 :                 :     :     +- CometProject
+                                 :                 :     :        +- CometBroadcastHashJoin
+                                 :                 :     :           :- CometFilter
+                                 :                 :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :                 :     :           +- CometBroadcastExchange
+                                 :                 :     :              +- CometBroadcastHashJoin
+                                 :                 :     :                 :- CometHashAggregate
+                                 :                 :     :                 :  +- CometExchange
+                                 :                 :     :                 :     +- CometHashAggregate
+                                 :                 :     :                 :        +- CometProject
+                                 :                 :     :                 :           +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :- CometProject
+                                 :                 :     :                 :              :  +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :     :- CometFilter
+                                 :                 :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                 :                 :     :                 :              :     :        +- SubqueryBroadcast
+                                 :                 :     :                 :              :     :           +- BroadcastExchange
+                                 :                 :     :                 :              :     :              +- CometNativeColumnarToRow
+                                 :                 :     :                 :              :     :                 +- CometProject
+                                 :                 :     :                 :              :     :                    +- CometFilter
+                                 :                 :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :                 :     :                 :              :     +- CometBroadcastExchange
+                                 :                 :     :                 :              :        +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :           :- CometFilter
+                                 :                 :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :                 :     :                 :              :           +- CometBroadcastExchange
+                                 :                 :     :                 :              :              +- CometProject
+                                 :                 :     :                 :              :                 +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :                    :- CometProject
+                                 :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :                    :     :- CometFilter
+                                 :                 :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                                 :                 :     :                 :              :                    :     :        +- ReusedSubquery
+                                 :                 :     :                 :              :                    :     +- CometBroadcastExchange
+                                 :                 :     :                 :              :                    :        +- CometFilter
+                                 :                 :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :                 :     :                 :              :                    +- CometBroadcastExchange
+                                 :                 :     :                 :              :                       +- CometProject
+                                 :                 :     :                 :              :                          +- CometFilter
+                                 :                 :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :                 :     :                 :              +- CometBroadcastExchange
+                                 :                 :     :                 :                 +- CometProject
+                                 :                 :     :                 :                    +- CometFilter
+                                 :                 :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :                 :     :                 +- CometBroadcastExchange
+                                 :                 :     :                    +- CometProject
+                                 :                 :     :                       +- CometBroadcastHashJoin
+                                 :                 :     :                          :- CometProject
+                                 :                 :     :                          :  +- CometBroadcastHashJoin
+                                 :                 :     :                          :     :- CometFilter
+                                 :                 :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                 :                 :     :                          :     :        +- ReusedSubquery
+                                 :                 :     :                          :     +- CometBroadcastExchange
+                                 :                 :     :                          :        +- CometFilter
+                                 :                 :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :                 :     :                          +- CometBroadcastExchange
+                                 :                 :     :                             +- CometProject
+                                 :                 :     :                                +- CometFilter
+                                 :                 :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :                 :     +- CometBroadcastExchange
+                                 :                 :        +- CometBroadcastHashJoin
+                                 :                 :           :- CometFilter
+                                 :                 :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :                 :           +- CometBroadcastExchange
+                                 :                 :              +- CometProject
+                                 :                 :                 +- CometBroadcastHashJoin
+                                 :                 :                    :- CometFilter
+                                 :                 :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :                 :                    +- CometBroadcastExchange
+                                 :                 :                       +- CometBroadcastHashJoin
+                                 :                 :                          :- CometHashAggregate
+                                 :                 :                          :  +- CometExchange
+                                 :                 :                          :     +- CometHashAggregate
+                                 :                 :                          :        +- CometProject
+                                 :                 :                          :           +- CometBroadcastHashJoin
+                                 :                 :                          :              :- CometProject
+                                 :                 :                          :              :  +- CometBroadcastHashJoin
+                                 :                 :                          :              :     :- CometFilter
+                                 :                 :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                 :                 :                          :              :     :        +- SubqueryBroadcast
+                                 :                 :                          :              :     :           +- BroadcastExchange
+                                 :                 :                          :              :     :              +- CometNativeColumnarToRow
+                                 :                 :                          :              :     :                 +- CometProject
+                                 :                 :                          :              :     :                    +- CometFilter
+                                 :                 :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :                 :                          :              :     +- CometBroadcastExchange
+                                 :                 :                          :              :        +- CometBroadcastHashJoin
+                                 :                 :                          :              :           :- CometFilter
+                                 :                 :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :                 :                          :              :           +- CometBroadcastExchange
+                                 :                 :                          :              :              +- CometProject
+                                 :                 :                          :              :                 +- CometBroadcastHashJoin
+                                 :                 :                          :              :                    :- CometProject
+                                 :                 :                          :              :                    :  +- CometBroadcastHashJoin
+                                 :                 :                          :              :                    :     :- CometFilter
+                                 :                 :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                                 :                 :                          :              :                    :     :        +- ReusedSubquery
+                                 :                 :                          :              :                    :     +- CometBroadcastExchange
+                                 :                 :                          :              :                    :        +- CometFilter
+                                 :                 :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :                 :                          :              :                    +- CometBroadcastExchange
+                                 :                 :                          :              :                       +- CometProject
+                                 :                 :                          :              :                          +- CometFilter
+                                 :                 :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :                 :                          :              +- CometBroadcastExchange
+                                 :                 :                          :                 +- CometProject
+                                 :                 :                          :                    +- CometFilter
+                                 :                 :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :                 :                          +- CometBroadcastExchange
+                                 :                 :                             +- CometProject
+                                 :                 :                                +- CometBroadcastHashJoin
+                                 :                 :                                   :- CometProject
+                                 :                 :                                   :  +- CometBroadcastHashJoin
+                                 :                 :                                   :     :- CometFilter
+                                 :                 :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                 :                 :                                   :     :        +- ReusedSubquery
+                                 :                 :                                   :     +- CometBroadcastExchange
+                                 :                 :                                   :        +- CometFilter
+                                 :                 :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :                 :                                   +- CometBroadcastExchange
+                                 :                 :                                      +- CometProject
+                                 :                 :                                         +- CometFilter
+                                 :                 :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :                 +- CometBroadcastExchange
+                                 :                    +- CometProject
+                                 :                       +- CometFilter
+                                 :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :- CometFilter
+                                 :  :  +- ReusedSubquery
+                                 :  +- CometHashAggregate
+                                 :     +- CometExchange
+                                 :        +- CometHashAggregate
+                                 :           +- CometProject
+                                 :              +- CometBroadcastHashJoin
+                                 :                 :- CometProject
+                                 :                 :  +- CometBroadcastHashJoin
+                                 :                 :     :- CometBroadcastHashJoin
+                                 :                 :     :  :- CometFilter
+                                 :                 :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                                 :                 :     :  :        +- ReusedSubquery
+                                 :                 :     :  +- CometBroadcastExchange
+                                 :                 :     :     +- CometProject
+                                 :                 :     :        +- CometBroadcastHashJoin
+                                 :                 :     :           :- CometFilter
+                                 :                 :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :                 :     :           +- CometBroadcastExchange
+                                 :                 :     :              +- CometBroadcastHashJoin
+                                 :                 :     :                 :- CometHashAggregate
+                                 :                 :     :                 :  +- CometExchange
+                                 :                 :     :                 :     +- CometHashAggregate
+                                 :                 :     :                 :        +- CometProject
+                                 :                 :     :                 :           +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :- CometProject
+                                 :                 :     :                 :              :  +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :     :- CometFilter
+                                 :                 :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                 :                 :     :                 :              :     :        +- SubqueryBroadcast
+                                 :                 :     :                 :              :     :           +- BroadcastExchange
+                                 :                 :     :                 :              :     :              +- CometNativeColumnarToRow
+                                 :                 :     :                 :              :     :                 +- CometProject
+                                 :                 :     :                 :              :     :                    +- CometFilter
+                                 :                 :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :                 :     :                 :              :     +- CometBroadcastExchange
+                                 :                 :     :                 :              :        +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :           :- CometFilter
+                                 :                 :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :                 :     :                 :              :           +- CometBroadcastExchange
+                                 :                 :     :                 :              :              +- CometProject
+                                 :                 :     :                 :              :                 +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :                    :- CometProject
+                                 :                 :     :                 :              :                    :  +- CometBroadcastHashJoin
+                                 :                 :     :                 :              :                    :     :- CometFilter
+                                 :                 :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                                 :                 :     :                 :              :                    :     :        +- ReusedSubquery
+                                 :                 :     :                 :              :                    :     +- CometBroadcastExchange
+                                 :                 :     :                 :              :                    :        +- CometFilter
+                                 :                 :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :                 :     :                 :              :                    +- CometBroadcastExchange
+                                 :                 :     :                 :              :                       +- CometProject
+                                 :                 :     :                 :              :                          +- CometFilter
+                                 :                 :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :                 :     :                 :              +- CometBroadcastExchange
+                                 :                 :     :                 :                 +- CometProject
+                                 :                 :     :                 :                    +- CometFilter
+                                 :                 :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :                 :     :                 +- CometBroadcastExchange
+                                 :                 :     :                    +- CometProject
+                                 :                 :     :                       +- CometBroadcastHashJoin
+                                 :                 :     :                          :- CometProject
+                                 :                 :     :                          :  +- CometBroadcastHashJoin
+                                 :                 :     :                          :     :- CometFilter
+                                 :                 :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                 :                 :     :                          :     :        +- ReusedSubquery
+                                 :                 :     :                          :     +- CometBroadcastExchange
+                                 :                 :     :                          :        +- CometFilter
+                                 :                 :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :                 :     :                          +- CometBroadcastExchange
+                                 :                 :     :                             +- CometProject
+                                 :                 :     :                                +- CometFilter
+                                 :                 :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :                 :     +- CometBroadcastExchange
+                                 :                 :        +- CometBroadcastHashJoin
+                                 :                 :           :- CometFilter
+                                 :                 :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :                 :           +- CometBroadcastExchange
+                                 :                 :              +- CometProject
+                                 :                 :                 +- CometBroadcastHashJoin
+                                 :                 :                    :- CometFilter
+                                 :                 :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :                 :                    +- CometBroadcastExchange
+                                 :                 :                       +- CometBroadcastHashJoin
+                                 :                 :                          :- CometHashAggregate
+                                 :                 :                          :  +- CometExchange
+                                 :                 :                          :     +- CometHashAggregate
+                                 :                 :                          :        +- CometProject
+                                 :                 :                          :           +- CometBroadcastHashJoin
+                                 :                 :                          :              :- CometProject
+                                 :                 :                          :              :  +- CometBroadcastHashJoin
+                                 :                 :                          :              :     :- CometFilter
+                                 :                 :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                 :                 :                          :              :     :        +- SubqueryBroadcast
+                                 :                 :                          :              :     :           +- BroadcastExchange
+                                 :                 :                          :              :     :              +- CometNativeColumnarToRow
+                                 :                 :                          :              :     :                 +- CometProject
+                                 :                 :                          :              :     :                    +- CometFilter
+                                 :                 :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :                 :                          :              :     +- CometBroadcastExchange
+                                 :                 :                          :              :        +- CometBroadcastHashJoin
+                                 :                 :                          :              :           :- CometFilter
+                                 :                 :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :                 :                          :              :           +- CometBroadcastExchange
+                                 :                 :                          :              :              +- CometProject
+                                 :                 :                          :              :                 +- CometBroadcastHashJoin
+                                 :                 :                          :              :                    :- CometProject
+                                 :                 :                          :              :                    :  +- CometBroadcastHashJoin
+                                 :                 :                          :              :                    :     :- CometFilter
+                                 :                 :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                                 :                 :                          :              :                    :     :        +- ReusedSubquery
+                                 :                 :                          :              :                    :     +- CometBroadcastExchange
+                                 :                 :                          :              :                    :        +- CometFilter
+                                 :                 :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :                 :                          :              :                    +- CometBroadcastExchange
+                                 :                 :                          :              :                       +- CometProject
+                                 :                 :                          :              :                          +- CometFilter
+                                 :                 :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :                 :                          :              +- CometBroadcastExchange
+                                 :                 :                          :                 +- CometProject
+                                 :                 :                          :                    +- CometFilter
+                                 :                 :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :                 :                          +- CometBroadcastExchange
+                                 :                 :                             +- CometProject
+                                 :                 :                                +- CometBroadcastHashJoin
+                                 :                 :                                   :- CometProject
+                                 :                 :                                   :  +- CometBroadcastHashJoin
+                                 :                 :                                   :     :- CometFilter
+                                 :                 :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                 :                 :                                   :     :        +- ReusedSubquery
+                                 :                 :                                   :     +- CometBroadcastExchange
+                                 :                 :                                   :        +- CometFilter
+                                 :                 :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :                 :                                   +- CometBroadcastExchange
+                                 :                 :                                      +- CometProject
+                                 :                 :                                         +- CometFilter
+                                 :                 :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 :                 +- CometBroadcastExchange
+                                 :                    +- CometProject
+                                 :                       +- CometFilter
+                                 :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                 +- CometFilter
+                                    :  +- ReusedSubquery
+                                    +- CometHashAggregate
+                                       +- CometExchange
+                                          +- CometHashAggregate
+                                             +- CometProject
+                                                +- CometBroadcastHashJoin
+                                                   :- CometProject
+                                                   :  +- CometBroadcastHashJoin
+                                                   :     :- CometBroadcastHashJoin
+                                                   :     :  :- CometFilter
+                                                   :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                                   :     :  :        +- ReusedSubquery
+                                                   :     :  +- CometBroadcastExchange
+                                                   :     :     +- CometProject
+                                                   :     :        +- CometBroadcastHashJoin
+                                                   :     :           :- CometFilter
+                                                   :     :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                                   :     :           +- CometBroadcastExchange
+                                                   :     :              +- CometBroadcastHashJoin
+                                                   :     :                 :- CometHashAggregate
+                                                   :     :                 :  +- CometExchange
+                                                   :     :                 :     +- CometHashAggregate
+                                                   :     :                 :        +- CometProject
+                                                   :     :                 :           +- CometBroadcastHashJoin
+                                                   :     :                 :              :- CometProject
+                                                   :     :                 :              :  +- CometBroadcastHashJoin
+                                                   :     :                 :              :     :- CometFilter
+                                                   :     :                 :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                                   :     :                 :              :     :        +- SubqueryBroadcast
+                                                   :     :                 :              :     :           +- BroadcastExchange
+                                                   :     :                 :              :     :              +- CometNativeColumnarToRow
+                                                   :     :                 :              :     :                 +- CometProject
+                                                   :     :                 :              :     :                    +- CometFilter
+                                                   :     :                 :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                   :     :                 :              :     +- CometBroadcastExchange
+                                                   :     :                 :              :        +- CometBroadcastHashJoin
+                                                   :     :                 :              :           :- CometFilter
+                                                   :     :                 :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                                   :     :                 :              :           +- CometBroadcastExchange
+                                                   :     :                 :              :              +- CometProject
+                                                   :     :                 :              :                 +- CometBroadcastHashJoin
+                                                   :     :                 :              :                    :- CometProject
+                                                   :     :                 :              :                    :  +- CometBroadcastHashJoin
+                                                   :     :                 :              :                    :     :- CometFilter
+                                                   :     :                 :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                                                   :     :                 :              :                    :     :        +- ReusedSubquery
+                                                   :     :                 :              :                    :     +- CometBroadcastExchange
+                                                   :     :                 :              :                    :        +- CometFilter
+                                                   :     :                 :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                                   :     :                 :              :                    +- CometBroadcastExchange
+                                                   :     :                 :              :                       +- CometProject
+                                                   :     :                 :              :                          +- CometFilter
+                                                   :     :                 :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                   :     :                 :              +- CometBroadcastExchange
+                                                   :     :                 :                 +- CometProject
+                                                   :     :                 :                    +- CometFilter
+                                                   :     :                 :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                   :     :                 +- CometBroadcastExchange
+                                                   :     :                    +- CometProject
+                                                   :     :                       +- CometBroadcastHashJoin
+                                                   :     :                          :- CometProject
+                                                   :     :                          :  +- CometBroadcastHashJoin
+                                                   :     :                          :     :- CometFilter
+                                                   :     :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                                   :     :                          :     :        +- ReusedSubquery
+                                                   :     :                          :     +- CometBroadcastExchange
+                                                   :     :                          :        +- CometFilter
+                                                   :     :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                                   :     :                          +- CometBroadcastExchange
+                                                   :     :                             +- CometProject
+                                                   :     :                                +- CometFilter
+                                                   :     :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                   :     +- CometBroadcastExchange
+                                                   :        +- CometBroadcastHashJoin
+                                                   :           :- CometFilter
+                                                   :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                                   :           +- CometBroadcastExchange
+                                                   :              +- CometProject
+                                                   :                 +- CometBroadcastHashJoin
+                                                   :                    :- CometFilter
+                                                   :                    :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                                   :                    +- CometBroadcastExchange
+                                                   :                       +- CometBroadcastHashJoin
+                                                   :                          :- CometHashAggregate
+                                                   :                          :  +- CometExchange
+                                                   :                          :     +- CometHashAggregate
+                                                   :                          :        +- CometProject
+                                                   :                          :           +- CometBroadcastHashJoin
+                                                   :                          :              :- CometProject
+                                                   :                          :              :  +- CometBroadcastHashJoin
+                                                   :                          :              :     :- CometFilter
+                                                   :                          :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                                   :                          :              :     :        +- SubqueryBroadcast
+                                                   :                          :              :     :           +- BroadcastExchange
+                                                   :                          :              :     :              +- CometNativeColumnarToRow
+                                                   :                          :              :     :                 +- CometProject
+                                                   :                          :              :     :                    +- CometFilter
+                                                   :                          :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                   :                          :              :     +- CometBroadcastExchange
+                                                   :                          :              :        +- CometBroadcastHashJoin
+                                                   :                          :              :           :- CometFilter
+                                                   :                          :              :           :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                                   :                          :              :           +- CometBroadcastExchange
+                                                   :                          :              :              +- CometProject
+                                                   :                          :              :                 +- CometBroadcastHashJoin
+                                                   :                          :              :                    :- CometProject
+                                                   :                          :              :                    :  +- CometBroadcastHashJoin
+                                                   :                          :              :                    :     :- CometFilter
+                                                   :                          :              :                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                                                   :                          :              :                    :     :        +- ReusedSubquery
+                                                   :                          :              :                    :     +- CometBroadcastExchange
+                                                   :                          :              :                    :        +- CometFilter
+                                                   :                          :              :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                                   :                          :              :                    +- CometBroadcastExchange
+                                                   :                          :              :                       +- CometProject
+                                                   :                          :              :                          +- CometFilter
+                                                   :                          :              :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                   :                          :              +- CometBroadcastExchange
+                                                   :                          :                 +- CometProject
+                                                   :                          :                    +- CometFilter
+                                                   :                          :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                   :                          +- CometBroadcastExchange
+                                                   :                             +- CometProject
+                                                   :                                +- CometBroadcastHashJoin
+                                                   :                                   :- CometProject
+                                                   :                                   :  +- CometBroadcastHashJoin
+                                                   :                                   :     :- CometFilter
+                                                   :                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                                   :                                   :     :        +- ReusedSubquery
+                                                   :                                   :     +- CometBroadcastExchange
+                                                   :                                   :        +- CometFilter
+                                                   :                                   :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                                   :                                   +- CometBroadcastExchange
+                                                   :                                      +- CometProject
+                                                   :                                         +- CometFilter
+                                                   :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                   +- CometBroadcastExchange
+                                                      +- CometProject
+                                                         +- CometFilter
+                                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 2010 out of 2169 eligible operators (92%). Final plan contains 38 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q18a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q18a.native_datafusion/extended.txt
@@ -1,0 +1,213 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometUnion
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometProject
+      :           +- CometBroadcastHashJoin
+      :              :- CometProject
+      :              :  +- CometBroadcastHashJoin
+      :              :     :- CometProject
+      :              :     :  +- CometBroadcastHashJoin
+      :              :     :     :- CometProject
+      :              :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :- CometProject
+      :              :     :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :     :- CometProject
+      :              :     :     :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :     :     :- CometFilter
+      :              :     :     :     :     :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+      :              :     :     :     :     :     :        +- CometSubqueryBroadcast
+      :              :     :     :     :     :     :           +- CometBroadcastExchange
+      :              :     :     :     :     :     :              +- CometProject
+      :              :     :     :     :     :     :                 +- CometFilter
+      :              :     :     :     :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+      :              :     :     :     :     :     +- CometBroadcastExchange
+      :              :     :     :     :     :        +- CometProject
+      :              :     :     :     :     :           +- CometFilter
+      :              :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+      :              :     :     :     :     +- CometBroadcastExchange
+      :              :     :     :     :        +- CometProject
+      :              :     :     :     :           +- CometFilter
+      :              :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer
+      :              :     :     :     +- CometBroadcastExchange
+      :              :     :     :        +- CometFilter
+      :              :     :     :           +- CometNativeScan parquet spark_catalog.default.customer_demographics
+      :              :     :     +- CometBroadcastExchange
+      :              :     :        +- CometProject
+      :              :     :           +- CometFilter
+      :              :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+      :              :     +- CometBroadcastExchange
+      :              :        +- CometProject
+      :              :           +- CometFilter
+      :              :              +- CometNativeScan parquet spark_catalog.default.date_dim
+      :              +- CometBroadcastExchange
+      :                 +- CometProject
+      :                    +- CometFilter
+      :                       +- CometNativeScan parquet spark_catalog.default.item
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometProject
+      :           +- CometBroadcastHashJoin
+      :              :- CometProject
+      :              :  +- CometBroadcastHashJoin
+      :              :     :- CometProject
+      :              :     :  +- CometBroadcastHashJoin
+      :              :     :     :- CometProject
+      :              :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :- CometProject
+      :              :     :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :     :- CometProject
+      :              :     :     :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :     :     :- CometFilter
+      :              :     :     :     :     :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+      :              :     :     :     :     :     :        +- ReusedSubquery
+      :              :     :     :     :     :     +- CometBroadcastExchange
+      :              :     :     :     :     :        +- CometProject
+      :              :     :     :     :     :           +- CometFilter
+      :              :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+      :              :     :     :     :     +- CometBroadcastExchange
+      :              :     :     :     :        +- CometProject
+      :              :     :     :     :           +- CometFilter
+      :              :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer
+      :              :     :     :     +- CometBroadcastExchange
+      :              :     :     :        +- CometFilter
+      :              :     :     :           +- CometNativeScan parquet spark_catalog.default.customer_demographics
+      :              :     :     +- CometBroadcastExchange
+      :              :     :        +- CometProject
+      :              :     :           +- CometFilter
+      :              :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+      :              :     +- CometBroadcastExchange
+      :              :        +- CometProject
+      :              :           +- CometFilter
+      :              :              +- CometNativeScan parquet spark_catalog.default.date_dim
+      :              +- CometBroadcastExchange
+      :                 +- CometProject
+      :                    +- CometFilter
+      :                       +- CometNativeScan parquet spark_catalog.default.item
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometProject
+      :           +- CometBroadcastHashJoin
+      :              :- CometProject
+      :              :  +- CometBroadcastHashJoin
+      :              :     :- CometProject
+      :              :     :  +- CometBroadcastHashJoin
+      :              :     :     :- CometProject
+      :              :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :- CometProject
+      :              :     :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :     :- CometProject
+      :              :     :     :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :     :     :- CometFilter
+      :              :     :     :     :     :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+      :              :     :     :     :     :     :        +- ReusedSubquery
+      :              :     :     :     :     :     +- CometBroadcastExchange
+      :              :     :     :     :     :        +- CometProject
+      :              :     :     :     :     :           +- CometFilter
+      :              :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+      :              :     :     :     :     +- CometBroadcastExchange
+      :              :     :     :     :        +- CometProject
+      :              :     :     :     :           +- CometFilter
+      :              :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer
+      :              :     :     :     +- CometBroadcastExchange
+      :              :     :     :        +- CometFilter
+      :              :     :     :           +- CometNativeScan parquet spark_catalog.default.customer_demographics
+      :              :     :     +- CometBroadcastExchange
+      :              :     :        +- CometProject
+      :              :     :           +- CometFilter
+      :              :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+      :              :     +- CometBroadcastExchange
+      :              :        +- CometProject
+      :              :           +- CometFilter
+      :              :              +- CometNativeScan parquet spark_catalog.default.date_dim
+      :              +- CometBroadcastExchange
+      :                 +- CometProject
+      :                    +- CometFilter
+      :                       +- CometNativeScan parquet spark_catalog.default.item
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometProject
+      :           +- CometBroadcastHashJoin
+      :              :- CometProject
+      :              :  +- CometBroadcastHashJoin
+      :              :     :- CometProject
+      :              :     :  +- CometBroadcastHashJoin
+      :              :     :     :- CometProject
+      :              :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :- CometProject
+      :              :     :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :     :- CometProject
+      :              :     :     :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :     :     :- CometFilter
+      :              :     :     :     :     :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+      :              :     :     :     :     :     :        +- ReusedSubquery
+      :              :     :     :     :     :     +- CometBroadcastExchange
+      :              :     :     :     :     :        +- CometProject
+      :              :     :     :     :     :           +- CometFilter
+      :              :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+      :              :     :     :     :     +- CometBroadcastExchange
+      :              :     :     :     :        +- CometProject
+      :              :     :     :     :           +- CometFilter
+      :              :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer
+      :              :     :     :     +- CometBroadcastExchange
+      :              :     :     :        +- CometFilter
+      :              :     :     :           +- CometNativeScan parquet spark_catalog.default.customer_demographics
+      :              :     :     +- CometBroadcastExchange
+      :              :     :        +- CometProject
+      :              :     :           +- CometFilter
+      :              :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+      :              :     +- CometBroadcastExchange
+      :              :        +- CometProject
+      :              :           +- CometFilter
+      :              :              +- CometNativeScan parquet spark_catalog.default.date_dim
+      :              +- CometBroadcastExchange
+      :                 +- CometProject
+      :                    +- CometFilter
+      :                       +- CometNativeScan parquet spark_catalog.default.item
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometProject
+                     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :- CometProject
+                     :     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :     :- CometProject
+                     :     :     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :     :     :- CometFilter
+                     :     :     :     :     :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                     :     :     :     :     :     :        +- ReusedSubquery
+                     :     :     :     :     :     +- CometBroadcastExchange
+                     :     :     :     :     :        +- CometProject
+                     :     :     :     :     :           +- CometFilter
+                     :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+                     :     :     :     :     +- CometBroadcastExchange
+                     :     :     :     :        +- CometProject
+                     :     :     :     :           +- CometFilter
+                     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer
+                     :     :     :     +- CometBroadcastExchange
+                     :     :     :        +- CometFilter
+                     :     :     :           +- CometNativeScan parquet spark_catalog.default.customer_demographics
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometProject
+                     :     :           +- CometFilter
+                     :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                     +- CometBroadcastExchange
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 205 out of 210 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q18a.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q18a.native_iceberg_compat/extended.txt
@@ -1,0 +1,214 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometUnion
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometProject
+      :           +- CometBroadcastHashJoin
+      :              :- CometProject
+      :              :  +- CometBroadcastHashJoin
+      :              :     :- CometProject
+      :              :     :  +- CometBroadcastHashJoin
+      :              :     :     :- CometProject
+      :              :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :- CometProject
+      :              :     :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :     :- CometProject
+      :              :     :     :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :     :     :- CometFilter
+      :              :     :     :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+      :              :     :     :     :     :     :        +- SubqueryBroadcast
+      :              :     :     :     :     :     :           +- BroadcastExchange
+      :              :     :     :     :     :     :              +- CometNativeColumnarToRow
+      :              :     :     :     :     :     :                 +- CometProject
+      :              :     :     :     :     :     :                    +- CometFilter
+      :              :     :     :     :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :              :     :     :     :     :     +- CometBroadcastExchange
+      :              :     :     :     :     :        +- CometProject
+      :              :     :     :     :     :           +- CometFilter
+      :              :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+      :              :     :     :     :     +- CometBroadcastExchange
+      :              :     :     :     :        +- CometProject
+      :              :     :     :     :           +- CometFilter
+      :              :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+      :              :     :     :     +- CometBroadcastExchange
+      :              :     :     :        +- CometFilter
+      :              :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+      :              :     :     +- CometBroadcastExchange
+      :              :     :        +- CometProject
+      :              :     :           +- CometFilter
+      :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+      :              :     +- CometBroadcastExchange
+      :              :        +- CometProject
+      :              :           +- CometFilter
+      :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :              +- CometBroadcastExchange
+      :                 +- CometProject
+      :                    +- CometFilter
+      :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometProject
+      :           +- CometBroadcastHashJoin
+      :              :- CometProject
+      :              :  +- CometBroadcastHashJoin
+      :              :     :- CometProject
+      :              :     :  +- CometBroadcastHashJoin
+      :              :     :     :- CometProject
+      :              :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :- CometProject
+      :              :     :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :     :- CometProject
+      :              :     :     :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :     :     :- CometFilter
+      :              :     :     :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+      :              :     :     :     :     :     :        +- ReusedSubquery
+      :              :     :     :     :     :     +- CometBroadcastExchange
+      :              :     :     :     :     :        +- CometProject
+      :              :     :     :     :     :           +- CometFilter
+      :              :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+      :              :     :     :     :     +- CometBroadcastExchange
+      :              :     :     :     :        +- CometProject
+      :              :     :     :     :           +- CometFilter
+      :              :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+      :              :     :     :     +- CometBroadcastExchange
+      :              :     :     :        +- CometFilter
+      :              :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+      :              :     :     +- CometBroadcastExchange
+      :              :     :        +- CometProject
+      :              :     :           +- CometFilter
+      :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+      :              :     +- CometBroadcastExchange
+      :              :        +- CometProject
+      :              :           +- CometFilter
+      :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :              +- CometBroadcastExchange
+      :                 +- CometProject
+      :                    +- CometFilter
+      :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometProject
+      :           +- CometBroadcastHashJoin
+      :              :- CometProject
+      :              :  +- CometBroadcastHashJoin
+      :              :     :- CometProject
+      :              :     :  +- CometBroadcastHashJoin
+      :              :     :     :- CometProject
+      :              :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :- CometProject
+      :              :     :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :     :- CometProject
+      :              :     :     :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :     :     :- CometFilter
+      :              :     :     :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+      :              :     :     :     :     :     :        +- ReusedSubquery
+      :              :     :     :     :     :     +- CometBroadcastExchange
+      :              :     :     :     :     :        +- CometProject
+      :              :     :     :     :     :           +- CometFilter
+      :              :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+      :              :     :     :     :     +- CometBroadcastExchange
+      :              :     :     :     :        +- CometProject
+      :              :     :     :     :           +- CometFilter
+      :              :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+      :              :     :     :     +- CometBroadcastExchange
+      :              :     :     :        +- CometFilter
+      :              :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+      :              :     :     +- CometBroadcastExchange
+      :              :     :        +- CometProject
+      :              :     :           +- CometFilter
+      :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+      :              :     +- CometBroadcastExchange
+      :              :        +- CometProject
+      :              :           +- CometFilter
+      :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :              +- CometBroadcastExchange
+      :                 +- CometProject
+      :                    +- CometFilter
+      :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometProject
+      :           +- CometBroadcastHashJoin
+      :              :- CometProject
+      :              :  +- CometBroadcastHashJoin
+      :              :     :- CometProject
+      :              :     :  +- CometBroadcastHashJoin
+      :              :     :     :- CometProject
+      :              :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :- CometProject
+      :              :     :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :     :- CometProject
+      :              :     :     :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :     :     :- CometFilter
+      :              :     :     :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+      :              :     :     :     :     :     :        +- ReusedSubquery
+      :              :     :     :     :     :     +- CometBroadcastExchange
+      :              :     :     :     :     :        +- CometProject
+      :              :     :     :     :     :           +- CometFilter
+      :              :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+      :              :     :     :     :     +- CometBroadcastExchange
+      :              :     :     :     :        +- CometProject
+      :              :     :     :     :           +- CometFilter
+      :              :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+      :              :     :     :     +- CometBroadcastExchange
+      :              :     :     :        +- CometFilter
+      :              :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+      :              :     :     +- CometBroadcastExchange
+      :              :     :        +- CometProject
+      :              :     :           +- CometFilter
+      :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+      :              :     +- CometBroadcastExchange
+      :              :        +- CometProject
+      :              :           +- CometFilter
+      :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :              +- CometBroadcastExchange
+      :                 +- CometProject
+      :                    +- CometFilter
+      :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometProject
+                     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :- CometProject
+                     :     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :     :- CometProject
+                     :     :     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :     :     :- CometFilter
+                     :     :     :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                     :     :     :     :     :     :        +- ReusedSubquery
+                     :     :     :     :     :     +- CometBroadcastExchange
+                     :     :     :     :     :        +- CometProject
+                     :     :     :     :     :           +- CometFilter
+                     :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+                     :     :     :     :     +- CometBroadcastExchange
+                     :     :     :     :        +- CometProject
+                     :     :     :     :           +- CometFilter
+                     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                     :     :     :     +- CometBroadcastExchange
+                     :     :     :        +- CometFilter
+                     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometProject
+                     :     :           +- CometFilter
+                     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     +- CometBroadcastExchange
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 204 out of 210 eligible operators (97%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q20.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q20.native_datafusion/extended.txt
@@ -1,0 +1,30 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometBroadcastHashJoin
+                              :     :- CometFilter
+                              :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                              :     :        +- CometSubqueryBroadcast
+                              :     :           +- CometBroadcastExchange
+                              :     :              +- CometProject
+                              :     :                 +- CometFilter
+                              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :     +- CometBroadcastExchange
+                              :        +- CometProject
+                              :           +- CometFilter
+                              :              +- CometNativeScan parquet spark_catalog.default.item
+                              +- CometBroadcastExchange
+                                 +- CometProject
+                                    +- CometFilter
+                                       +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 23 out of 27 eligible operators (85%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q20.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q20.native_iceberg_compat/extended.txt
@@ -1,0 +1,31 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometBroadcastHashJoin
+                              :     :- CometFilter
+                              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                              :     :        +- SubqueryBroadcast
+                              :     :           +- BroadcastExchange
+                              :     :              +- CometNativeColumnarToRow
+                              :     :                 +- CometProject
+                              :     :                    +- CometFilter
+                              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :     +- CometBroadcastExchange
+                              :        +- CometProject
+                              :           +- CometFilter
+                              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                              +- CometBroadcastExchange
+                                 +- CometProject
+                                    +- CometFilter
+                                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 22 out of 27 eligible operators (81%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q22.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q22.native_datafusion/extended.txt
@@ -1,0 +1,32 @@
+TakeOrderedAndProject
++- HashAggregate
+   +- Exchange
+      +- HashAggregate
+         +- Expand
+            +- Project
+               +-  BroadcastNestedLoopJoin [COMET: BroadcastNestedLoopJoin is not supported]
+                  :- CometNativeColumnarToRow
+                  :  +- CometProject
+                  :     +- CometBroadcastHashJoin
+                  :        :- CometProject
+                  :        :  +- CometBroadcastHashJoin
+                  :        :     :- CometFilter
+                  :        :     :  +- CometNativeScan parquet spark_catalog.default.inventory
+                  :        :     :        +- CometSubqueryBroadcast
+                  :        :     :           +- CometBroadcastExchange
+                  :        :     :              +- CometProject
+                  :        :     :                 +- CometFilter
+                  :        :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :        :     +- CometBroadcastExchange
+                  :        :        +- CometProject
+                  :        :           +- CometFilter
+                  :        :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :        +- CometBroadcastExchange
+                  :           +- CometProject
+                  :              +- CometFilter
+                  :                 +- CometNativeScan parquet spark_catalog.default.item
+                  +- BroadcastExchange
+                     +- CometNativeColumnarToRow
+                        +- CometNativeScan parquet spark_catalog.default.warehouse
+
+Comet accelerated 19 out of 28 eligible operators (67%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q22.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q22.native_iceberg_compat/extended.txt
@@ -1,0 +1,33 @@
+TakeOrderedAndProject
++- HashAggregate
+   +- Exchange
+      +- HashAggregate
+         +- Expand
+            +- Project
+               +-  BroadcastNestedLoopJoin [COMET: BroadcastNestedLoopJoin is not supported]
+                  :- CometNativeColumnarToRow
+                  :  +- CometProject
+                  :     +- CometBroadcastHashJoin
+                  :        :- CometProject
+                  :        :  +- CometBroadcastHashJoin
+                  :        :     :- CometFilter
+                  :        :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.inventory
+                  :        :     :        +- SubqueryBroadcast
+                  :        :     :           +- BroadcastExchange
+                  :        :     :              +- CometNativeColumnarToRow
+                  :        :     :                 +- CometProject
+                  :        :     :                    +- CometFilter
+                  :        :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :        :     +- CometBroadcastExchange
+                  :        :        +- CometProject
+                  :        :           +- CometFilter
+                  :        :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :        +- CometBroadcastExchange
+                  :           +- CometProject
+                  :              +- CometFilter
+                  :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  +- BroadcastExchange
+                     +- CometNativeColumnarToRow
+                        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.warehouse
+
+Comet accelerated 18 out of 28 eligible operators (64%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q22a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q22a.native_datafusion/extended.txt
@@ -1,0 +1,154 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometUnion
+      :- CometHashAggregate
+      :  +- CometHashAggregate
+      :     +- CometHashAggregate
+      :        +- CometExchange
+      :           +- CometHashAggregate
+      :              +- CometProject
+      :                 +- CometBroadcastHashJoin
+      :                    :- CometProject
+      :                    :  +- CometBroadcastHashJoin
+      :                    :     :- CometProject
+      :                    :     :  +- CometBroadcastHashJoin
+      :                    :     :     :- CometFilter
+      :                    :     :     :  +- CometNativeScan parquet spark_catalog.default.inventory
+      :                    :     :     :        +- CometSubqueryBroadcast
+      :                    :     :     :           +- CometBroadcastExchange
+      :                    :     :     :              +- CometProject
+      :                    :     :     :                 +- CometFilter
+      :                    :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                    :     :     +- CometBroadcastExchange
+      :                    :     :        +- CometProject
+      :                    :     :           +- CometFilter
+      :                    :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                    :     +- CometBroadcastExchange
+      :                    :        +- CometProject
+      :                    :           +- CometFilter
+      :                    :              +- CometNativeScan parquet spark_catalog.default.item
+      :                    +- CometBroadcastExchange
+      :                       +- CometFilter
+      :                          +- CometNativeScan parquet spark_catalog.default.warehouse
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometHashAggregate
+      :           +- CometExchange
+      :              +- CometHashAggregate
+      :                 +- CometProject
+      :                    +- CometBroadcastHashJoin
+      :                       :- CometProject
+      :                       :  +- CometBroadcastHashJoin
+      :                       :     :- CometProject
+      :                       :     :  +- CometBroadcastHashJoin
+      :                       :     :     :- CometFilter
+      :                       :     :     :  +- CometNativeScan parquet spark_catalog.default.inventory
+      :                       :     :     :        +- CometSubqueryBroadcast
+      :                       :     :     :           +- CometBroadcastExchange
+      :                       :     :     :              +- CometProject
+      :                       :     :     :                 +- CometFilter
+      :                       :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                       :     :     +- CometBroadcastExchange
+      :                       :     :        +- CometProject
+      :                       :     :           +- CometFilter
+      :                       :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                       :     +- CometBroadcastExchange
+      :                       :        +- CometProject
+      :                       :           +- CometFilter
+      :                       :              +- CometNativeScan parquet spark_catalog.default.item
+      :                       +- CometBroadcastExchange
+      :                          +- CometFilter
+      :                             +- CometNativeScan parquet spark_catalog.default.warehouse
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometHashAggregate
+      :           +- CometExchange
+      :              +- CometHashAggregate
+      :                 +- CometProject
+      :                    +- CometBroadcastHashJoin
+      :                       :- CometProject
+      :                       :  +- CometBroadcastHashJoin
+      :                       :     :- CometProject
+      :                       :     :  +- CometBroadcastHashJoin
+      :                       :     :     :- CometFilter
+      :                       :     :     :  +- CometNativeScan parquet spark_catalog.default.inventory
+      :                       :     :     :        +- CometSubqueryBroadcast
+      :                       :     :     :           +- CometBroadcastExchange
+      :                       :     :     :              +- CometProject
+      :                       :     :     :                 +- CometFilter
+      :                       :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                       :     :     +- CometBroadcastExchange
+      :                       :     :        +- CometProject
+      :                       :     :           +- CometFilter
+      :                       :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                       :     +- CometBroadcastExchange
+      :                       :        +- CometProject
+      :                       :           +- CometFilter
+      :                       :              +- CometNativeScan parquet spark_catalog.default.item
+      :                       +- CometBroadcastExchange
+      :                          +- CometFilter
+      :                             +- CometNativeScan parquet spark_catalog.default.warehouse
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometHashAggregate
+      :           +- CometExchange
+      :              +- CometHashAggregate
+      :                 +- CometProject
+      :                    +- CometBroadcastHashJoin
+      :                       :- CometProject
+      :                       :  +- CometBroadcastHashJoin
+      :                       :     :- CometProject
+      :                       :     :  +- CometBroadcastHashJoin
+      :                       :     :     :- CometFilter
+      :                       :     :     :  +- CometNativeScan parquet spark_catalog.default.inventory
+      :                       :     :     :        +- CometSubqueryBroadcast
+      :                       :     :     :           +- CometBroadcastExchange
+      :                       :     :     :              +- CometProject
+      :                       :     :     :                 +- CometFilter
+      :                       :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                       :     :     +- CometBroadcastExchange
+      :                       :     :        +- CometProject
+      :                       :     :           +- CometFilter
+      :                       :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                       :     +- CometBroadcastExchange
+      :                       :        +- CometProject
+      :                       :           +- CometFilter
+      :                       :              +- CometNativeScan parquet spark_catalog.default.item
+      :                       +- CometBroadcastExchange
+      :                          +- CometFilter
+      :                             +- CometNativeScan parquet spark_catalog.default.warehouse
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometBroadcastHashJoin
+                              :     :- CometProject
+                              :     :  +- CometBroadcastHashJoin
+                              :     :     :- CometFilter
+                              :     :     :  +- CometNativeScan parquet spark_catalog.default.inventory
+                              :     :     :        +- CometSubqueryBroadcast
+                              :     :     :           +- CometBroadcastExchange
+                              :     :     :              +- CometProject
+                              :     :     :                 +- CometFilter
+                              :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :     :     +- CometBroadcastExchange
+                              :     :        +- CometProject
+                              :     :           +- CometFilter
+                              :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :     +- CometBroadcastExchange
+                              :        +- CometProject
+                              :           +- CometFilter
+                              :              +- CometNativeScan parquet spark_catalog.default.item
+                              +- CometBroadcastExchange
+                                 +- CometFilter
+                                    +- CometNativeScan parquet spark_catalog.default.warehouse
+
+Comet accelerated 146 out of 151 eligible operators (96%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q22a.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q22a.native_iceberg_compat/extended.txt
@@ -1,0 +1,159 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometUnion
+      :- CometHashAggregate
+      :  +- CometHashAggregate
+      :     +- CometHashAggregate
+      :        +- CometExchange
+      :           +- CometHashAggregate
+      :              +- CometProject
+      :                 +- CometBroadcastHashJoin
+      :                    :- CometProject
+      :                    :  +- CometBroadcastHashJoin
+      :                    :     :- CometProject
+      :                    :     :  +- CometBroadcastHashJoin
+      :                    :     :     :- CometFilter
+      :                    :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.inventory
+      :                    :     :     :        +- SubqueryBroadcast
+      :                    :     :     :           +- BroadcastExchange
+      :                    :     :     :              +- CometNativeColumnarToRow
+      :                    :     :     :                 +- CometProject
+      :                    :     :     :                    +- CometFilter
+      :                    :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                    :     :     +- CometBroadcastExchange
+      :                    :     :        +- CometProject
+      :                    :     :           +- CometFilter
+      :                    :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                    :     +- CometBroadcastExchange
+      :                    :        +- CometProject
+      :                    :           +- CometFilter
+      :                    :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                    +- CometBroadcastExchange
+      :                       +- CometFilter
+      :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.warehouse
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometHashAggregate
+      :           +- CometExchange
+      :              +- CometHashAggregate
+      :                 +- CometProject
+      :                    +- CometBroadcastHashJoin
+      :                       :- CometProject
+      :                       :  +- CometBroadcastHashJoin
+      :                       :     :- CometProject
+      :                       :     :  +- CometBroadcastHashJoin
+      :                       :     :     :- CometFilter
+      :                       :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.inventory
+      :                       :     :     :        +- SubqueryBroadcast
+      :                       :     :     :           +- BroadcastExchange
+      :                       :     :     :              +- CometNativeColumnarToRow
+      :                       :     :     :                 +- CometProject
+      :                       :     :     :                    +- CometFilter
+      :                       :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                       :     :     +- CometBroadcastExchange
+      :                       :     :        +- CometProject
+      :                       :     :           +- CometFilter
+      :                       :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                       :     +- CometBroadcastExchange
+      :                       :        +- CometProject
+      :                       :           +- CometFilter
+      :                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                       +- CometBroadcastExchange
+      :                          +- CometFilter
+      :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.warehouse
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometHashAggregate
+      :           +- CometExchange
+      :              +- CometHashAggregate
+      :                 +- CometProject
+      :                    +- CometBroadcastHashJoin
+      :                       :- CometProject
+      :                       :  +- CometBroadcastHashJoin
+      :                       :     :- CometProject
+      :                       :     :  +- CometBroadcastHashJoin
+      :                       :     :     :- CometFilter
+      :                       :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.inventory
+      :                       :     :     :        +- SubqueryBroadcast
+      :                       :     :     :           +- BroadcastExchange
+      :                       :     :     :              +- CometNativeColumnarToRow
+      :                       :     :     :                 +- CometProject
+      :                       :     :     :                    +- CometFilter
+      :                       :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                       :     :     +- CometBroadcastExchange
+      :                       :     :        +- CometProject
+      :                       :     :           +- CometFilter
+      :                       :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                       :     +- CometBroadcastExchange
+      :                       :        +- CometProject
+      :                       :           +- CometFilter
+      :                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                       +- CometBroadcastExchange
+      :                          +- CometFilter
+      :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.warehouse
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometHashAggregate
+      :           +- CometExchange
+      :              +- CometHashAggregate
+      :                 +- CometProject
+      :                    +- CometBroadcastHashJoin
+      :                       :- CometProject
+      :                       :  +- CometBroadcastHashJoin
+      :                       :     :- CometProject
+      :                       :     :  +- CometBroadcastHashJoin
+      :                       :     :     :- CometFilter
+      :                       :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.inventory
+      :                       :     :     :        +- SubqueryBroadcast
+      :                       :     :     :           +- BroadcastExchange
+      :                       :     :     :              +- CometNativeColumnarToRow
+      :                       :     :     :                 +- CometProject
+      :                       :     :     :                    +- CometFilter
+      :                       :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                       :     :     +- CometBroadcastExchange
+      :                       :     :        +- CometProject
+      :                       :     :           +- CometFilter
+      :                       :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                       :     +- CometBroadcastExchange
+      :                       :        +- CometProject
+      :                       :           +- CometFilter
+      :                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                       +- CometBroadcastExchange
+      :                          +- CometFilter
+      :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.warehouse
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometBroadcastHashJoin
+                              :     :- CometProject
+                              :     :  +- CometBroadcastHashJoin
+                              :     :     :- CometFilter
+                              :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.inventory
+                              :     :     :        +- SubqueryBroadcast
+                              :     :     :           +- BroadcastExchange
+                              :     :     :              +- CometNativeColumnarToRow
+                              :     :     :                 +- CometProject
+                              :     :     :                    +- CometFilter
+                              :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :     :     +- CometBroadcastExchange
+                              :     :        +- CometProject
+                              :     :           +- CometFilter
+                              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :     +- CometBroadcastExchange
+                              :        +- CometProject
+                              :           +- CometFilter
+                              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                              +- CometBroadcastExchange
+                                 +- CometFilter
+                                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.warehouse
+
+Comet accelerated 141 out of 151 eligible operators (93%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q24.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q24.native_datafusion/extended.txt
@@ -1,0 +1,95 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometColumnarExchange
+      +- Filter
+         :  +- Subquery
+         :     +- HashAggregate
+         :        +- Exchange
+         :           +- HashAggregate
+         :              +- HashAggregate
+         :                 +- Exchange
+         :                    +- HashAggregate
+         :                       +- Project
+         :                          +-  BroadcastHashJoin [COMET: Comet is not compatible with Spark for case conversion in locale-specific cases. Set spark.comet.caseConversion.enabled=true to enable it anyway.]
+         :                             :- CometNativeColumnarToRow
+         :                             :  +- CometProject
+         :                             :     +- CometBroadcastHashJoin
+         :                             :        :- CometProject
+         :                             :        :  +- CometBroadcastHashJoin
+         :                             :        :     :- CometProject
+         :                             :        :     :  +- CometBroadcastHashJoin
+         :                             :        :     :     :- CometProject
+         :                             :        :     :     :  +- CometSortMergeJoin
+         :                             :        :     :     :     :- CometSort
+         :                             :        :     :     :     :  +- CometExchange
+         :                             :        :     :     :     :     +- CometProject
+         :                             :        :     :     :     :        +- CometFilter
+         :                             :        :     :     :     :           +- CometNativeScan parquet spark_catalog.default.store_sales
+         :                             :        :     :     :     +- CometSort
+         :                             :        :     :     :        +- CometExchange
+         :                             :        :     :     :           +- CometProject
+         :                             :        :     :     :              +- CometFilter
+         :                             :        :     :     :                 +- CometNativeScan parquet spark_catalog.default.store_returns
+         :                             :        :     :     +- CometBroadcastExchange
+         :                             :        :     :        +- CometProject
+         :                             :        :     :           +- CometFilter
+         :                             :        :     :              +- CometNativeScan parquet spark_catalog.default.store
+         :                             :        :     +- CometBroadcastExchange
+         :                             :        :        +- CometProject
+         :                             :        :           +- CometFilter
+         :                             :        :              +- CometNativeScan parquet spark_catalog.default.item
+         :                             :        +- CometBroadcastExchange
+         :                             :           +- CometProject
+         :                             :              +- CometFilter
+         :                             :                 +- CometNativeScan parquet spark_catalog.default.customer
+         :                             +- BroadcastExchange
+         :                                +- CometNativeColumnarToRow
+         :                                   +- CometProject
+         :                                      +- CometFilter
+         :                                         +- CometNativeScan parquet spark_catalog.default.customer_address
+         +- HashAggregate
+            +- Exchange
+               +- HashAggregate
+                  +- HashAggregate
+                     +- Exchange
+                        +- HashAggregate
+                           +- Project
+                              +-  BroadcastHashJoin [COMET: Comet is not compatible with Spark for case conversion in locale-specific cases. Set spark.comet.caseConversion.enabled=true to enable it anyway.]
+                                 :- CometNativeColumnarToRow
+                                 :  +- CometProject
+                                 :     +- CometBroadcastHashJoin
+                                 :        :- CometProject
+                                 :        :  +- CometBroadcastHashJoin
+                                 :        :     :- CometProject
+                                 :        :     :  +- CometBroadcastHashJoin
+                                 :        :     :     :- CometProject
+                                 :        :     :     :  +- CometSortMergeJoin
+                                 :        :     :     :     :- CometSort
+                                 :        :     :     :     :  +- CometExchange
+                                 :        :     :     :     :     +- CometProject
+                                 :        :     :     :     :        +- CometFilter
+                                 :        :     :     :     :           +- CometNativeScan parquet spark_catalog.default.store_sales
+                                 :        :     :     :     +- CometSort
+                                 :        :     :     :        +- CometExchange
+                                 :        :     :     :           +- CometProject
+                                 :        :     :     :              +- CometFilter
+                                 :        :     :     :                 +- CometNativeScan parquet spark_catalog.default.store_returns
+                                 :        :     :     +- CometBroadcastExchange
+                                 :        :     :        +- CometProject
+                                 :        :     :           +- CometFilter
+                                 :        :     :              +- CometNativeScan parquet spark_catalog.default.store
+                                 :        :     +- CometBroadcastExchange
+                                 :        :        +- CometProject
+                                 :        :           +- CometFilter
+                                 :        :              +- CometNativeScan parquet spark_catalog.default.item
+                                 :        +- CometBroadcastExchange
+                                 :           +- CometProject
+                                 :              +- CometFilter
+                                 :                 +- CometNativeScan parquet spark_catalog.default.customer
+                                 +- BroadcastExchange
+                                    +- CometNativeColumnarToRow
+                                       +- CometProject
+                                          +- CometFilter
+                                             +- CometNativeScan parquet spark_catalog.default.customer_address
+
+Comet accelerated 68 out of 88 eligible operators (77%). Final plan contains 5 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q24.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q24.native_iceberg_compat/extended.txt
@@ -1,0 +1,95 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometColumnarExchange
+      +- Filter
+         :  +- Subquery
+         :     +- HashAggregate
+         :        +- Exchange
+         :           +- HashAggregate
+         :              +- HashAggregate
+         :                 +- Exchange
+         :                    +- HashAggregate
+         :                       +- Project
+         :                          +-  BroadcastHashJoin [COMET: Comet is not compatible with Spark for case conversion in locale-specific cases. Set spark.comet.caseConversion.enabled=true to enable it anyway.]
+         :                             :- CometNativeColumnarToRow
+         :                             :  +- CometProject
+         :                             :     +- CometBroadcastHashJoin
+         :                             :        :- CometProject
+         :                             :        :  +- CometBroadcastHashJoin
+         :                             :        :     :- CometProject
+         :                             :        :     :  +- CometBroadcastHashJoin
+         :                             :        :     :     :- CometProject
+         :                             :        :     :     :  +- CometSortMergeJoin
+         :                             :        :     :     :     :- CometSort
+         :                             :        :     :     :     :  +- CometExchange
+         :                             :        :     :     :     :     +- CometProject
+         :                             :        :     :     :     :        +- CometFilter
+         :                             :        :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :                             :        :     :     :     +- CometSort
+         :                             :        :     :     :        +- CometExchange
+         :                             :        :     :     :           +- CometProject
+         :                             :        :     :     :              +- CometFilter
+         :                             :        :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+         :                             :        :     :     +- CometBroadcastExchange
+         :                             :        :     :        +- CometProject
+         :                             :        :     :           +- CometFilter
+         :                             :        :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+         :                             :        :     +- CometBroadcastExchange
+         :                             :        :        +- CometProject
+         :                             :        :           +- CometFilter
+         :                             :        :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+         :                             :        +- CometBroadcastExchange
+         :                             :           +- CometProject
+         :                             :              +- CometFilter
+         :                             :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         :                             +- BroadcastExchange
+         :                                +- CometNativeColumnarToRow
+         :                                   +- CometProject
+         :                                      +- CometFilter
+         :                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+         +- HashAggregate
+            +- Exchange
+               +- HashAggregate
+                  +- HashAggregate
+                     +- Exchange
+                        +- HashAggregate
+                           +- Project
+                              +-  BroadcastHashJoin [COMET: Comet is not compatible with Spark for case conversion in locale-specific cases. Set spark.comet.caseConversion.enabled=true to enable it anyway.]
+                                 :- CometNativeColumnarToRow
+                                 :  +- CometProject
+                                 :     +- CometBroadcastHashJoin
+                                 :        :- CometProject
+                                 :        :  +- CometBroadcastHashJoin
+                                 :        :     :- CometProject
+                                 :        :     :  +- CometBroadcastHashJoin
+                                 :        :     :     :- CometProject
+                                 :        :     :     :  +- CometSortMergeJoin
+                                 :        :     :     :     :- CometSort
+                                 :        :     :     :     :  +- CometExchange
+                                 :        :     :     :     :     +- CometProject
+                                 :        :     :     :     :        +- CometFilter
+                                 :        :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                 :        :     :     :     +- CometSort
+                                 :        :     :     :        +- CometExchange
+                                 :        :     :     :           +- CometProject
+                                 :        :     :     :              +- CometFilter
+                                 :        :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+                                 :        :     :     +- CometBroadcastExchange
+                                 :        :     :        +- CometProject
+                                 :        :     :           +- CometFilter
+                                 :        :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                                 :        :     +- CometBroadcastExchange
+                                 :        :        +- CometProject
+                                 :        :           +- CometFilter
+                                 :        :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                 :        +- CometBroadcastExchange
+                                 :           +- CometProject
+                                 :              +- CometFilter
+                                 :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                                 +- BroadcastExchange
+                                    +- CometNativeColumnarToRow
+                                       +- CometProject
+                                          +- CometFilter
+                                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+
+Comet accelerated 68 out of 88 eligible operators (77%). Final plan contains 5 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q27a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q27a.native_datafusion/extended.txt
@@ -1,0 +1,98 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometUnion
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometProject
+      :           +- CometBroadcastHashJoin
+      :              :- CometProject
+      :              :  +- CometBroadcastHashJoin
+      :              :     :- CometProject
+      :              :     :  +- CometBroadcastHashJoin
+      :              :     :     :- CometProject
+      :              :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :- CometFilter
+      :              :     :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+      :              :     :     :     :        +- CometSubqueryBroadcast
+      :              :     :     :     :           +- CometBroadcastExchange
+      :              :     :     :     :              +- CometProject
+      :              :     :     :     :                 +- CometFilter
+      :              :     :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+      :              :     :     :     +- CometBroadcastExchange
+      :              :     :     :        +- CometProject
+      :              :     :     :           +- CometFilter
+      :              :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+      :              :     :     +- CometBroadcastExchange
+      :              :     :        +- CometProject
+      :              :     :           +- CometFilter
+      :              :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+      :              :     +- CometBroadcastExchange
+      :              :        +- CometProject
+      :              :           +- CometFilter
+      :              :              +- CometNativeScan parquet spark_catalog.default.store
+      :              +- CometBroadcastExchange
+      :                 +- CometProject
+      :                    +- CometFilter
+      :                       +- CometNativeScan parquet spark_catalog.default.item
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometProject
+      :           +- CometBroadcastHashJoin
+      :              :- CometProject
+      :              :  +- CometBroadcastHashJoin
+      :              :     :- CometProject
+      :              :     :  +- CometBroadcastHashJoin
+      :              :     :     :- CometProject
+      :              :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :- CometFilter
+      :              :     :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+      :              :     :     :     :        +- ReusedSubquery
+      :              :     :     :     +- CometBroadcastExchange
+      :              :     :     :        +- CometProject
+      :              :     :     :           +- CometFilter
+      :              :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+      :              :     :     +- CometBroadcastExchange
+      :              :     :        +- CometProject
+      :              :     :           +- CometFilter
+      :              :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+      :              :     +- CometBroadcastExchange
+      :              :        +- CometProject
+      :              :           +- CometFilter
+      :              :              +- CometNativeScan parquet spark_catalog.default.store
+      :              +- CometBroadcastExchange
+      :                 +- CometProject
+      :                    +- CometFilter
+      :                       +- CometNativeScan parquet spark_catalog.default.item
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometProject
+                     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :- CometFilter
+                     :     :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                     :     :     :     :        +- ReusedSubquery
+                     :     :     :     +- CometBroadcastExchange
+                     :     :     :        +- CometProject
+                     :     :     :           +- CometFilter
+                     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometProject
+                     :     :           +- CometFilter
+                     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              +- CometNativeScan parquet spark_catalog.default.store
+                     +- CometBroadcastExchange
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 92 out of 95 eligible operators (96%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q27a.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q27a.native_iceberg_compat/extended.txt
@@ -1,0 +1,99 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometUnion
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometProject
+      :           +- CometBroadcastHashJoin
+      :              :- CometProject
+      :              :  +- CometBroadcastHashJoin
+      :              :     :- CometProject
+      :              :     :  +- CometBroadcastHashJoin
+      :              :     :     :- CometProject
+      :              :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :- CometFilter
+      :              :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+      :              :     :     :     :        +- SubqueryBroadcast
+      :              :     :     :     :           +- BroadcastExchange
+      :              :     :     :     :              +- CometNativeColumnarToRow
+      :              :     :     :     :                 +- CometProject
+      :              :     :     :     :                    +- CometFilter
+      :              :     :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :              :     :     :     +- CometBroadcastExchange
+      :              :     :     :        +- CometProject
+      :              :     :     :           +- CometFilter
+      :              :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+      :              :     :     +- CometBroadcastExchange
+      :              :     :        +- CometProject
+      :              :     :           +- CometFilter
+      :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :              :     +- CometBroadcastExchange
+      :              :        +- CometProject
+      :              :           +- CometFilter
+      :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+      :              +- CometBroadcastExchange
+      :                 +- CometProject
+      :                    +- CometFilter
+      :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :- CometHashAggregate
+      :  +- CometExchange
+      :     +- CometHashAggregate
+      :        +- CometProject
+      :           +- CometBroadcastHashJoin
+      :              :- CometProject
+      :              :  +- CometBroadcastHashJoin
+      :              :     :- CometProject
+      :              :     :  +- CometBroadcastHashJoin
+      :              :     :     :- CometProject
+      :              :     :     :  +- CometBroadcastHashJoin
+      :              :     :     :     :- CometFilter
+      :              :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+      :              :     :     :     :        +- ReusedSubquery
+      :              :     :     :     +- CometBroadcastExchange
+      :              :     :     :        +- CometProject
+      :              :     :     :           +- CometFilter
+      :              :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+      :              :     :     +- CometBroadcastExchange
+      :              :     :        +- CometProject
+      :              :     :           +- CometFilter
+      :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :              :     +- CometBroadcastExchange
+      :              :        +- CometProject
+      :              :           +- CometFilter
+      :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+      :              +- CometBroadcastExchange
+      :                 +- CometProject
+      :                    +- CometFilter
+      :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometProject
+                     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :- CometFilter
+                     :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                     :     :     :     :        +- ReusedSubquery
+                     :     :     :     +- CometBroadcastExchange
+                     :     :     :        +- CometProject
+                     :     :     :           +- CometFilter
+                     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometProject
+                     :     :           +- CometFilter
+                     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                     +- CometBroadcastExchange
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 91 out of 95 eligible operators (95%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q34.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q34.native_datafusion/extended.txt
@@ -1,0 +1,40 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometProject
+         +- CometBroadcastHashJoin
+            :- CometFilter
+            :  +- CometHashAggregate
+            :     +- CometExchange
+            :        +- CometHashAggregate
+            :           +- CometProject
+            :              +- CometBroadcastHashJoin
+            :                 :- CometProject
+            :                 :  +- CometBroadcastHashJoin
+            :                 :     :- CometProject
+            :                 :     :  +- CometBroadcastHashJoin
+            :                 :     :     :- CometFilter
+            :                 :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+            :                 :     :     :        +- CometSubqueryBroadcast
+            :                 :     :     :           +- CometBroadcastExchange
+            :                 :     :     :              +- CometProject
+            :                 :     :     :                 +- CometFilter
+            :                 :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     +- CometBroadcastExchange
+            :                 :     :        +- CometProject
+            :                 :     :           +- CometFilter
+            :                 :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     +- CometBroadcastExchange
+            :                 :        +- CometProject
+            :                 :           +- CometFilter
+            :                 :              +- CometNativeScan parquet spark_catalog.default.store
+            :                 +- CometBroadcastExchange
+            :                    +- CometProject
+            :                       +- CometFilter
+            :                          +- CometNativeScan parquet spark_catalog.default.household_demographics
+            +- CometBroadcastExchange
+               +- CometProject
+                  +- CometFilter
+                     +- CometNativeScan parquet spark_catalog.default.customer
+
+Comet accelerated 36 out of 37 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q34.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q34.native_iceberg_compat/extended.txt
@@ -1,0 +1,41 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometProject
+         +- CometBroadcastHashJoin
+            :- CometFilter
+            :  +- CometHashAggregate
+            :     +- CometExchange
+            :        +- CometHashAggregate
+            :           +- CometProject
+            :              +- CometBroadcastHashJoin
+            :                 :- CometProject
+            :                 :  +- CometBroadcastHashJoin
+            :                 :     :- CometProject
+            :                 :     :  +- CometBroadcastHashJoin
+            :                 :     :     :- CometFilter
+            :                 :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+            :                 :     :     :        +- SubqueryBroadcast
+            :                 :     :     :           +- BroadcastExchange
+            :                 :     :     :              +- CometNativeColumnarToRow
+            :                 :     :     :                 +- CometProject
+            :                 :     :     :                    +- CometFilter
+            :                 :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :                 :     :     +- CometBroadcastExchange
+            :                 :     :        +- CometProject
+            :                 :     :           +- CometFilter
+            :                 :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :                 :     +- CometBroadcastExchange
+            :                 :        +- CometProject
+            :                 :           +- CometFilter
+            :                 :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+            :                 +- CometBroadcastExchange
+            :                    +- CometProject
+            :                       +- CometFilter
+            :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+            +- CometBroadcastExchange
+               +- CometProject
+                  +- CometFilter
+                     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+
+Comet accelerated 35 out of 37 eligible operators (94%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q35.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q35.native_datafusion/extended.txt
@@ -1,0 +1,61 @@
+TakeOrderedAndProject
++- HashAggregate
+   +- Exchange
+      +- HashAggregate
+         +- Project
+            +- BroadcastHashJoin
+               :- Project
+               :  +- BroadcastHashJoin
+               :     :- Project
+               :     :  +- Filter
+               :     :     +- BroadcastHashJoin
+               :     :        :-  BroadcastHashJoin [COMET: Unsupported join type ExistenceJoin(exists#1)]
+               :     :        :  :- CometNativeColumnarToRow
+               :     :        :  :  +- CometBroadcastHashJoin
+               :     :        :  :     :- CometFilter
+               :     :        :  :     :  +- CometNativeScan parquet spark_catalog.default.customer
+               :     :        :  :     +- CometBroadcastExchange
+               :     :        :  :        +- CometProject
+               :     :        :  :           +- CometBroadcastHashJoin
+               :     :        :  :              :- CometNativeScan parquet spark_catalog.default.store_sales
+               :     :        :  :              :     +- CometSubqueryBroadcast
+               :     :        :  :              :        +- CometBroadcastExchange
+               :     :        :  :              :           +- CometProject
+               :     :        :  :              :              +- CometFilter
+               :     :        :  :              :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     :        :  :              +- CometBroadcastExchange
+               :     :        :  :                 +- CometProject
+               :     :        :  :                    +- CometFilter
+               :     :        :  :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     :        :  +- BroadcastExchange
+               :     :        :     +- CometNativeColumnarToRow
+               :     :        :        +- CometProject
+               :     :        :           +- CometBroadcastHashJoin
+               :     :        :              :- CometNativeScan parquet spark_catalog.default.web_sales
+               :     :        :              :     +- ReusedSubquery
+               :     :        :              +- CometBroadcastExchange
+               :     :        :                 +- CometProject
+               :     :        :                    +- CometFilter
+               :     :        :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     :        +- BroadcastExchange
+               :     :           +- CometNativeColumnarToRow
+               :     :              +- CometProject
+               :     :                 +- CometBroadcastHashJoin
+               :     :                    :- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :     :                    :     +- ReusedSubquery
+               :     :                    +- CometBroadcastExchange
+               :     :                       +- CometProject
+               :     :                          +- CometFilter
+               :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :     +- BroadcastExchange
+               :        +- CometNativeColumnarToRow
+               :           +- CometProject
+               :              +- CometFilter
+               :                 +- CometNativeScan parquet spark_catalog.default.customer_address
+               +- BroadcastExchange
+                  +- CometNativeColumnarToRow
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.customer_demographics
+
+Comet accelerated 35 out of 54 eligible operators (64%). Final plan contains 5 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q35.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q35.native_iceberg_compat/extended.txt
@@ -1,0 +1,62 @@
+TakeOrderedAndProject
++- HashAggregate
+   +- Exchange
+      +- HashAggregate
+         +- Project
+            +- BroadcastHashJoin
+               :- Project
+               :  +- BroadcastHashJoin
+               :     :- Project
+               :     :  +- Filter
+               :     :     +- BroadcastHashJoin
+               :     :        :-  BroadcastHashJoin [COMET: Unsupported join type ExistenceJoin(exists#1)]
+               :     :        :  :- CometNativeColumnarToRow
+               :     :        :  :  +- CometBroadcastHashJoin
+               :     :        :  :     :- CometFilter
+               :     :        :  :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+               :     :        :  :     +- CometBroadcastExchange
+               :     :        :  :        +- CometProject
+               :     :        :  :           +- CometBroadcastHashJoin
+               :     :        :  :              :- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :     :        :  :              :     +- SubqueryBroadcast
+               :     :        :  :              :        +- BroadcastExchange
+               :     :        :  :              :           +- CometNativeColumnarToRow
+               :     :        :  :              :              +- CometProject
+               :     :        :  :              :                 +- CometFilter
+               :     :        :  :              :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     :        :  :              +- CometBroadcastExchange
+               :     :        :  :                 +- CometProject
+               :     :        :  :                    +- CometFilter
+               :     :        :  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     :        :  +- BroadcastExchange
+               :     :        :     +- CometNativeColumnarToRow
+               :     :        :        +- CometProject
+               :     :        :           +- CometBroadcastHashJoin
+               :     :        :              :- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :     :        :              :     +- ReusedSubquery
+               :     :        :              +- CometBroadcastExchange
+               :     :        :                 +- CometProject
+               :     :        :                    +- CometFilter
+               :     :        :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     :        +- BroadcastExchange
+               :     :           +- CometNativeColumnarToRow
+               :     :              +- CometProject
+               :     :                 +- CometBroadcastHashJoin
+               :     :                    :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :     :                    :     +- ReusedSubquery
+               :     :                    +- CometBroadcastExchange
+               :     :                       +- CometProject
+               :     :                          +- CometFilter
+               :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :     +- BroadcastExchange
+               :        +- CometNativeColumnarToRow
+               :           +- CometProject
+               :              +- CometFilter
+               :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+               +- BroadcastExchange
+                  +- CometNativeColumnarToRow
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+
+Comet accelerated 34 out of 54 eligible operators (62%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q35a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q35a.native_datafusion/extended.txt
@@ -1,0 +1,55 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometBroadcastHashJoin
+                  :     :     :  :- CometFilter
+                  :     :     :  :  +- CometNativeScan parquet spark_catalog.default.customer
+                  :     :     :  +- CometBroadcastExchange
+                  :     :     :     +- CometProject
+                  :     :     :        +- CometBroadcastHashJoin
+                  :     :     :           :- CometNativeScan parquet spark_catalog.default.store_sales
+                  :     :     :           :     +- CometSubqueryBroadcast
+                  :     :     :           :        +- CometBroadcastExchange
+                  :     :     :           :           +- CometProject
+                  :     :     :           :              +- CometFilter
+                  :     :     :           :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     :           +- CometBroadcastExchange
+                  :     :     :              +- CometProject
+                  :     :     :                 +- CometFilter
+                  :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometUnion
+                  :     :           :- CometProject
+                  :     :           :  +- CometBroadcastHashJoin
+                  :     :           :     :- CometNativeScan parquet spark_catalog.default.web_sales
+                  :     :           :     :     +- ReusedSubquery
+                  :     :           :     +- CometBroadcastExchange
+                  :     :           :        +- CometProject
+                  :     :           :           +- CometFilter
+                  :     :           :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     :           +- CometProject
+                  :     :              +- CometBroadcastHashJoin
+                  :     :                 :- CometNativeScan parquet spark_catalog.default.catalog_sales
+                  :     :                 :     +- ReusedSubquery
+                  :     :                 +- CometBroadcastExchange
+                  :     :                    +- CometProject
+                  :     :                       +- CometFilter
+                  :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometNativeScan parquet spark_catalog.default.customer_demographics
+
+Comet accelerated 49 out of 52 eligible operators (94%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q35a.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q35a.native_iceberg_compat/extended.txt
@@ -1,0 +1,56 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometBroadcastHashJoin
+                  :- CometProject
+                  :  +- CometBroadcastHashJoin
+                  :     :- CometProject
+                  :     :  +- CometBroadcastHashJoin
+                  :     :     :- CometBroadcastHashJoin
+                  :     :     :  :- CometFilter
+                  :     :     :  :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                  :     :     :  +- CometBroadcastExchange
+                  :     :     :     +- CometProject
+                  :     :     :        +- CometBroadcastHashJoin
+                  :     :     :           :- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                  :     :     :           :     +- SubqueryBroadcast
+                  :     :     :           :        +- BroadcastExchange
+                  :     :     :           :           +- CometNativeColumnarToRow
+                  :     :     :           :              +- CometProject
+                  :     :     :           :                 +- CometFilter
+                  :     :     :           :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     :           +- CometBroadcastExchange
+                  :     :     :              +- CometProject
+                  :     :     :                 +- CometFilter
+                  :     :     :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :     +- CometBroadcastExchange
+                  :     :        +- CometUnion
+                  :     :           :- CometProject
+                  :     :           :  +- CometBroadcastHashJoin
+                  :     :           :     :- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                  :     :           :     :     +- ReusedSubquery
+                  :     :           :     +- CometBroadcastExchange
+                  :     :           :        +- CometProject
+                  :     :           :           +- CometFilter
+                  :     :           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     :           +- CometProject
+                  :     :              +- CometBroadcastHashJoin
+                  :     :                 :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                  :     :                 :     +- ReusedSubquery
+                  :     :                 +- CometBroadcastExchange
+                  :     :                    +- CometProject
+                  :     :                       +- CometFilter
+                  :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :     +- CometBroadcastExchange
+                  :        +- CometProject
+                  :           +- CometFilter
+                  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                  +- CometBroadcastExchange
+                     +- CometProject
+                        +- CometFilter
+                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+
+Comet accelerated 48 out of 52 eligible operators (92%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q36a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q36a.native_datafusion/extended.txt
@@ -1,0 +1,102 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometUnion
+                           :- CometHashAggregate
+                           :  +- CometExchange
+                           :     +- CometHashAggregate
+                           :        +- CometProject
+                           :           +- CometBroadcastHashJoin
+                           :              :- CometProject
+                           :              :  +- CometBroadcastHashJoin
+                           :              :     :- CometProject
+                           :              :     :  +- CometBroadcastHashJoin
+                           :              :     :     :- CometFilter
+                           :              :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                           :              :     :     :        +- CometSubqueryBroadcast
+                           :              :     :     :           +- CometBroadcastExchange
+                           :              :     :     :              +- CometProject
+                           :              :     :     :                 +- CometFilter
+                           :              :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :              :     :     +- CometBroadcastExchange
+                           :              :     :        +- CometProject
+                           :              :     :           +- CometFilter
+                           :              :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :              :     +- CometBroadcastExchange
+                           :              :        +- CometProject
+                           :              :           +- CometFilter
+                           :              :              +- CometNativeScan parquet spark_catalog.default.item
+                           :              +- CometBroadcastExchange
+                           :                 +- CometProject
+                           :                    +- CometFilter
+                           :                       +- CometNativeScan parquet spark_catalog.default.store
+                           :- CometHashAggregate
+                           :  +- CometExchange
+                           :     +- CometHashAggregate
+                           :        +- CometHashAggregate
+                           :           +- CometExchange
+                           :              +- CometHashAggregate
+                           :                 +- CometProject
+                           :                    +- CometBroadcastHashJoin
+                           :                       :- CometProject
+                           :                       :  +- CometBroadcastHashJoin
+                           :                       :     :- CometProject
+                           :                       :     :  +- CometBroadcastHashJoin
+                           :                       :     :     :- CometFilter
+                           :                       :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                           :                       :     :     :        +- CometSubqueryBroadcast
+                           :                       :     :     :           +- CometBroadcastExchange
+                           :                       :     :     :              +- CometProject
+                           :                       :     :     :                 +- CometFilter
+                           :                       :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :                       :     :     +- CometBroadcastExchange
+                           :                       :     :        +- CometProject
+                           :                       :     :           +- CometFilter
+                           :                       :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :                       :     +- CometBroadcastExchange
+                           :                       :        +- CometProject
+                           :                       :           +- CometFilter
+                           :                       :              +- CometNativeScan parquet spark_catalog.default.item
+                           :                       +- CometBroadcastExchange
+                           :                          +- CometProject
+                           :                             +- CometFilter
+                           :                                +- CometNativeScan parquet spark_catalog.default.store
+                           +- CometHashAggregate
+                              +- CometExchange
+                                 +- CometHashAggregate
+                                    +- CometHashAggregate
+                                       +- CometExchange
+                                          +- CometHashAggregate
+                                             +- CometProject
+                                                +- CometBroadcastHashJoin
+                                                   :- CometProject
+                                                   :  +- CometBroadcastHashJoin
+                                                   :     :- CometProject
+                                                   :     :  +- CometBroadcastHashJoin
+                                                   :     :     :- CometFilter
+                                                   :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                                   :     :     :        +- CometSubqueryBroadcast
+                                                   :     :     :           +- CometBroadcastExchange
+                                                   :     :     :              +- CometProject
+                                                   :     :     :                 +- CometFilter
+                                                   :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                   :     :     +- CometBroadcastExchange
+                                                   :     :        +- CometProject
+                                                   :     :           +- CometFilter
+                                                   :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                   :     +- CometBroadcastExchange
+                                                   :        +- CometProject
+                                                   :           +- CometFilter
+                                                   :              +- CometNativeScan parquet spark_catalog.default.item
+                                                   +- CometBroadcastExchange
+                                                      +- CometProject
+                                                         +- CometFilter
+                                                            +- CometNativeScan parquet spark_catalog.default.store
+
+Comet accelerated 93 out of 99 eligible operators (93%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q36a.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q36a.native_iceberg_compat/extended.txt
@@ -1,0 +1,105 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometUnion
+                           :- CometHashAggregate
+                           :  +- CometExchange
+                           :     +- CometHashAggregate
+                           :        +- CometProject
+                           :           +- CometBroadcastHashJoin
+                           :              :- CometProject
+                           :              :  +- CometBroadcastHashJoin
+                           :              :     :- CometProject
+                           :              :     :  +- CometBroadcastHashJoin
+                           :              :     :     :- CometFilter
+                           :              :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                           :              :     :     :        +- SubqueryBroadcast
+                           :              :     :     :           +- BroadcastExchange
+                           :              :     :     :              +- CometNativeColumnarToRow
+                           :              :     :     :                 +- CometProject
+                           :              :     :     :                    +- CometFilter
+                           :              :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :              :     :     +- CometBroadcastExchange
+                           :              :     :        +- CometProject
+                           :              :     :           +- CometFilter
+                           :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :              :     +- CometBroadcastExchange
+                           :              :        +- CometProject
+                           :              :           +- CometFilter
+                           :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :              +- CometBroadcastExchange
+                           :                 +- CometProject
+                           :                    +- CometFilter
+                           :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                           :- CometHashAggregate
+                           :  +- CometExchange
+                           :     +- CometHashAggregate
+                           :        +- CometHashAggregate
+                           :           +- CometExchange
+                           :              +- CometHashAggregate
+                           :                 +- CometProject
+                           :                    +- CometBroadcastHashJoin
+                           :                       :- CometProject
+                           :                       :  +- CometBroadcastHashJoin
+                           :                       :     :- CometProject
+                           :                       :     :  +- CometBroadcastHashJoin
+                           :                       :     :     :- CometFilter
+                           :                       :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                           :                       :     :     :        +- SubqueryBroadcast
+                           :                       :     :     :           +- BroadcastExchange
+                           :                       :     :     :              +- CometNativeColumnarToRow
+                           :                       :     :     :                 +- CometProject
+                           :                       :     :     :                    +- CometFilter
+                           :                       :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :                       :     :     +- CometBroadcastExchange
+                           :                       :     :        +- CometProject
+                           :                       :     :           +- CometFilter
+                           :                       :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :                       :     +- CometBroadcastExchange
+                           :                       :        +- CometProject
+                           :                       :           +- CometFilter
+                           :                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :                       +- CometBroadcastExchange
+                           :                          +- CometProject
+                           :                             +- CometFilter
+                           :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                           +- CometHashAggregate
+                              +- CometExchange
+                                 +- CometHashAggregate
+                                    +- CometHashAggregate
+                                       +- CometExchange
+                                          +- CometHashAggregate
+                                             +- CometProject
+                                                +- CometBroadcastHashJoin
+                                                   :- CometProject
+                                                   :  +- CometBroadcastHashJoin
+                                                   :     :- CometProject
+                                                   :     :  +- CometBroadcastHashJoin
+                                                   :     :     :- CometFilter
+                                                   :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                                   :     :     :        +- SubqueryBroadcast
+                                                   :     :     :           +- BroadcastExchange
+                                                   :     :     :              +- CometNativeColumnarToRow
+                                                   :     :     :                 +- CometProject
+                                                   :     :     :                    +- CometFilter
+                                                   :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                   :     :     +- CometBroadcastExchange
+                                                   :     :        +- CometProject
+                                                   :     :           +- CometFilter
+                                                   :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                   :     +- CometBroadcastExchange
+                                                   :        +- CometProject
+                                                   :           +- CometFilter
+                                                   :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                                   +- CometBroadcastExchange
+                                                      +- CometProject
+                                                         +- CometFilter
+                                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+
+Comet accelerated 90 out of 99 eligible operators (90%). Final plan contains 4 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q47.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q47.native_datafusion/extended.txt
@@ -1,0 +1,102 @@
+TakeOrderedAndProject
++- Project
+   +- BroadcastHashJoin
+      :- Project
+      :  +- BroadcastHashJoin
+      :     :- Project
+      :     :  +- Filter
+      :     :     +- Window
+      :     :        +- Filter
+      :     :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      :     :              +- CometNativeColumnarToRow
+      :     :                 +- CometSort
+      :     :                    +- CometExchange
+      :     :                       +- CometHashAggregate
+      :     :                          +- CometExchange
+      :     :                             +- CometHashAggregate
+      :     :                                +- CometProject
+      :     :                                   +- CometBroadcastHashJoin
+      :     :                                      :- CometProject
+      :     :                                      :  +- CometBroadcastHashJoin
+      :     :                                      :     :- CometProject
+      :     :                                      :     :  +- CometBroadcastHashJoin
+      :     :                                      :     :     :- CometProject
+      :     :                                      :     :     :  +- CometFilter
+      :     :                                      :     :     :     +- CometNativeScan parquet spark_catalog.default.item
+      :     :                                      :     :     +- CometBroadcastExchange
+      :     :                                      :     :        +- CometFilter
+      :     :                                      :     :           +- CometNativeScan parquet spark_catalog.default.store_sales
+      :     :                                      :     :                 +- CometSubqueryBroadcast
+      :     :                                      :     :                    +- CometBroadcastExchange
+      :     :                                      :     :                       +- CometFilter
+      :     :                                      :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+      :     :                                      :     +- CometBroadcastExchange
+      :     :                                      :        +- CometFilter
+      :     :                                      :           +- CometNativeScan parquet spark_catalog.default.date_dim
+      :     :                                      +- CometBroadcastExchange
+      :     :                                         +- CometFilter
+      :     :                                            +- CometNativeScan parquet spark_catalog.default.store
+      :     +- BroadcastExchange
+      :        +- Project
+      :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      :              +- CometNativeColumnarToRow
+      :                 +- CometSort
+      :                    +- CometExchange
+      :                       +- CometHashAggregate
+      :                          +- CometExchange
+      :                             +- CometHashAggregate
+      :                                +- CometProject
+      :                                   +- CometBroadcastHashJoin
+      :                                      :- CometProject
+      :                                      :  +- CometBroadcastHashJoin
+      :                                      :     :- CometProject
+      :                                      :     :  +- CometBroadcastHashJoin
+      :                                      :     :     :- CometProject
+      :                                      :     :     :  +- CometFilter
+      :                                      :     :     :     +- CometNativeScan parquet spark_catalog.default.item
+      :                                      :     :     +- CometBroadcastExchange
+      :                                      :     :        +- CometFilter
+      :                                      :     :           +- CometNativeScan parquet spark_catalog.default.store_sales
+      :                                      :     :                 +- CometSubqueryBroadcast
+      :                                      :     :                    +- CometBroadcastExchange
+      :                                      :     :                       +- CometFilter
+      :                                      :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                                      :     +- CometBroadcastExchange
+      :                                      :        +- CometFilter
+      :                                      :           +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                                      +- CometBroadcastExchange
+      :                                         +- CometFilter
+      :                                            +- CometNativeScan parquet spark_catalog.default.store
+      +- BroadcastExchange
+         +- Project
+            +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               +- CometNativeColumnarToRow
+                  +- CometSort
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometExchange
+                              +- CometHashAggregate
+                                 +- CometProject
+                                    +- CometBroadcastHashJoin
+                                       :- CometProject
+                                       :  +- CometBroadcastHashJoin
+                                       :     :- CometProject
+                                       :     :  +- CometBroadcastHashJoin
+                                       :     :     :- CometProject
+                                       :     :     :  +- CometFilter
+                                       :     :     :     +- CometNativeScan parquet spark_catalog.default.item
+                                       :     :     +- CometBroadcastExchange
+                                       :     :        +- CometFilter
+                                       :     :           +- CometNativeScan parquet spark_catalog.default.store_sales
+                                       :     :                 +- CometSubqueryBroadcast
+                                       :     :                    +- CometBroadcastExchange
+                                       :     :                       +- CometFilter
+                                       :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       :     +- CometBroadcastExchange
+                                       :        +- CometFilter
+                                       :           +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       +- CometBroadcastExchange
+                                          +- CometFilter
+                                             +- CometNativeScan parquet spark_catalog.default.store
+
+Comet accelerated 78 out of 97 eligible operators (80%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q47.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q47.native_iceberg_compat/extended.txt
@@ -1,0 +1,105 @@
+TakeOrderedAndProject
++- Project
+   +- BroadcastHashJoin
+      :- Project
+      :  +- BroadcastHashJoin
+      :     :- Project
+      :     :  +- Filter
+      :     :     +- Window
+      :     :        +- Filter
+      :     :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      :     :              +- CometNativeColumnarToRow
+      :     :                 +- CometSort
+      :     :                    +- CometExchange
+      :     :                       +- CometHashAggregate
+      :     :                          +- CometExchange
+      :     :                             +- CometHashAggregate
+      :     :                                +- CometProject
+      :     :                                   +- CometBroadcastHashJoin
+      :     :                                      :- CometProject
+      :     :                                      :  +- CometBroadcastHashJoin
+      :     :                                      :     :- CometProject
+      :     :                                      :     :  +- CometBroadcastHashJoin
+      :     :                                      :     :     :- CometProject
+      :     :                                      :     :     :  +- CometFilter
+      :     :                                      :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :     :                                      :     :     +- CometBroadcastExchange
+      :     :                                      :     :        +- CometFilter
+      :     :                                      :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+      :     :                                      :     :                 +- SubqueryBroadcast
+      :     :                                      :     :                    +- BroadcastExchange
+      :     :                                      :     :                       +- CometNativeColumnarToRow
+      :     :                                      :     :                          +- CometFilter
+      :     :                                      :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :     :                                      :     +- CometBroadcastExchange
+      :     :                                      :        +- CometFilter
+      :     :                                      :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :     :                                      +- CometBroadcastExchange
+      :     :                                         +- CometFilter
+      :     :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+      :     +- BroadcastExchange
+      :        +- Project
+      :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      :              +- CometNativeColumnarToRow
+      :                 +- CometSort
+      :                    +- CometExchange
+      :                       +- CometHashAggregate
+      :                          +- CometExchange
+      :                             +- CometHashAggregate
+      :                                +- CometProject
+      :                                   +- CometBroadcastHashJoin
+      :                                      :- CometProject
+      :                                      :  +- CometBroadcastHashJoin
+      :                                      :     :- CometProject
+      :                                      :     :  +- CometBroadcastHashJoin
+      :                                      :     :     :- CometProject
+      :                                      :     :     :  +- CometFilter
+      :                                      :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                                      :     :     +- CometBroadcastExchange
+      :                                      :     :        +- CometFilter
+      :                                      :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+      :                                      :     :                 +- SubqueryBroadcast
+      :                                      :     :                    +- BroadcastExchange
+      :                                      :     :                       +- CometNativeColumnarToRow
+      :                                      :     :                          +- CometFilter
+      :                                      :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                                      :     +- CometBroadcastExchange
+      :                                      :        +- CometFilter
+      :                                      :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                                      +- CometBroadcastExchange
+      :                                         +- CometFilter
+      :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+      +- BroadcastExchange
+         +- Project
+            +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               +- CometNativeColumnarToRow
+                  +- CometSort
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometExchange
+                              +- CometHashAggregate
+                                 +- CometProject
+                                    +- CometBroadcastHashJoin
+                                       :- CometProject
+                                       :  +- CometBroadcastHashJoin
+                                       :     :- CometProject
+                                       :     :  +- CometBroadcastHashJoin
+                                       :     :     :- CometProject
+                                       :     :     :  +- CometFilter
+                                       :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                       :     :     +- CometBroadcastExchange
+                                       :     :        +- CometFilter
+                                       :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                       :     :                 +- SubqueryBroadcast
+                                       :     :                    +- BroadcastExchange
+                                       :     :                       +- CometNativeColumnarToRow
+                                       :     :                          +- CometFilter
+                                       :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       :     +- CometBroadcastExchange
+                                       :        +- CometFilter
+                                       :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       +- CometBroadcastExchange
+                                          +- CometFilter
+                                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+
+Comet accelerated 75 out of 97 eligible operators (77%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q49.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q49.native_datafusion/extended.txt
@@ -1,0 +1,91 @@
+TakeOrderedAndProject
++- HashAggregate
+   +- HashAggregate
+      +- Union
+         :- Project
+         :  +- Filter
+         :     +- Window
+         :        +- Sort
+         :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+         :              +- CometNativeColumnarToRow
+         :                 +- CometSort
+         :                    +- CometExchange
+         :                       +- CometHashAggregate
+         :                          +- CometExchange
+         :                             +- CometHashAggregate
+         :                                +- CometProject
+         :                                   +- CometBroadcastHashJoin
+         :                                      :- CometProject
+         :                                      :  +- CometBroadcastHashJoin
+         :                                      :     :- CometBroadcastExchange
+         :                                      :     :  +- CometProject
+         :                                      :     :     +- CometFilter
+         :                                      :     :        +- CometNativeScan parquet spark_catalog.default.web_sales
+         :                                      :     :              +- CometSubqueryBroadcast
+         :                                      :     :                 +- CometBroadcastExchange
+         :                                      :     :                    +- CometProject
+         :                                      :     :                       +- CometFilter
+         :                                      :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+         :                                      :     +- CometProject
+         :                                      :        +- CometFilter
+         :                                      :           +- CometNativeScan parquet spark_catalog.default.web_returns
+         :                                      +- CometBroadcastExchange
+         :                                         +- CometProject
+         :                                            +- CometFilter
+         :                                               +- CometNativeScan parquet spark_catalog.default.date_dim
+         :- Project
+         :  +- Filter
+         :     +- Window
+         :        +- Sort
+         :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+         :              +- CometNativeColumnarToRow
+         :                 +- CometSort
+         :                    +- CometExchange
+         :                       +- CometHashAggregate
+         :                          +- CometExchange
+         :                             +- CometHashAggregate
+         :                                +- CometProject
+         :                                   +- CometBroadcastHashJoin
+         :                                      :- CometProject
+         :                                      :  +- CometBroadcastHashJoin
+         :                                      :     :- CometBroadcastExchange
+         :                                      :     :  +- CometProject
+         :                                      :     :     +- CometFilter
+         :                                      :     :        +- CometNativeScan parquet spark_catalog.default.catalog_sales
+         :                                      :     :              +- ReusedSubquery
+         :                                      :     +- CometProject
+         :                                      :        +- CometFilter
+         :                                      :           +- CometNativeScan parquet spark_catalog.default.catalog_returns
+         :                                      +- CometBroadcastExchange
+         :                                         +- CometProject
+         :                                            +- CometFilter
+         :                                               +- CometNativeScan parquet spark_catalog.default.date_dim
+         +- Project
+            +- Filter
+               +- Window
+                  +- Sort
+                     +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+                        +- CometNativeColumnarToRow
+                           +- CometSort
+                              +- CometExchange
+                                 +- CometHashAggregate
+                                    +- CometExchange
+                                       +- CometHashAggregate
+                                          +- CometProject
+                                             +- CometBroadcastHashJoin
+                                                :- CometProject
+                                                :  +- CometBroadcastHashJoin
+                                                :     :- CometBroadcastExchange
+                                                :     :  +- CometProject
+                                                :     :     +- CometFilter
+                                                :     :        +- CometNativeScan parquet spark_catalog.default.store_sales
+                                                :     :              +- ReusedSubquery
+                                                :     +- CometProject
+                                                :        +- CometFilter
+                                                :           +- CometNativeScan parquet spark_catalog.default.store_returns
+                                                +- CometBroadcastExchange
+                                                   +- CometProject
+                                                      +- CometFilter
+                                                         +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 64 out of 86 eligible operators (74%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q49.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q49.native_iceberg_compat/extended.txt
@@ -1,0 +1,92 @@
+TakeOrderedAndProject
++- HashAggregate
+   +- HashAggregate
+      +- Union
+         :- Project
+         :  +- Filter
+         :     +- Window
+         :        +- Sort
+         :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+         :              +- CometNativeColumnarToRow
+         :                 +- CometSort
+         :                    +- CometExchange
+         :                       +- CometHashAggregate
+         :                          +- CometExchange
+         :                             +- CometHashAggregate
+         :                                +- CometProject
+         :                                   +- CometBroadcastHashJoin
+         :                                      :- CometProject
+         :                                      :  +- CometBroadcastHashJoin
+         :                                      :     :- CometBroadcastExchange
+         :                                      :     :  +- CometProject
+         :                                      :     :     +- CometFilter
+         :                                      :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+         :                                      :     :              +- SubqueryBroadcast
+         :                                      :     :                 +- BroadcastExchange
+         :                                      :     :                    +- CometNativeColumnarToRow
+         :                                      :     :                       +- CometProject
+         :                                      :     :                          +- CometFilter
+         :                                      :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :                                      :     +- CometProject
+         :                                      :        +- CometFilter
+         :                                      :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+         :                                      +- CometBroadcastExchange
+         :                                         +- CometProject
+         :                                            +- CometFilter
+         :                                               +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :- Project
+         :  +- Filter
+         :     +- Window
+         :        +- Sort
+         :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+         :              +- CometNativeColumnarToRow
+         :                 +- CometSort
+         :                    +- CometExchange
+         :                       +- CometHashAggregate
+         :                          +- CometExchange
+         :                             +- CometHashAggregate
+         :                                +- CometProject
+         :                                   +- CometBroadcastHashJoin
+         :                                      :- CometProject
+         :                                      :  +- CometBroadcastHashJoin
+         :                                      :     :- CometBroadcastExchange
+         :                                      :     :  +- CometProject
+         :                                      :     :     +- CometFilter
+         :                                      :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+         :                                      :     :              +- ReusedSubquery
+         :                                      :     +- CometProject
+         :                                      :        +- CometFilter
+         :                                      :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+         :                                      +- CometBroadcastExchange
+         :                                         +- CometProject
+         :                                            +- CometFilter
+         :                                               +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         +- Project
+            +- Filter
+               +- Window
+                  +- Sort
+                     +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+                        +- CometNativeColumnarToRow
+                           +- CometSort
+                              +- CometExchange
+                                 +- CometHashAggregate
+                                    +- CometExchange
+                                       +- CometHashAggregate
+                                          +- CometProject
+                                             +- CometBroadcastHashJoin
+                                                :- CometProject
+                                                :  +- CometBroadcastHashJoin
+                                                :     :- CometBroadcastExchange
+                                                :     :  +- CometProject
+                                                :     :     +- CometFilter
+                                                :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                                :     :              +- ReusedSubquery
+                                                :     +- CometProject
+                                                :        +- CometFilter
+                                                :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+                                                +- CometBroadcastExchange
+                                                   +- CometProject
+                                                      +- CometFilter
+                                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 63 out of 86 eligible operators (73%). Final plan contains 4 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q51a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q51a.native_datafusion/extended.txt
@@ -1,0 +1,208 @@
+TakeOrderedAndProject
++- Filter
+   +- HashAggregate
+      +- HashAggregate
+         +- Project
+            +- BroadcastHashJoin
+               :-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               :  +- CometNativeColumnarToRow
+               :     +- CometSort
+               :        +- CometExchange
+               :           +- CometProject
+               :              +- CometFilter
+               :                 +- CometSortMergeJoin
+               :                    :- CometSort
+               :                    :  +- CometColumnarExchange
+               :                    :     +- HashAggregate
+               :                    :        +- Exchange
+               :                    :           +- HashAggregate
+               :                    :              +- Project
+               :                    :                 +- BroadcastHashJoin
+               :                    :                    :- Project
+               :                    :                    :  +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               :                    :                    :     +- CometNativeColumnarToRow
+               :                    :                    :        +- CometSort
+               :                    :                    :           +- CometExchange
+               :                    :                    :              +- CometHashAggregate
+               :                    :                    :                 +- CometExchange
+               :                    :                    :                    +- CometHashAggregate
+               :                    :                    :                       +- CometProject
+               :                    :                    :                          +- CometBroadcastHashJoin
+               :                    :                    :                             :- CometFilter
+               :                    :                    :                             :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                    :                    :                             :        +- CometSubqueryBroadcast
+               :                    :                    :                             :           +- CometBroadcastExchange
+               :                    :                    :                             :              +- CometProject
+               :                    :                    :                             :                 +- CometFilter
+               :                    :                    :                             :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                    :                    :                             +- CometBroadcastExchange
+               :                    :                    :                                +- CometProject
+               :                    :                    :                                   +- CometFilter
+               :                    :                    :                                      +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                    :                    +- BroadcastExchange
+               :                    :                       +- Project
+               :                    :                          +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               :                    :                             +- CometNativeColumnarToRow
+               :                    :                                +- CometSort
+               :                    :                                   +- CometExchange
+               :                    :                                      +- CometHashAggregate
+               :                    :                                         +- CometExchange
+               :                    :                                            +- CometHashAggregate
+               :                    :                                               +- CometProject
+               :                    :                                                  +- CometBroadcastHashJoin
+               :                    :                                                     :- CometFilter
+               :                    :                                                     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                    :                                                     :        +- CometSubqueryBroadcast
+               :                    :                                                     :           +- CometBroadcastExchange
+               :                    :                                                     :              +- CometProject
+               :                    :                                                     :                 +- CometFilter
+               :                    :                                                     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                    :                                                     +- CometBroadcastExchange
+               :                    :                                                        +- CometProject
+               :                    :                                                           +- CometFilter
+               :                    :                                                              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                    +- CometSort
+               :                       +- CometColumnarExchange
+               :                          +- HashAggregate
+               :                             +- Exchange
+               :                                +- HashAggregate
+               :                                   +- Project
+               :                                      +- BroadcastHashJoin
+               :                                         :- Project
+               :                                         :  +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               :                                         :     +- CometNativeColumnarToRow
+               :                                         :        +- CometSort
+               :                                         :           +- CometExchange
+               :                                         :              +- CometHashAggregate
+               :                                         :                 +- CometExchange
+               :                                         :                    +- CometHashAggregate
+               :                                         :                       +- CometProject
+               :                                         :                          +- CometBroadcastHashJoin
+               :                                         :                             :- CometFilter
+               :                                         :                             :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                                         :                             :        +- ReusedSubquery
+               :                                         :                             +- CometBroadcastExchange
+               :                                         :                                +- CometProject
+               :                                         :                                   +- CometFilter
+               :                                         :                                      +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                         +- BroadcastExchange
+               :                                            +- Project
+               :                                               +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               :                                                  +- CometNativeColumnarToRow
+               :                                                     +- CometSort
+               :                                                        +- CometExchange
+               :                                                           +- CometHashAggregate
+               :                                                              +- CometExchange
+               :                                                                 +- CometHashAggregate
+               :                                                                    +- CometProject
+               :                                                                       +- CometBroadcastHashJoin
+               :                                                                          :- CometFilter
+               :                                                                          :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                                                                          :        +- ReusedSubquery
+               :                                                                          +- CometBroadcastExchange
+               :                                                                             +- CometProject
+               :                                                                                +- CometFilter
+               :                                                                                   +- CometNativeScan parquet spark_catalog.default.date_dim
+               +- BroadcastExchange
+                  +- Project
+                     +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+                        +- CometNativeColumnarToRow
+                           +- CometSort
+                              +- CometExchange
+                                 +- CometProject
+                                    +- CometFilter
+                                       +- CometSortMergeJoin
+                                          :- CometSort
+                                          :  +- CometColumnarExchange
+                                          :     +- HashAggregate
+                                          :        +- Exchange
+                                          :           +- HashAggregate
+                                          :              +- Project
+                                          :                 +- BroadcastHashJoin
+                                          :                    :- Project
+                                          :                    :  +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+                                          :                    :     +- CometNativeColumnarToRow
+                                          :                    :        +- CometSort
+                                          :                    :           +- CometExchange
+                                          :                    :              +- CometHashAggregate
+                                          :                    :                 +- CometExchange
+                                          :                    :                    +- CometHashAggregate
+                                          :                    :                       +- CometProject
+                                          :                    :                          +- CometBroadcastHashJoin
+                                          :                    :                             :- CometFilter
+                                          :                    :                             :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                                          :                    :                             :        +- CometSubqueryBroadcast
+                                          :                    :                             :           +- CometBroadcastExchange
+                                          :                    :                             :              +- CometProject
+                                          :                    :                             :                 +- CometFilter
+                                          :                    :                             :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                          :                    :                             +- CometBroadcastExchange
+                                          :                    :                                +- CometProject
+                                          :                    :                                   +- CometFilter
+                                          :                    :                                      +- CometNativeScan parquet spark_catalog.default.date_dim
+                                          :                    +- BroadcastExchange
+                                          :                       +- Project
+                                          :                          +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+                                          :                             +- CometNativeColumnarToRow
+                                          :                                +- CometSort
+                                          :                                   +- CometExchange
+                                          :                                      +- CometHashAggregate
+                                          :                                         +- CometExchange
+                                          :                                            +- CometHashAggregate
+                                          :                                               +- CometProject
+                                          :                                                  +- CometBroadcastHashJoin
+                                          :                                                     :- CometFilter
+                                          :                                                     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                                          :                                                     :        +- CometSubqueryBroadcast
+                                          :                                                     :           +- CometBroadcastExchange
+                                          :                                                     :              +- CometProject
+                                          :                                                     :                 +- CometFilter
+                                          :                                                     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                          :                                                     +- CometBroadcastExchange
+                                          :                                                        +- CometProject
+                                          :                                                           +- CometFilter
+                                          :                                                              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                          +- CometSort
+                                             +- CometColumnarExchange
+                                                +- HashAggregate
+                                                   +- Exchange
+                                                      +- HashAggregate
+                                                         +- Project
+                                                            +- BroadcastHashJoin
+                                                               :- Project
+                                                               :  +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+                                                               :     +- CometNativeColumnarToRow
+                                                               :        +- CometSort
+                                                               :           +- CometExchange
+                                                               :              +- CometHashAggregate
+                                                               :                 +- CometExchange
+                                                               :                    +- CometHashAggregate
+                                                               :                       +- CometProject
+                                                               :                          +- CometBroadcastHashJoin
+                                                               :                             :- CometFilter
+                                                               :                             :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                                               :                             :        +- ReusedSubquery
+                                                               :                             +- CometBroadcastExchange
+                                                               :                                +- CometProject
+                                                               :                                   +- CometFilter
+                                                               :                                      +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                               +- BroadcastExchange
+                                                                  +- Project
+                                                                     +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+                                                                        +- CometNativeColumnarToRow
+                                                                           +- CometSort
+                                                                              +- CometExchange
+                                                                                 +- CometHashAggregate
+                                                                                    +- CometExchange
+                                                                                       +- CometHashAggregate
+                                                                                          +- CometProject
+                                                                                             +- CometBroadcastHashJoin
+                                                                                                :- CometFilter
+                                                                                                :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                                                                                :        +- ReusedSubquery
+                                                                                                +- CometBroadcastExchange
+                                                                                                   +- CometProject
+                                                                                                      +- CometFilter
+                                                                                                         +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 138 out of 196 eligible operators (70%). Final plan contains 10 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q51a.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q51a.native_iceberg_compat/extended.txt
@@ -1,0 +1,212 @@
+TakeOrderedAndProject
++- Filter
+   +- HashAggregate
+      +- HashAggregate
+         +- Project
+            +- BroadcastHashJoin
+               :-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               :  +- CometNativeColumnarToRow
+               :     +- CometSort
+               :        +- CometExchange
+               :           +- CometProject
+               :              +- CometFilter
+               :                 +- CometSortMergeJoin
+               :                    :- CometSort
+               :                    :  +- CometColumnarExchange
+               :                    :     +- HashAggregate
+               :                    :        +- Exchange
+               :                    :           +- HashAggregate
+               :                    :              +- Project
+               :                    :                 +- BroadcastHashJoin
+               :                    :                    :- Project
+               :                    :                    :  +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               :                    :                    :     +- CometNativeColumnarToRow
+               :                    :                    :        +- CometSort
+               :                    :                    :           +- CometExchange
+               :                    :                    :              +- CometHashAggregate
+               :                    :                    :                 +- CometExchange
+               :                    :                    :                    +- CometHashAggregate
+               :                    :                    :                       +- CometProject
+               :                    :                    :                          +- CometBroadcastHashJoin
+               :                    :                    :                             :- CometFilter
+               :                    :                    :                             :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                    :                    :                             :        +- SubqueryBroadcast
+               :                    :                    :                             :           +- BroadcastExchange
+               :                    :                    :                             :              +- CometNativeColumnarToRow
+               :                    :                    :                             :                 +- CometProject
+               :                    :                    :                             :                    +- CometFilter
+               :                    :                    :                             :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                    :                    :                             +- CometBroadcastExchange
+               :                    :                    :                                +- CometProject
+               :                    :                    :                                   +- CometFilter
+               :                    :                    :                                      +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                    :                    +- BroadcastExchange
+               :                    :                       +- Project
+               :                    :                          +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               :                    :                             +- CometNativeColumnarToRow
+               :                    :                                +- CometSort
+               :                    :                                   +- CometExchange
+               :                    :                                      +- CometHashAggregate
+               :                    :                                         +- CometExchange
+               :                    :                                            +- CometHashAggregate
+               :                    :                                               +- CometProject
+               :                    :                                                  +- CometBroadcastHashJoin
+               :                    :                                                     :- CometFilter
+               :                    :                                                     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                    :                                                     :        +- SubqueryBroadcast
+               :                    :                                                     :           +- BroadcastExchange
+               :                    :                                                     :              +- CometNativeColumnarToRow
+               :                    :                                                     :                 +- CometProject
+               :                    :                                                     :                    +- CometFilter
+               :                    :                                                     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                    :                                                     +- CometBroadcastExchange
+               :                    :                                                        +- CometProject
+               :                    :                                                           +- CometFilter
+               :                    :                                                              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                    +- CometSort
+               :                       +- CometColumnarExchange
+               :                          +- HashAggregate
+               :                             +- Exchange
+               :                                +- HashAggregate
+               :                                   +- Project
+               :                                      +- BroadcastHashJoin
+               :                                         :- Project
+               :                                         :  +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               :                                         :     +- CometNativeColumnarToRow
+               :                                         :        +- CometSort
+               :                                         :           +- CometExchange
+               :                                         :              +- CometHashAggregate
+               :                                         :                 +- CometExchange
+               :                                         :                    +- CometHashAggregate
+               :                                         :                       +- CometProject
+               :                                         :                          +- CometBroadcastHashJoin
+               :                                         :                             :- CometFilter
+               :                                         :                             :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                                         :                             :        +- ReusedSubquery
+               :                                         :                             +- CometBroadcastExchange
+               :                                         :                                +- CometProject
+               :                                         :                                   +- CometFilter
+               :                                         :                                      +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                         +- BroadcastExchange
+               :                                            +- Project
+               :                                               +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               :                                                  +- CometNativeColumnarToRow
+               :                                                     +- CometSort
+               :                                                        +- CometExchange
+               :                                                           +- CometHashAggregate
+               :                                                              +- CometExchange
+               :                                                                 +- CometHashAggregate
+               :                                                                    +- CometProject
+               :                                                                       +- CometBroadcastHashJoin
+               :                                                                          :- CometFilter
+               :                                                                          :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                                                                          :        +- ReusedSubquery
+               :                                                                          +- CometBroadcastExchange
+               :                                                                             +- CometProject
+               :                                                                                +- CometFilter
+               :                                                                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               +- BroadcastExchange
+                  +- Project
+                     +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+                        +- CometNativeColumnarToRow
+                           +- CometSort
+                              +- CometExchange
+                                 +- CometProject
+                                    +- CometFilter
+                                       +- CometSortMergeJoin
+                                          :- CometSort
+                                          :  +- CometColumnarExchange
+                                          :     +- HashAggregate
+                                          :        +- Exchange
+                                          :           +- HashAggregate
+                                          :              +- Project
+                                          :                 +- BroadcastHashJoin
+                                          :                    :- Project
+                                          :                    :  +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+                                          :                    :     +- CometNativeColumnarToRow
+                                          :                    :        +- CometSort
+                                          :                    :           +- CometExchange
+                                          :                    :              +- CometHashAggregate
+                                          :                    :                 +- CometExchange
+                                          :                    :                    +- CometHashAggregate
+                                          :                    :                       +- CometProject
+                                          :                    :                          +- CometBroadcastHashJoin
+                                          :                    :                             :- CometFilter
+                                          :                    :                             :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                          :                    :                             :        +- SubqueryBroadcast
+                                          :                    :                             :           +- BroadcastExchange
+                                          :                    :                             :              +- CometNativeColumnarToRow
+                                          :                    :                             :                 +- CometProject
+                                          :                    :                             :                    +- CometFilter
+                                          :                    :                             :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                          :                    :                             +- CometBroadcastExchange
+                                          :                    :                                +- CometProject
+                                          :                    :                                   +- CometFilter
+                                          :                    :                                      +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                          :                    +- BroadcastExchange
+                                          :                       +- Project
+                                          :                          +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+                                          :                             +- CometNativeColumnarToRow
+                                          :                                +- CometSort
+                                          :                                   +- CometExchange
+                                          :                                      +- CometHashAggregate
+                                          :                                         +- CometExchange
+                                          :                                            +- CometHashAggregate
+                                          :                                               +- CometProject
+                                          :                                                  +- CometBroadcastHashJoin
+                                          :                                                     :- CometFilter
+                                          :                                                     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                          :                                                     :        +- SubqueryBroadcast
+                                          :                                                     :           +- BroadcastExchange
+                                          :                                                     :              +- CometNativeColumnarToRow
+                                          :                                                     :                 +- CometProject
+                                          :                                                     :                    +- CometFilter
+                                          :                                                     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                          :                                                     +- CometBroadcastExchange
+                                          :                                                        +- CometProject
+                                          :                                                           +- CometFilter
+                                          :                                                              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                          +- CometSort
+                                             +- CometColumnarExchange
+                                                +- HashAggregate
+                                                   +- Exchange
+                                                      +- HashAggregate
+                                                         +- Project
+                                                            +- BroadcastHashJoin
+                                                               :- Project
+                                                               :  +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+                                                               :     +- CometNativeColumnarToRow
+                                                               :        +- CometSort
+                                                               :           +- CometExchange
+                                                               :              +- CometHashAggregate
+                                                               :                 +- CometExchange
+                                                               :                    +- CometHashAggregate
+                                                               :                       +- CometProject
+                                                               :                          +- CometBroadcastHashJoin
+                                                               :                             :- CometFilter
+                                                               :                             :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                                               :                             :        +- ReusedSubquery
+                                                               :                             +- CometBroadcastExchange
+                                                               :                                +- CometProject
+                                                               :                                   +- CometFilter
+                                                               :                                      +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                               +- BroadcastExchange
+                                                                  +- Project
+                                                                     +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+                                                                        +- CometNativeColumnarToRow
+                                                                           +- CometSort
+                                                                              +- CometExchange
+                                                                                 +- CometHashAggregate
+                                                                                    +- CometExchange
+                                                                                       +- CometHashAggregate
+                                                                                          +- CometProject
+                                                                                             +- CometBroadcastHashJoin
+                                                                                                :- CometFilter
+                                                                                                :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                                                                                :        +- ReusedSubquery
+                                                                                                +- CometBroadcastExchange
+                                                                                                   +- CometProject
+                                                                                                      +- CometFilter
+                                                                                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 134 out of 196 eligible operators (68%). Final plan contains 14 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q57.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q57.native_datafusion/extended.txt
@@ -1,0 +1,102 @@
+TakeOrderedAndProject
++- Project
+   +- BroadcastHashJoin
+      :- Project
+      :  +- BroadcastHashJoin
+      :     :- Project
+      :     :  +- Filter
+      :     :     +- Window
+      :     :        +- Filter
+      :     :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      :     :              +- CometNativeColumnarToRow
+      :     :                 +- CometSort
+      :     :                    +- CometExchange
+      :     :                       +- CometHashAggregate
+      :     :                          +- CometExchange
+      :     :                             +- CometHashAggregate
+      :     :                                +- CometProject
+      :     :                                   +- CometBroadcastHashJoin
+      :     :                                      :- CometProject
+      :     :                                      :  +- CometBroadcastHashJoin
+      :     :                                      :     :- CometProject
+      :     :                                      :     :  +- CometBroadcastHashJoin
+      :     :                                      :     :     :- CometProject
+      :     :                                      :     :     :  +- CometFilter
+      :     :                                      :     :     :     +- CometNativeScan parquet spark_catalog.default.item
+      :     :                                      :     :     +- CometBroadcastExchange
+      :     :                                      :     :        +- CometFilter
+      :     :                                      :     :           +- CometNativeScan parquet spark_catalog.default.catalog_sales
+      :     :                                      :     :                 +- CometSubqueryBroadcast
+      :     :                                      :     :                    +- CometBroadcastExchange
+      :     :                                      :     :                       +- CometFilter
+      :     :                                      :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+      :     :                                      :     +- CometBroadcastExchange
+      :     :                                      :        +- CometFilter
+      :     :                                      :           +- CometNativeScan parquet spark_catalog.default.date_dim
+      :     :                                      +- CometBroadcastExchange
+      :     :                                         +- CometFilter
+      :     :                                            +- CometNativeScan parquet spark_catalog.default.call_center
+      :     +- BroadcastExchange
+      :        +- Project
+      :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      :              +- CometNativeColumnarToRow
+      :                 +- CometSort
+      :                    +- CometExchange
+      :                       +- CometHashAggregate
+      :                          +- CometExchange
+      :                             +- CometHashAggregate
+      :                                +- CometProject
+      :                                   +- CometBroadcastHashJoin
+      :                                      :- CometProject
+      :                                      :  +- CometBroadcastHashJoin
+      :                                      :     :- CometProject
+      :                                      :     :  +- CometBroadcastHashJoin
+      :                                      :     :     :- CometProject
+      :                                      :     :     :  +- CometFilter
+      :                                      :     :     :     +- CometNativeScan parquet spark_catalog.default.item
+      :                                      :     :     +- CometBroadcastExchange
+      :                                      :     :        +- CometFilter
+      :                                      :     :           +- CometNativeScan parquet spark_catalog.default.catalog_sales
+      :                                      :     :                 +- CometSubqueryBroadcast
+      :                                      :     :                    +- CometBroadcastExchange
+      :                                      :     :                       +- CometFilter
+      :                                      :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                                      :     +- CometBroadcastExchange
+      :                                      :        +- CometFilter
+      :                                      :           +- CometNativeScan parquet spark_catalog.default.date_dim
+      :                                      +- CometBroadcastExchange
+      :                                         +- CometFilter
+      :                                            +- CometNativeScan parquet spark_catalog.default.call_center
+      +- BroadcastExchange
+         +- Project
+            +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               +- CometNativeColumnarToRow
+                  +- CometSort
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometExchange
+                              +- CometHashAggregate
+                                 +- CometProject
+                                    +- CometBroadcastHashJoin
+                                       :- CometProject
+                                       :  +- CometBroadcastHashJoin
+                                       :     :- CometProject
+                                       :     :  +- CometBroadcastHashJoin
+                                       :     :     :- CometProject
+                                       :     :     :  +- CometFilter
+                                       :     :     :     +- CometNativeScan parquet spark_catalog.default.item
+                                       :     :     +- CometBroadcastExchange
+                                       :     :        +- CometFilter
+                                       :     :           +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                                       :     :                 +- CometSubqueryBroadcast
+                                       :     :                    +- CometBroadcastExchange
+                                       :     :                       +- CometFilter
+                                       :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       :     +- CometBroadcastExchange
+                                       :        +- CometFilter
+                                       :           +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       +- CometBroadcastExchange
+                                          +- CometFilter
+                                             +- CometNativeScan parquet spark_catalog.default.call_center
+
+Comet accelerated 78 out of 97 eligible operators (80%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q57.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q57.native_iceberg_compat/extended.txt
@@ -1,0 +1,105 @@
+TakeOrderedAndProject
++- Project
+   +- BroadcastHashJoin
+      :- Project
+      :  +- BroadcastHashJoin
+      :     :- Project
+      :     :  +- Filter
+      :     :     +- Window
+      :     :        +- Filter
+      :     :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      :     :              +- CometNativeColumnarToRow
+      :     :                 +- CometSort
+      :     :                    +- CometExchange
+      :     :                       +- CometHashAggregate
+      :     :                          +- CometExchange
+      :     :                             +- CometHashAggregate
+      :     :                                +- CometProject
+      :     :                                   +- CometBroadcastHashJoin
+      :     :                                      :- CometProject
+      :     :                                      :  +- CometBroadcastHashJoin
+      :     :                                      :     :- CometProject
+      :     :                                      :     :  +- CometBroadcastHashJoin
+      :     :                                      :     :     :- CometProject
+      :     :                                      :     :     :  +- CometFilter
+      :     :                                      :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :     :                                      :     :     +- CometBroadcastExchange
+      :     :                                      :     :        +- CometFilter
+      :     :                                      :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+      :     :                                      :     :                 +- SubqueryBroadcast
+      :     :                                      :     :                    +- BroadcastExchange
+      :     :                                      :     :                       +- CometNativeColumnarToRow
+      :     :                                      :     :                          +- CometFilter
+      :     :                                      :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :     :                                      :     +- CometBroadcastExchange
+      :     :                                      :        +- CometFilter
+      :     :                                      :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :     :                                      +- CometBroadcastExchange
+      :     :                                         +- CometFilter
+      :     :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.call_center
+      :     +- BroadcastExchange
+      :        +- Project
+      :           +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      :              +- CometNativeColumnarToRow
+      :                 +- CometSort
+      :                    +- CometExchange
+      :                       +- CometHashAggregate
+      :                          +- CometExchange
+      :                             +- CometHashAggregate
+      :                                +- CometProject
+      :                                   +- CometBroadcastHashJoin
+      :                                      :- CometProject
+      :                                      :  +- CometBroadcastHashJoin
+      :                                      :     :- CometProject
+      :                                      :     :  +- CometBroadcastHashJoin
+      :                                      :     :     :- CometProject
+      :                                      :     :     :  +- CometFilter
+      :                                      :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+      :                                      :     :     +- CometBroadcastExchange
+      :                                      :     :        +- CometFilter
+      :                                      :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+      :                                      :     :                 +- SubqueryBroadcast
+      :                                      :     :                    +- BroadcastExchange
+      :                                      :     :                       +- CometNativeColumnarToRow
+      :                                      :     :                          +- CometFilter
+      :                                      :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                                      :     +- CometBroadcastExchange
+      :                                      :        +- CometFilter
+      :                                      :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+      :                                      +- CometBroadcastExchange
+      :                                         +- CometFilter
+      :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.call_center
+      +- BroadcastExchange
+         +- Project
+            +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+               +- CometNativeColumnarToRow
+                  +- CometSort
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometExchange
+                              +- CometHashAggregate
+                                 +- CometProject
+                                    +- CometBroadcastHashJoin
+                                       :- CometProject
+                                       :  +- CometBroadcastHashJoin
+                                       :     :- CometProject
+                                       :     :  +- CometBroadcastHashJoin
+                                       :     :     :- CometProject
+                                       :     :     :  +- CometFilter
+                                       :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                       :     :     +- CometBroadcastExchange
+                                       :     :        +- CometFilter
+                                       :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                                       :     :                 +- SubqueryBroadcast
+                                       :     :                    +- BroadcastExchange
+                                       :     :                       +- CometNativeColumnarToRow
+                                       :     :                          +- CometFilter
+                                       :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       :     +- CometBroadcastExchange
+                                       :        +- CometFilter
+                                       :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       +- CometBroadcastExchange
+                                          +- CometFilter
+                                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.call_center
+
+Comet accelerated 75 out of 97 eligible operators (77%). Final plan contains 6 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q5a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q5a.native_datafusion/extended.txt
@@ -1,0 +1,320 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometUnion
+               :- CometHashAggregate
+               :  +- CometExchange
+               :     +- CometHashAggregate
+               :        +- CometUnion
+               :           :- CometHashAggregate
+               :           :  +- CometExchange
+               :           :     +- CometHashAggregate
+               :           :        +- CometProject
+               :           :           +- CometBroadcastHashJoin
+               :           :              :- CometUnion
+               :           :              :  :- CometProject
+               :           :              :  :  +- CometBroadcastHashJoin
+               :           :              :  :     :- CometProject
+               :           :              :  :     :  +- CometFilter
+               :           :              :  :     :     +- CometNativeScan parquet spark_catalog.default.store_sales
+               :           :              :  :     :           +- CometSubqueryBroadcast
+               :           :              :  :     :              +- CometBroadcastExchange
+               :           :              :  :     :                 +- CometProject
+               :           :              :  :     :                    +- CometFilter
+               :           :              :  :     :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :           :              :  :     +- CometBroadcastExchange
+               :           :              :  :        +- CometProject
+               :           :              :  :           +- CometFilter
+               :           :              :  :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :           :              :  +- CometProject
+               :           :              :     +- CometBroadcastHashJoin
+               :           :              :        :- CometProject
+               :           :              :        :  +- CometFilter
+               :           :              :        :     +- CometNativeScan parquet spark_catalog.default.store_returns
+               :           :              :        :           +- ReusedSubquery
+               :           :              :        +- CometBroadcastExchange
+               :           :              :           +- CometProject
+               :           :              :              +- CometFilter
+               :           :              :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+               :           :              +- CometBroadcastExchange
+               :           :                 +- CometProject
+               :           :                    +- CometFilter
+               :           :                       +- CometNativeScan parquet spark_catalog.default.store
+               :           :- CometHashAggregate
+               :           :  +- CometExchange
+               :           :     +- CometHashAggregate
+               :           :        +- CometProject
+               :           :           +- CometBroadcastHashJoin
+               :           :              :- CometUnion
+               :           :              :  :- CometProject
+               :           :              :  :  +- CometBroadcastHashJoin
+               :           :              :  :     :- CometProject
+               :           :              :  :     :  +- CometFilter
+               :           :              :  :     :     +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :           :              :  :     :           +- ReusedSubquery
+               :           :              :  :     +- CometBroadcastExchange
+               :           :              :  :        +- CometProject
+               :           :              :  :           +- CometFilter
+               :           :              :  :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :           :              :  +- CometProject
+               :           :              :     +- CometBroadcastHashJoin
+               :           :              :        :- CometProject
+               :           :              :        :  +- CometFilter
+               :           :              :        :     +- CometNativeScan parquet spark_catalog.default.catalog_returns
+               :           :              :        :           +- ReusedSubquery
+               :           :              :        +- CometBroadcastExchange
+               :           :              :           +- CometProject
+               :           :              :              +- CometFilter
+               :           :              :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+               :           :              +- CometBroadcastExchange
+               :           :                 +- CometProject
+               :           :                    +- CometFilter
+               :           :                       +- CometNativeScan parquet spark_catalog.default.catalog_page
+               :           +- CometHashAggregate
+               :              +- CometExchange
+               :                 +- CometHashAggregate
+               :                    +- CometProject
+               :                       +- CometBroadcastHashJoin
+               :                          :- CometUnion
+               :                          :  :- CometProject
+               :                          :  :  +- CometBroadcastHashJoin
+               :                          :  :     :- CometProject
+               :                          :  :     :  +- CometFilter
+               :                          :  :     :     +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                          :  :     :           +- ReusedSubquery
+               :                          :  :     +- CometBroadcastExchange
+               :                          :  :        +- CometProject
+               :                          :  :           +- CometFilter
+               :                          :  :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                          :  +- CometProject
+               :                          :     +- CometBroadcastHashJoin
+               :                          :        :- CometProject
+               :                          :        :  +- CometBroadcastHashJoin
+               :                          :        :     :- CometBroadcastExchange
+               :                          :        :     :  +- CometNativeScan parquet spark_catalog.default.web_returns
+               :                          :        :     :        +- ReusedSubquery
+               :                          :        :     +- CometProject
+               :                          :        :        +- CometFilter
+               :                          :        :           +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                          :        +- CometBroadcastExchange
+               :                          :           +- CometProject
+               :                          :              +- CometFilter
+               :                          :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                          +- CometBroadcastExchange
+               :                             +- CometProject
+               :                                +- CometFilter
+               :                                   +- CometNativeScan parquet spark_catalog.default.web_site
+               :- CometHashAggregate
+               :  +- CometExchange
+               :     +- CometHashAggregate
+               :        +- CometHashAggregate
+               :           +- CometExchange
+               :              +- CometHashAggregate
+               :                 +- CometUnion
+               :                    :- CometHashAggregate
+               :                    :  +- CometExchange
+               :                    :     +- CometHashAggregate
+               :                    :        +- CometProject
+               :                    :           +- CometBroadcastHashJoin
+               :                    :              :- CometUnion
+               :                    :              :  :- CometProject
+               :                    :              :  :  +- CometBroadcastHashJoin
+               :                    :              :  :     :- CometProject
+               :                    :              :  :     :  +- CometFilter
+               :                    :              :  :     :     +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                    :              :  :     :           +- CometSubqueryBroadcast
+               :                    :              :  :     :              +- CometBroadcastExchange
+               :                    :              :  :     :                 +- CometProject
+               :                    :              :  :     :                    +- CometFilter
+               :                    :              :  :     :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                    :              :  :     +- CometBroadcastExchange
+               :                    :              :  :        +- CometProject
+               :                    :              :  :           +- CometFilter
+               :                    :              :  :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                    :              :  +- CometProject
+               :                    :              :     +- CometBroadcastHashJoin
+               :                    :              :        :- CometProject
+               :                    :              :        :  +- CometFilter
+               :                    :              :        :     +- CometNativeScan parquet spark_catalog.default.store_returns
+               :                    :              :        :           +- ReusedSubquery
+               :                    :              :        +- CometBroadcastExchange
+               :                    :              :           +- CometProject
+               :                    :              :              +- CometFilter
+               :                    :              :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                    :              +- CometBroadcastExchange
+               :                    :                 +- CometProject
+               :                    :                    +- CometFilter
+               :                    :                       +- CometNativeScan parquet spark_catalog.default.store
+               :                    :- CometHashAggregate
+               :                    :  +- CometExchange
+               :                    :     +- CometHashAggregate
+               :                    :        +- CometProject
+               :                    :           +- CometBroadcastHashJoin
+               :                    :              :- CometUnion
+               :                    :              :  :- CometProject
+               :                    :              :  :  +- CometBroadcastHashJoin
+               :                    :              :  :     :- CometProject
+               :                    :              :  :     :  +- CometFilter
+               :                    :              :  :     :     +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                    :              :  :     :           +- ReusedSubquery
+               :                    :              :  :     +- CometBroadcastExchange
+               :                    :              :  :        +- CometProject
+               :                    :              :  :           +- CometFilter
+               :                    :              :  :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                    :              :  +- CometProject
+               :                    :              :     +- CometBroadcastHashJoin
+               :                    :              :        :- CometProject
+               :                    :              :        :  +- CometFilter
+               :                    :              :        :     +- CometNativeScan parquet spark_catalog.default.catalog_returns
+               :                    :              :        :           +- ReusedSubquery
+               :                    :              :        +- CometBroadcastExchange
+               :                    :              :           +- CometProject
+               :                    :              :              +- CometFilter
+               :                    :              :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                    :              +- CometBroadcastExchange
+               :                    :                 +- CometProject
+               :                    :                    +- CometFilter
+               :                    :                       +- CometNativeScan parquet spark_catalog.default.catalog_page
+               :                    +- CometHashAggregate
+               :                       +- CometExchange
+               :                          +- CometHashAggregate
+               :                             +- CometProject
+               :                                +- CometBroadcastHashJoin
+               :                                   :- CometUnion
+               :                                   :  :- CometProject
+               :                                   :  :  +- CometBroadcastHashJoin
+               :                                   :  :     :- CometProject
+               :                                   :  :     :  +- CometFilter
+               :                                   :  :     :     +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                                   :  :     :           +- ReusedSubquery
+               :                                   :  :     +- CometBroadcastExchange
+               :                                   :  :        +- CometProject
+               :                                   :  :           +- CometFilter
+               :                                   :  :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :  +- CometProject
+               :                                   :     +- CometBroadcastHashJoin
+               :                                   :        :- CometProject
+               :                                   :        :  +- CometBroadcastHashJoin
+               :                                   :        :     :- CometBroadcastExchange
+               :                                   :        :     :  +- CometNativeScan parquet spark_catalog.default.web_returns
+               :                                   :        :     :        +- ReusedSubquery
+               :                                   :        :     +- CometProject
+               :                                   :        :        +- CometFilter
+               :                                   :        :           +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                                   :        +- CometBroadcastExchange
+               :                                   :           +- CometProject
+               :                                   :              +- CometFilter
+               :                                   :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   +- CometBroadcastExchange
+               :                                      +- CometProject
+               :                                         +- CometFilter
+               :                                            +- CometNativeScan parquet spark_catalog.default.web_site
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometHashAggregate
+                           +- CometExchange
+                              +- CometHashAggregate
+                                 +- CometUnion
+                                    :- CometHashAggregate
+                                    :  +- CometExchange
+                                    :     +- CometHashAggregate
+                                    :        +- CometProject
+                                    :           +- CometBroadcastHashJoin
+                                    :              :- CometUnion
+                                    :              :  :- CometProject
+                                    :              :  :  +- CometBroadcastHashJoin
+                                    :              :  :     :- CometProject
+                                    :              :  :     :  +- CometFilter
+                                    :              :  :     :     +- CometNativeScan parquet spark_catalog.default.store_sales
+                                    :              :  :     :           +- CometSubqueryBroadcast
+                                    :              :  :     :              +- CometBroadcastExchange
+                                    :              :  :     :                 +- CometProject
+                                    :              :  :     :                    +- CometFilter
+                                    :              :  :     :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+                                    :              :  :     +- CometBroadcastExchange
+                                    :              :  :        +- CometProject
+                                    :              :  :           +- CometFilter
+                                    :              :  :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                    :              :  +- CometProject
+                                    :              :     +- CometBroadcastHashJoin
+                                    :              :        :- CometProject
+                                    :              :        :  +- CometFilter
+                                    :              :        :     +- CometNativeScan parquet spark_catalog.default.store_returns
+                                    :              :        :           +- ReusedSubquery
+                                    :              :        +- CometBroadcastExchange
+                                    :              :           +- CometProject
+                                    :              :              +- CometFilter
+                                    :              :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                                    :              +- CometBroadcastExchange
+                                    :                 +- CometProject
+                                    :                    +- CometFilter
+                                    :                       +- CometNativeScan parquet spark_catalog.default.store
+                                    :- CometHashAggregate
+                                    :  +- CometExchange
+                                    :     +- CometHashAggregate
+                                    :        +- CometProject
+                                    :           +- CometBroadcastHashJoin
+                                    :              :- CometUnion
+                                    :              :  :- CometProject
+                                    :              :  :  +- CometBroadcastHashJoin
+                                    :              :  :     :- CometProject
+                                    :              :  :     :  +- CometFilter
+                                    :              :  :     :     +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                                    :              :  :     :           +- ReusedSubquery
+                                    :              :  :     +- CometBroadcastExchange
+                                    :              :  :        +- CometProject
+                                    :              :  :           +- CometFilter
+                                    :              :  :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                    :              :  +- CometProject
+                                    :              :     +- CometBroadcastHashJoin
+                                    :              :        :- CometProject
+                                    :              :        :  +- CometFilter
+                                    :              :        :     +- CometNativeScan parquet spark_catalog.default.catalog_returns
+                                    :              :        :           +- ReusedSubquery
+                                    :              :        +- CometBroadcastExchange
+                                    :              :           +- CometProject
+                                    :              :              +- CometFilter
+                                    :              :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                                    :              +- CometBroadcastExchange
+                                    :                 +- CometProject
+                                    :                    +- CometFilter
+                                    :                       +- CometNativeScan parquet spark_catalog.default.catalog_page
+                                    +- CometHashAggregate
+                                       +- CometExchange
+                                          +- CometHashAggregate
+                                             +- CometProject
+                                                +- CometBroadcastHashJoin
+                                                   :- CometUnion
+                                                   :  :- CometProject
+                                                   :  :  +- CometBroadcastHashJoin
+                                                   :  :     :- CometProject
+                                                   :  :     :  +- CometFilter
+                                                   :  :     :     +- CometNativeScan parquet spark_catalog.default.web_sales
+                                                   :  :     :           +- ReusedSubquery
+                                                   :  :     +- CometBroadcastExchange
+                                                   :  :        +- CometProject
+                                                   :  :           +- CometFilter
+                                                   :  :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                   :  +- CometProject
+                                                   :     +- CometBroadcastHashJoin
+                                                   :        :- CometProject
+                                                   :        :  +- CometBroadcastHashJoin
+                                                   :        :     :- CometBroadcastExchange
+                                                   :        :     :  +- CometNativeScan parquet spark_catalog.default.web_returns
+                                                   :        :     :        +- ReusedSubquery
+                                                   :        :     +- CometProject
+                                                   :        :        +- CometFilter
+                                                   :        :           +- CometNativeScan parquet spark_catalog.default.web_sales
+                                                   :        +- CometBroadcastExchange
+                                                   :           +- CometProject
+                                                   :              +- CometFilter
+                                                   :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                   +- CometBroadcastExchange
+                                                      +- CometProject
+                                                         +- CometFilter
+                                                            +- CometNativeScan parquet spark_catalog.default.web_site
+
+Comet accelerated 299 out of 317 eligible operators (94%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q5a.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q5a.native_iceberg_compat/extended.txt
@@ -1,0 +1,323 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometUnion
+               :- CometHashAggregate
+               :  +- CometExchange
+               :     +- CometHashAggregate
+               :        +- CometUnion
+               :           :- CometHashAggregate
+               :           :  +- CometExchange
+               :           :     +- CometHashAggregate
+               :           :        +- CometProject
+               :           :           +- CometBroadcastHashJoin
+               :           :              :- CometUnion
+               :           :              :  :- CometProject
+               :           :              :  :  +- CometBroadcastHashJoin
+               :           :              :  :     :- CometProject
+               :           :              :  :     :  +- CometFilter
+               :           :              :  :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :           :              :  :     :           +- SubqueryBroadcast
+               :           :              :  :     :              +- BroadcastExchange
+               :           :              :  :     :                 +- CometNativeColumnarToRow
+               :           :              :  :     :                    +- CometProject
+               :           :              :  :     :                       +- CometFilter
+               :           :              :  :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :           :              :  :     +- CometBroadcastExchange
+               :           :              :  :        +- CometProject
+               :           :              :  :           +- CometFilter
+               :           :              :  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :           :              :  +- CometProject
+               :           :              :     +- CometBroadcastHashJoin
+               :           :              :        :- CometProject
+               :           :              :        :  +- CometFilter
+               :           :              :        :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+               :           :              :        :           +- ReusedSubquery
+               :           :              :        +- CometBroadcastExchange
+               :           :              :           +- CometProject
+               :           :              :              +- CometFilter
+               :           :              :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :           :              +- CometBroadcastExchange
+               :           :                 +- CometProject
+               :           :                    +- CometFilter
+               :           :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+               :           :- CometHashAggregate
+               :           :  +- CometExchange
+               :           :     +- CometHashAggregate
+               :           :        +- CometProject
+               :           :           +- CometBroadcastHashJoin
+               :           :              :- CometUnion
+               :           :              :  :- CometProject
+               :           :              :  :  +- CometBroadcastHashJoin
+               :           :              :  :     :- CometProject
+               :           :              :  :     :  +- CometFilter
+               :           :              :  :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :           :              :  :     :           +- ReusedSubquery
+               :           :              :  :     +- CometBroadcastExchange
+               :           :              :  :        +- CometProject
+               :           :              :  :           +- CometFilter
+               :           :              :  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :           :              :  +- CometProject
+               :           :              :     +- CometBroadcastHashJoin
+               :           :              :        :- CometProject
+               :           :              :        :  +- CometFilter
+               :           :              :        :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+               :           :              :        :           +- ReusedSubquery
+               :           :              :        +- CometBroadcastExchange
+               :           :              :           +- CometProject
+               :           :              :              +- CometFilter
+               :           :              :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :           :              +- CometBroadcastExchange
+               :           :                 +- CometProject
+               :           :                    +- CometFilter
+               :           :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_page
+               :           +- CometHashAggregate
+               :              +- CometExchange
+               :                 +- CometHashAggregate
+               :                    +- CometProject
+               :                       +- CometBroadcastHashJoin
+               :                          :- CometUnion
+               :                          :  :- CometProject
+               :                          :  :  +- CometBroadcastHashJoin
+               :                          :  :     :- CometProject
+               :                          :  :     :  +- CometFilter
+               :                          :  :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                          :  :     :           +- ReusedSubquery
+               :                          :  :     +- CometBroadcastExchange
+               :                          :  :        +- CometProject
+               :                          :  :           +- CometFilter
+               :                          :  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                          :  +- CometProject
+               :                          :     +- CometBroadcastHashJoin
+               :                          :        :- CometProject
+               :                          :        :  +- CometBroadcastHashJoin
+               :                          :        :     :- CometBroadcastExchange
+               :                          :        :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+               :                          :        :     :        +- ReusedSubquery
+               :                          :        :     +- CometProject
+               :                          :        :        +- CometFilter
+               :                          :        :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                          :        +- CometBroadcastExchange
+               :                          :           +- CometProject
+               :                          :              +- CometFilter
+               :                          :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                          +- CometBroadcastExchange
+               :                             +- CometProject
+               :                                +- CometFilter
+               :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_site
+               :- CometHashAggregate
+               :  +- CometExchange
+               :     +- CometHashAggregate
+               :        +- CometHashAggregate
+               :           +- CometExchange
+               :              +- CometHashAggregate
+               :                 +- CometUnion
+               :                    :- CometHashAggregate
+               :                    :  +- CometExchange
+               :                    :     +- CometHashAggregate
+               :                    :        +- CometProject
+               :                    :           +- CometBroadcastHashJoin
+               :                    :              :- CometUnion
+               :                    :              :  :- CometProject
+               :                    :              :  :  +- CometBroadcastHashJoin
+               :                    :              :  :     :- CometProject
+               :                    :              :  :     :  +- CometFilter
+               :                    :              :  :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                    :              :  :     :           +- SubqueryBroadcast
+               :                    :              :  :     :              +- BroadcastExchange
+               :                    :              :  :     :                 +- CometNativeColumnarToRow
+               :                    :              :  :     :                    +- CometProject
+               :                    :              :  :     :                       +- CometFilter
+               :                    :              :  :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                    :              :  :     +- CometBroadcastExchange
+               :                    :              :  :        +- CometProject
+               :                    :              :  :           +- CometFilter
+               :                    :              :  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                    :              :  +- CometProject
+               :                    :              :     +- CometBroadcastHashJoin
+               :                    :              :        :- CometProject
+               :                    :              :        :  +- CometFilter
+               :                    :              :        :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+               :                    :              :        :           +- ReusedSubquery
+               :                    :              :        +- CometBroadcastExchange
+               :                    :              :           +- CometProject
+               :                    :              :              +- CometFilter
+               :                    :              :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                    :              +- CometBroadcastExchange
+               :                    :                 +- CometProject
+               :                    :                    +- CometFilter
+               :                    :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+               :                    :- CometHashAggregate
+               :                    :  +- CometExchange
+               :                    :     +- CometHashAggregate
+               :                    :        +- CometProject
+               :                    :           +- CometBroadcastHashJoin
+               :                    :              :- CometUnion
+               :                    :              :  :- CometProject
+               :                    :              :  :  +- CometBroadcastHashJoin
+               :                    :              :  :     :- CometProject
+               :                    :              :  :     :  +- CometFilter
+               :                    :              :  :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                    :              :  :     :           +- ReusedSubquery
+               :                    :              :  :     +- CometBroadcastExchange
+               :                    :              :  :        +- CometProject
+               :                    :              :  :           +- CometFilter
+               :                    :              :  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                    :              :  +- CometProject
+               :                    :              :     +- CometBroadcastHashJoin
+               :                    :              :        :- CometProject
+               :                    :              :        :  +- CometFilter
+               :                    :              :        :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+               :                    :              :        :           +- ReusedSubquery
+               :                    :              :        +- CometBroadcastExchange
+               :                    :              :           +- CometProject
+               :                    :              :              +- CometFilter
+               :                    :              :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                    :              +- CometBroadcastExchange
+               :                    :                 +- CometProject
+               :                    :                    +- CometFilter
+               :                    :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_page
+               :                    +- CometHashAggregate
+               :                       +- CometExchange
+               :                          +- CometHashAggregate
+               :                             +- CometProject
+               :                                +- CometBroadcastHashJoin
+               :                                   :- CometUnion
+               :                                   :  :- CometProject
+               :                                   :  :  +- CometBroadcastHashJoin
+               :                                   :  :     :- CometProject
+               :                                   :  :     :  +- CometFilter
+               :                                   :  :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                                   :  :     :           +- ReusedSubquery
+               :                                   :  :     +- CometBroadcastExchange
+               :                                   :  :        +- CometProject
+               :                                   :  :           +- CometFilter
+               :                                   :  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :  +- CometProject
+               :                                   :     +- CometBroadcastHashJoin
+               :                                   :        :- CometProject
+               :                                   :        :  +- CometBroadcastHashJoin
+               :                                   :        :     :- CometBroadcastExchange
+               :                                   :        :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+               :                                   :        :     :        +- ReusedSubquery
+               :                                   :        :     +- CometProject
+               :                                   :        :        +- CometFilter
+               :                                   :        :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                                   :        +- CometBroadcastExchange
+               :                                   :           +- CometProject
+               :                                   :              +- CometFilter
+               :                                   :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   +- CometBroadcastExchange
+               :                                      +- CometProject
+               :                                         +- CometFilter
+               :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_site
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometHashAggregate
+                           +- CometExchange
+                              +- CometHashAggregate
+                                 +- CometUnion
+                                    :- CometHashAggregate
+                                    :  +- CometExchange
+                                    :     +- CometHashAggregate
+                                    :        +- CometProject
+                                    :           +- CometBroadcastHashJoin
+                                    :              :- CometUnion
+                                    :              :  :- CometProject
+                                    :              :  :  +- CometBroadcastHashJoin
+                                    :              :  :     :- CometProject
+                                    :              :  :     :  +- CometFilter
+                                    :              :  :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                    :              :  :     :           +- SubqueryBroadcast
+                                    :              :  :     :              +- BroadcastExchange
+                                    :              :  :     :                 +- CometNativeColumnarToRow
+                                    :              :  :     :                    +- CometProject
+                                    :              :  :     :                       +- CometFilter
+                                    :              :  :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                    :              :  :     +- CometBroadcastExchange
+                                    :              :  :        +- CometProject
+                                    :              :  :           +- CometFilter
+                                    :              :  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                    :              :  +- CometProject
+                                    :              :     +- CometBroadcastHashJoin
+                                    :              :        :- CometProject
+                                    :              :        :  +- CometFilter
+                                    :              :        :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+                                    :              :        :           +- ReusedSubquery
+                                    :              :        +- CometBroadcastExchange
+                                    :              :           +- CometProject
+                                    :              :              +- CometFilter
+                                    :              :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                    :              +- CometBroadcastExchange
+                                    :                 +- CometProject
+                                    :                    +- CometFilter
+                                    :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                                    :- CometHashAggregate
+                                    :  +- CometExchange
+                                    :     +- CometHashAggregate
+                                    :        +- CometProject
+                                    :           +- CometBroadcastHashJoin
+                                    :              :- CometUnion
+                                    :              :  :- CometProject
+                                    :              :  :  +- CometBroadcastHashJoin
+                                    :              :  :     :- CometProject
+                                    :              :  :     :  +- CometFilter
+                                    :              :  :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                                    :              :  :     :           +- ReusedSubquery
+                                    :              :  :     +- CometBroadcastExchange
+                                    :              :  :        +- CometProject
+                                    :              :  :           +- CometFilter
+                                    :              :  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                    :              :  +- CometProject
+                                    :              :     +- CometBroadcastHashJoin
+                                    :              :        :- CometProject
+                                    :              :        :  +- CometFilter
+                                    :              :        :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+                                    :              :        :           +- ReusedSubquery
+                                    :              :        +- CometBroadcastExchange
+                                    :              :           +- CometProject
+                                    :              :              +- CometFilter
+                                    :              :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                    :              +- CometBroadcastExchange
+                                    :                 +- CometProject
+                                    :                    +- CometFilter
+                                    :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_page
+                                    +- CometHashAggregate
+                                       +- CometExchange
+                                          +- CometHashAggregate
+                                             +- CometProject
+                                                +- CometBroadcastHashJoin
+                                                   :- CometUnion
+                                                   :  :- CometProject
+                                                   :  :  +- CometBroadcastHashJoin
+                                                   :  :     :- CometProject
+                                                   :  :     :  +- CometFilter
+                                                   :  :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                                   :  :     :           +- ReusedSubquery
+                                                   :  :     +- CometBroadcastExchange
+                                                   :  :        +- CometProject
+                                                   :  :           +- CometFilter
+                                                   :  :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                   :  +- CometProject
+                                                   :     +- CometBroadcastHashJoin
+                                                   :        :- CometProject
+                                                   :        :  +- CometBroadcastHashJoin
+                                                   :        :     :- CometBroadcastExchange
+                                                   :        :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+                                                   :        :     :        +- ReusedSubquery
+                                                   :        :     +- CometProject
+                                                   :        :        +- CometFilter
+                                                   :        :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                                   :        +- CometBroadcastExchange
+                                                   :           +- CometProject
+                                                   :              +- CometFilter
+                                                   :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                   +- CometBroadcastExchange
+                                                      +- CometProject
+                                                         +- CometFilter
+                                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_site
+
+Comet accelerated 296 out of 317 eligible operators (93%). Final plan contains 4 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q6.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q6.native_datafusion/extended.txt
@@ -1,0 +1,65 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometFilter
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometProject
+                     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :- CometProject
+                     :     :     :     :  +- CometFilter
+                     :     :     :     :     +- CometNativeScan parquet spark_catalog.default.customer_address
+                     :     :     :     +- CometBroadcastExchange
+                     :     :     :        +- CometFilter
+                     :     :     :           +- CometNativeScan parquet spark_catalog.default.customer
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometFilter
+                     :     :           +- CometNativeScan parquet spark_catalog.default.store_sales
+                     :     :                 +- CometSubqueryBroadcast
+                     :     :                    +- CometBroadcastExchange
+                     :     :                       +- CometProject
+                     :     :                          +- CometFilter
+                     :     :                             :  +- ReusedSubquery
+                     :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :     :                                   +- Subquery
+                     :     :                                      +- CometNativeColumnarToRow
+                     :     :                                         +- CometHashAggregate
+                     :     :                                            +- CometExchange
+                     :     :                                               +- CometHashAggregate
+                     :     :                                                  +- CometProject
+                     :     :                                                     +- CometFilter
+                     :     :                                                        +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              :  +- ReusedSubquery
+                     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                     :                    +- Subquery
+                     :                       +- CometNativeColumnarToRow
+                     :                          +- CometHashAggregate
+                     :                             +- CometExchange
+                     :                                +- CometHashAggregate
+                     :                                   +- CometProject
+                     :                                      +- CometFilter
+                     :                                         +- CometNativeScan parquet spark_catalog.default.date_dim
+                     +- CometBroadcastExchange
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometFilter
+                              :  +- CometNativeScan parquet spark_catalog.default.item
+                              +- CometBroadcastExchange
+                                 +- CometFilter
+                                    +- CometHashAggregate
+                                       +- CometExchange
+                                          +- CometHashAggregate
+                                             +- CometProject
+                                                +- CometFilter
+                                                   +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 55 out of 60 eligible operators (91%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q6.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q6.native_iceberg_compat/extended.txt
@@ -1,0 +1,59 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometFilter
+      +- CometHashAggregate
+         +- CometExchange
+            +- CometHashAggregate
+               +- CometProject
+                  +- CometBroadcastHashJoin
+                     :- CometProject
+                     :  +- CometBroadcastHashJoin
+                     :     :- CometProject
+                     :     :  +- CometBroadcastHashJoin
+                     :     :     :- CometProject
+                     :     :     :  +- CometBroadcastHashJoin
+                     :     :     :     :- CometProject
+                     :     :     :     :  +- CometFilter
+                     :     :     :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                     :     :     :     +- CometBroadcastExchange
+                     :     :     :        +- CometFilter
+                     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                     :     :     +- CometBroadcastExchange
+                     :     :        +- CometFilter
+                     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                     :     :                 +- SubqueryBroadcast
+                     :     :                    +- BroadcastExchange
+                     :     :                       +- CometNativeColumnarToRow
+                     :     :                          +- CometProject
+                     :     :                             +- CometFilter
+                     :     :                                :  +- ReusedSubquery
+                     :     :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :     :                                      +- Subquery
+                     :     :                                         +- CometNativeColumnarToRow
+                     :     :                                            +- CometHashAggregate
+                     :     :                                               +- CometExchange
+                     :     :                                                  +- CometHashAggregate
+                     :     :                                                     +- CometProject
+                     :     :                                                        +- CometFilter
+                     :     :                                                           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :     +- CometBroadcastExchange
+                     :        +- CometProject
+                     :           +- CometFilter
+                     :              :  +- ReusedSubquery
+                     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                     :                    +- ReusedSubquery
+                     +- CometBroadcastExchange
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometFilter
+                              :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                              +- CometBroadcastExchange
+                                 +- CometFilter
+                                    +- CometHashAggregate
+                                       +- CometExchange
+                                          +- CometHashAggregate
+                                             +- CometProject
+                                                +- CometFilter
+                                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 48 out of 54 eligible operators (88%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q64.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q64.native_datafusion/extended.txt
@@ -1,0 +1,245 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometProject
+         +- CometSortMergeJoin
+            :- CometSort
+            :  +- CometExchange
+            :     +- CometHashAggregate
+            :        +- CometHashAggregate
+            :           +- CometProject
+            :              +- CometBroadcastHashJoin
+            :                 :- CometProject
+            :                 :  +- CometBroadcastHashJoin
+            :                 :     :- CometProject
+            :                 :     :  +- CometBroadcastHashJoin
+            :                 :     :     :- CometProject
+            :                 :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :- CometProject
+            :                 :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :- CometProject
+            :                 :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometSortMergeJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometSort
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :  +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :     +- CometNativeScan parquet spark_catalog.default.store_sales
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :           +- CometSubqueryBroadcast
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :              +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                 +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                 +- CometNativeScan parquet spark_catalog.default.store_returns
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometSort
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometHashAggregate
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                 +- CometExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                    +- CometHashAggregate
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                       +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                          +- CometSortMergeJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :- CometSort
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :  +- CometExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :     +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :           +- CometNativeScan parquet spark_catalog.default.catalog_sales
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             +- CometSort
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                +- CometExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                   +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                      +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                         +- CometNativeScan parquet spark_catalog.default.catalog_returns
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.store
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.customer
+            :                 :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.date_dim
+            :                 :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :        +- CometProject
+            :                 :     :     :     :     :     :     :     :     :           +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+            :                 :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :        +- CometProject
+            :                 :     :     :     :     :     :     :     :           +- CometFilter
+            :                 :     :     :     :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+            :                 :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.promotion
+            :                 :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.household_demographics
+            :                 :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.household_demographics
+            :                 :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :        +- CometProject
+            :                 :     :     :     :           +- CometFilter
+            :                 :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+            :                 :     :     :     +- CometBroadcastExchange
+            :                 :     :     :        +- CometProject
+            :                 :     :     :           +- CometFilter
+            :                 :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+            :                 :     :     +- CometBroadcastExchange
+            :                 :     :        +- CometFilter
+            :                 :     :           +- CometNativeScan parquet spark_catalog.default.income_band
+            :                 :     +- CometBroadcastExchange
+            :                 :        +- CometFilter
+            :                 :           +- CometNativeScan parquet spark_catalog.default.income_band
+            :                 +- CometBroadcastExchange
+            :                    +- CometProject
+            :                       +- CometFilter
+            :                          +- CometNativeScan parquet spark_catalog.default.item
+            +- CometSort
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometBroadcastHashJoin
+                              :     :- CometProject
+                              :     :  +- CometBroadcastHashJoin
+                              :     :     :- CometProject
+                              :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :- CometProject
+                              :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :- CometProject
+                              :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometSortMergeJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometSort
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :  +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :     +- CometNativeScan parquet spark_catalog.default.store_sales
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :           +- CometSubqueryBroadcast
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :              +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                 +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                 +- CometNativeScan parquet spark_catalog.default.store_returns
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometSort
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometHashAggregate
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                 +- CometExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                    +- CometHashAggregate
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                       +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                          +- CometSortMergeJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :- CometSort
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :  +- CometExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :     +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :           +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             +- CometSort
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                +- CometExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                   +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                      +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                         +- CometNativeScan parquet spark_catalog.default.catalog_returns
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.store
+                              :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.customer
+                              :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :        +- CometProject
+                              :     :     :     :     :     :     :     :     :           +- CometFilter
+                              :     :     :     :     :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+                              :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :        +- CometProject
+                              :     :     :     :     :     :     :     :           +- CometFilter
+                              :     :     :     :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+                              :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.promotion
+                              :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.household_demographics
+                              :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.household_demographics
+                              :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :        +- CometProject
+                              :     :     :     :           +- CometFilter
+                              :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                              :     :     :     +- CometBroadcastExchange
+                              :     :     :        +- CometProject
+                              :     :     :           +- CometFilter
+                              :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_address
+                              :     :     +- CometBroadcastExchange
+                              :     :        +- CometFilter
+                              :     :           +- CometNativeScan parquet spark_catalog.default.income_band
+                              :     +- CometBroadcastExchange
+                              :        +- CometFilter
+                              :           +- CometNativeScan parquet spark_catalog.default.income_band
+                              +- CometBroadcastExchange
+                                 +- CometProject
+                                    +- CometFilter
+                                       +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 240 out of 242 eligible operators (99%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q64.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q64.native_iceberg_compat/extended.txt
@@ -1,0 +1,247 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometExchange
+      +- CometProject
+         +- CometSortMergeJoin
+            :- CometSort
+            :  +- CometExchange
+            :     +- CometHashAggregate
+            :        +- CometHashAggregate
+            :           +- CometProject
+            :              +- CometBroadcastHashJoin
+            :                 :- CometProject
+            :                 :  +- CometBroadcastHashJoin
+            :                 :     :- CometProject
+            :                 :     :  +- CometBroadcastHashJoin
+            :                 :     :     :- CometProject
+            :                 :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :- CometProject
+            :                 :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :- CometProject
+            :                 :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometSortMergeJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometSort
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometBroadcastHashJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :  +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :           +- SubqueryBroadcast
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :              +- BroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                 +- CometNativeColumnarToRow
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                    +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometSort
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometHashAggregate
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                 +- CometExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                    +- CometHashAggregate
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                       +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                          +- CometSortMergeJoin
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :- CometSort
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :  +- CometExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :     +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             +- CometSort
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                +- CometExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                   +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                      +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometProject
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+            :                 :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+            :                 :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :                 :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+            :                 :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :     :        +- CometProject
+            :                 :     :     :     :     :     :     :     :     :           +- CometFilter
+            :                 :     :     :     :     :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+            :                 :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :     :        +- CometProject
+            :                 :     :     :     :     :     :     :     :           +- CometFilter
+            :                 :     :     :     :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+            :                 :     :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+            :                 :     :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+            :                 :     :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :     :        +- CometFilter
+            :                 :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+            :                 :     :     :     :     +- CometBroadcastExchange
+            :                 :     :     :     :        +- CometProject
+            :                 :     :     :     :           +- CometFilter
+            :                 :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+            :                 :     :     :     +- CometBroadcastExchange
+            :                 :     :     :        +- CometProject
+            :                 :     :     :           +- CometFilter
+            :                 :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+            :                 :     :     +- CometBroadcastExchange
+            :                 :     :        +- CometFilter
+            :                 :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.income_band
+            :                 :     +- CometBroadcastExchange
+            :                 :        +- CometFilter
+            :                 :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.income_band
+            :                 +- CometBroadcastExchange
+            :                    +- CometProject
+            :                       +- CometFilter
+            :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+            +- CometSort
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometBroadcastHashJoin
+                              :     :- CometProject
+                              :     :  +- CometBroadcastHashJoin
+                              :     :     :- CometProject
+                              :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :- CometProject
+                              :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :- CometProject
+                              :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometSortMergeJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :- CometSort
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :  +- CometExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometBroadcastHashJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :  +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :           +- SubqueryBroadcast
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :              +- BroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                 +- CometNativeColumnarToRow
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                    +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometSort
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometHashAggregate
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                 +- CometExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                    +- CometHashAggregate
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                       +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                          +- CometSortMergeJoin
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :- CometSort
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :  +- CometExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :     +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                             +- CometSort
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                +- CometExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                   +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                      +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     :                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :     :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :     :        +- CometProject
+                              :     :     :     :     :     :     :     :     :     :     :     :     :           +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                              :     :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                              :     :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :     :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :     :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :     :        +- CometProject
+                              :     :     :     :     :     :     :     :     :           +- CometFilter
+                              :     :     :     :     :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+                              :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :     :        +- CometProject
+                              :     :     :     :     :     :     :     :           +- CometFilter
+                              :     :     :     :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+                              :     :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+                              :     :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+                              :     :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :     :        +- CometFilter
+                              :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+                              :     :     :     :     +- CometBroadcastExchange
+                              :     :     :     :        +- CometProject
+                              :     :     :     :           +- CometFilter
+                              :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                              :     :     :     +- CometBroadcastExchange
+                              :     :     :        +- CometProject
+                              :     :     :           +- CometFilter
+                              :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_address
+                              :     :     +- CometBroadcastExchange
+                              :     :        +- CometFilter
+                              :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.income_band
+                              :     +- CometBroadcastExchange
+                              :        +- CometFilter
+                              :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.income_band
+                              +- CometBroadcastExchange
+                                 +- CometProject
+                                    +- CometFilter
+                                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 238 out of 242 eligible operators (98%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q67a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q67a.native_datafusion/extended.txt
@@ -1,0 +1,289 @@
+TakeOrderedAndProject
++- Filter
+   +- Window
+      +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+         +- CometNativeColumnarToRow
+            +- CometSort
+               +- CometColumnarExchange
+                  +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+                     +- CometNativeColumnarToRow
+                        +- CometSort
+                           +- CometUnion
+                              :- CometHashAggregate
+                              :  +- CometExchange
+                              :     +- CometHashAggregate
+                              :        +- CometProject
+                              :           +- CometBroadcastHashJoin
+                              :              :- CometProject
+                              :              :  +- CometBroadcastHashJoin
+                              :              :     :- CometProject
+                              :              :     :  +- CometBroadcastHashJoin
+                              :              :     :     :- CometFilter
+                              :              :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                              :              :     :     :        +- CometSubqueryBroadcast
+                              :              :     :     :           +- CometBroadcastExchange
+                              :              :     :     :              +- CometProject
+                              :              :     :     :                 +- CometFilter
+                              :              :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :              :     :     +- CometBroadcastExchange
+                              :              :     :        +- CometProject
+                              :              :     :           +- CometFilter
+                              :              :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :              :     +- CometBroadcastExchange
+                              :              :        +- CometProject
+                              :              :           +- CometFilter
+                              :              :              +- CometNativeScan parquet spark_catalog.default.store
+                              :              +- CometBroadcastExchange
+                              :                 +- CometProject
+                              :                    +- CometFilter
+                              :                       +- CometNativeScan parquet spark_catalog.default.item
+                              :- CometHashAggregate
+                              :  +- CometExchange
+                              :     +- CometHashAggregate
+                              :        +- CometHashAggregate
+                              :           +- CometExchange
+                              :              +- CometHashAggregate
+                              :                 +- CometProject
+                              :                    +- CometBroadcastHashJoin
+                              :                       :- CometProject
+                              :                       :  +- CometBroadcastHashJoin
+                              :                       :     :- CometProject
+                              :                       :     :  +- CometBroadcastHashJoin
+                              :                       :     :     :- CometFilter
+                              :                       :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                              :                       :     :     :        +- CometSubqueryBroadcast
+                              :                       :     :     :           +- CometBroadcastExchange
+                              :                       :     :     :              +- CometProject
+                              :                       :     :     :                 +- CometFilter
+                              :                       :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :                       :     :     +- CometBroadcastExchange
+                              :                       :     :        +- CometProject
+                              :                       :     :           +- CometFilter
+                              :                       :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :                       :     +- CometBroadcastExchange
+                              :                       :        +- CometProject
+                              :                       :           +- CometFilter
+                              :                       :              +- CometNativeScan parquet spark_catalog.default.store
+                              :                       +- CometBroadcastExchange
+                              :                          +- CometProject
+                              :                             +- CometFilter
+                              :                                +- CometNativeScan parquet spark_catalog.default.item
+                              :- CometHashAggregate
+                              :  +- CometExchange
+                              :     +- CometHashAggregate
+                              :        +- CometHashAggregate
+                              :           +- CometExchange
+                              :              +- CometHashAggregate
+                              :                 +- CometProject
+                              :                    +- CometBroadcastHashJoin
+                              :                       :- CometProject
+                              :                       :  +- CometBroadcastHashJoin
+                              :                       :     :- CometProject
+                              :                       :     :  +- CometBroadcastHashJoin
+                              :                       :     :     :- CometFilter
+                              :                       :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                              :                       :     :     :        +- CometSubqueryBroadcast
+                              :                       :     :     :           +- CometBroadcastExchange
+                              :                       :     :     :              +- CometProject
+                              :                       :     :     :                 +- CometFilter
+                              :                       :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :                       :     :     +- CometBroadcastExchange
+                              :                       :     :        +- CometProject
+                              :                       :     :           +- CometFilter
+                              :                       :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :                       :     +- CometBroadcastExchange
+                              :                       :        +- CometProject
+                              :                       :           +- CometFilter
+                              :                       :              +- CometNativeScan parquet spark_catalog.default.store
+                              :                       +- CometBroadcastExchange
+                              :                          +- CometProject
+                              :                             +- CometFilter
+                              :                                +- CometNativeScan parquet spark_catalog.default.item
+                              :- CometHashAggregate
+                              :  +- CometExchange
+                              :     +- CometHashAggregate
+                              :        +- CometHashAggregate
+                              :           +- CometExchange
+                              :              +- CometHashAggregate
+                              :                 +- CometProject
+                              :                    +- CometBroadcastHashJoin
+                              :                       :- CometProject
+                              :                       :  +- CometBroadcastHashJoin
+                              :                       :     :- CometProject
+                              :                       :     :  +- CometBroadcastHashJoin
+                              :                       :     :     :- CometFilter
+                              :                       :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                              :                       :     :     :        +- CometSubqueryBroadcast
+                              :                       :     :     :           +- CometBroadcastExchange
+                              :                       :     :     :              +- CometProject
+                              :                       :     :     :                 +- CometFilter
+                              :                       :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :                       :     :     +- CometBroadcastExchange
+                              :                       :     :        +- CometProject
+                              :                       :     :           +- CometFilter
+                              :                       :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :                       :     +- CometBroadcastExchange
+                              :                       :        +- CometProject
+                              :                       :           +- CometFilter
+                              :                       :              +- CometNativeScan parquet spark_catalog.default.store
+                              :                       +- CometBroadcastExchange
+                              :                          +- CometProject
+                              :                             +- CometFilter
+                              :                                +- CometNativeScan parquet spark_catalog.default.item
+                              :- CometHashAggregate
+                              :  +- CometExchange
+                              :     +- CometHashAggregate
+                              :        +- CometHashAggregate
+                              :           +- CometExchange
+                              :              +- CometHashAggregate
+                              :                 +- CometProject
+                              :                    +- CometBroadcastHashJoin
+                              :                       :- CometProject
+                              :                       :  +- CometBroadcastHashJoin
+                              :                       :     :- CometProject
+                              :                       :     :  +- CometBroadcastHashJoin
+                              :                       :     :     :- CometFilter
+                              :                       :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                              :                       :     :     :        +- CometSubqueryBroadcast
+                              :                       :     :     :           +- CometBroadcastExchange
+                              :                       :     :     :              +- CometProject
+                              :                       :     :     :                 +- CometFilter
+                              :                       :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :                       :     :     +- CometBroadcastExchange
+                              :                       :     :        +- CometProject
+                              :                       :     :           +- CometFilter
+                              :                       :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :                       :     +- CometBroadcastExchange
+                              :                       :        +- CometProject
+                              :                       :           +- CometFilter
+                              :                       :              +- CometNativeScan parquet spark_catalog.default.store
+                              :                       +- CometBroadcastExchange
+                              :                          +- CometProject
+                              :                             +- CometFilter
+                              :                                +- CometNativeScan parquet spark_catalog.default.item
+                              :- CometHashAggregate
+                              :  +- CometExchange
+                              :     +- CometHashAggregate
+                              :        +- CometHashAggregate
+                              :           +- CometExchange
+                              :              +- CometHashAggregate
+                              :                 +- CometProject
+                              :                    +- CometBroadcastHashJoin
+                              :                       :- CometProject
+                              :                       :  +- CometBroadcastHashJoin
+                              :                       :     :- CometProject
+                              :                       :     :  +- CometBroadcastHashJoin
+                              :                       :     :     :- CometFilter
+                              :                       :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                              :                       :     :     :        +- CometSubqueryBroadcast
+                              :                       :     :     :           +- CometBroadcastExchange
+                              :                       :     :     :              +- CometProject
+                              :                       :     :     :                 +- CometFilter
+                              :                       :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :                       :     :     +- CometBroadcastExchange
+                              :                       :     :        +- CometProject
+                              :                       :     :           +- CometFilter
+                              :                       :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :                       :     +- CometBroadcastExchange
+                              :                       :        +- CometProject
+                              :                       :           +- CometFilter
+                              :                       :              +- CometNativeScan parquet spark_catalog.default.store
+                              :                       +- CometBroadcastExchange
+                              :                          +- CometProject
+                              :                             +- CometFilter
+                              :                                +- CometNativeScan parquet spark_catalog.default.item
+                              :- CometHashAggregate
+                              :  +- CometExchange
+                              :     +- CometHashAggregate
+                              :        +- CometHashAggregate
+                              :           +- CometExchange
+                              :              +- CometHashAggregate
+                              :                 +- CometProject
+                              :                    +- CometBroadcastHashJoin
+                              :                       :- CometProject
+                              :                       :  +- CometBroadcastHashJoin
+                              :                       :     :- CometProject
+                              :                       :     :  +- CometBroadcastHashJoin
+                              :                       :     :     :- CometFilter
+                              :                       :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                              :                       :     :     :        +- CometSubqueryBroadcast
+                              :                       :     :     :           +- CometBroadcastExchange
+                              :                       :     :     :              +- CometProject
+                              :                       :     :     :                 +- CometFilter
+                              :                       :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :                       :     :     +- CometBroadcastExchange
+                              :                       :     :        +- CometProject
+                              :                       :     :           +- CometFilter
+                              :                       :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :                       :     +- CometBroadcastExchange
+                              :                       :        +- CometProject
+                              :                       :           +- CometFilter
+                              :                       :              +- CometNativeScan parquet spark_catalog.default.store
+                              :                       +- CometBroadcastExchange
+                              :                          +- CometProject
+                              :                             +- CometFilter
+                              :                                +- CometNativeScan parquet spark_catalog.default.item
+                              :- CometHashAggregate
+                              :  +- CometExchange
+                              :     +- CometHashAggregate
+                              :        +- CometHashAggregate
+                              :           +- CometExchange
+                              :              +- CometHashAggregate
+                              :                 +- CometProject
+                              :                    +- CometBroadcastHashJoin
+                              :                       :- CometProject
+                              :                       :  +- CometBroadcastHashJoin
+                              :                       :     :- CometProject
+                              :                       :     :  +- CometBroadcastHashJoin
+                              :                       :     :     :- CometFilter
+                              :                       :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                              :                       :     :     :        +- CometSubqueryBroadcast
+                              :                       :     :     :           +- CometBroadcastExchange
+                              :                       :     :     :              +- CometProject
+                              :                       :     :     :                 +- CometFilter
+                              :                       :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :                       :     :     +- CometBroadcastExchange
+                              :                       :     :        +- CometProject
+                              :                       :     :           +- CometFilter
+                              :                       :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                              :                       :     +- CometBroadcastExchange
+                              :                       :        +- CometProject
+                              :                       :           +- CometFilter
+                              :                       :              +- CometNativeScan parquet spark_catalog.default.store
+                              :                       +- CometBroadcastExchange
+                              :                          +- CometProject
+                              :                             +- CometFilter
+                              :                                +- CometNativeScan parquet spark_catalog.default.item
+                              +- CometHashAggregate
+                                 +- CometExchange
+                                    +- CometHashAggregate
+                                       +- CometHashAggregate
+                                          +- CometExchange
+                                             +- CometHashAggregate
+                                                +- CometProject
+                                                   +- CometBroadcastHashJoin
+                                                      :- CometProject
+                                                      :  +- CometBroadcastHashJoin
+                                                      :     :- CometProject
+                                                      :     :  +- CometBroadcastHashJoin
+                                                      :     :     :- CometFilter
+                                                      :     :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                                      :     :     :        +- CometSubqueryBroadcast
+                                                      :     :     :           +- CometBroadcastExchange
+                                                      :     :     :              +- CometProject
+                                                      :     :     :                 +- CometFilter
+                                                      :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                      :     :     +- CometBroadcastExchange
+                                                      :     :        +- CometProject
+                                                      :     :           +- CometFilter
+                                                      :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                      :     +- CometBroadcastExchange
+                                                      :        +- CometProject
+                                                      :           +- CometFilter
+                                                      :              +- CometNativeScan parquet spark_catalog.default.store
+                                                      +- CometBroadcastExchange
+                                                         +- CometProject
+                                                            +- CometFilter
+                                                               +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 271 out of 285 eligible operators (95%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q67a.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q67a.native_iceberg_compat/extended.txt
@@ -1,0 +1,298 @@
+TakeOrderedAndProject
++- Filter
+   +- Window
+      +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+         +- CometNativeColumnarToRow
+            +- CometSort
+               +- CometColumnarExchange
+                  +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+                     +- CometNativeColumnarToRow
+                        +- CometSort
+                           +- CometUnion
+                              :- CometHashAggregate
+                              :  +- CometExchange
+                              :     +- CometHashAggregate
+                              :        +- CometProject
+                              :           +- CometBroadcastHashJoin
+                              :              :- CometProject
+                              :              :  +- CometBroadcastHashJoin
+                              :              :     :- CometProject
+                              :              :     :  +- CometBroadcastHashJoin
+                              :              :     :     :- CometFilter
+                              :              :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                              :              :     :     :        +- SubqueryBroadcast
+                              :              :     :     :           +- BroadcastExchange
+                              :              :     :     :              +- CometNativeColumnarToRow
+                              :              :     :     :                 +- CometProject
+                              :              :     :     :                    +- CometFilter
+                              :              :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :              :     :     +- CometBroadcastExchange
+                              :              :     :        +- CometProject
+                              :              :     :           +- CometFilter
+                              :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :              :     +- CometBroadcastExchange
+                              :              :        +- CometProject
+                              :              :           +- CometFilter
+                              :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                              :              +- CometBroadcastExchange
+                              :                 +- CometProject
+                              :                    +- CometFilter
+                              :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                              :- CometHashAggregate
+                              :  +- CometExchange
+                              :     +- CometHashAggregate
+                              :        +- CometHashAggregate
+                              :           +- CometExchange
+                              :              +- CometHashAggregate
+                              :                 +- CometProject
+                              :                    +- CometBroadcastHashJoin
+                              :                       :- CometProject
+                              :                       :  +- CometBroadcastHashJoin
+                              :                       :     :- CometProject
+                              :                       :     :  +- CometBroadcastHashJoin
+                              :                       :     :     :- CometFilter
+                              :                       :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                              :                       :     :     :        +- SubqueryBroadcast
+                              :                       :     :     :           +- BroadcastExchange
+                              :                       :     :     :              +- CometNativeColumnarToRow
+                              :                       :     :     :                 +- CometProject
+                              :                       :     :     :                    +- CometFilter
+                              :                       :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :                       :     :     +- CometBroadcastExchange
+                              :                       :     :        +- CometProject
+                              :                       :     :           +- CometFilter
+                              :                       :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :                       :     +- CometBroadcastExchange
+                              :                       :        +- CometProject
+                              :                       :           +- CometFilter
+                              :                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                              :                       +- CometBroadcastExchange
+                              :                          +- CometProject
+                              :                             +- CometFilter
+                              :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                              :- CometHashAggregate
+                              :  +- CometExchange
+                              :     +- CometHashAggregate
+                              :        +- CometHashAggregate
+                              :           +- CometExchange
+                              :              +- CometHashAggregate
+                              :                 +- CometProject
+                              :                    +- CometBroadcastHashJoin
+                              :                       :- CometProject
+                              :                       :  +- CometBroadcastHashJoin
+                              :                       :     :- CometProject
+                              :                       :     :  +- CometBroadcastHashJoin
+                              :                       :     :     :- CometFilter
+                              :                       :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                              :                       :     :     :        +- SubqueryBroadcast
+                              :                       :     :     :           +- BroadcastExchange
+                              :                       :     :     :              +- CometNativeColumnarToRow
+                              :                       :     :     :                 +- CometProject
+                              :                       :     :     :                    +- CometFilter
+                              :                       :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :                       :     :     +- CometBroadcastExchange
+                              :                       :     :        +- CometProject
+                              :                       :     :           +- CometFilter
+                              :                       :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :                       :     +- CometBroadcastExchange
+                              :                       :        +- CometProject
+                              :                       :           +- CometFilter
+                              :                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                              :                       +- CometBroadcastExchange
+                              :                          +- CometProject
+                              :                             +- CometFilter
+                              :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                              :- CometHashAggregate
+                              :  +- CometExchange
+                              :     +- CometHashAggregate
+                              :        +- CometHashAggregate
+                              :           +- CometExchange
+                              :              +- CometHashAggregate
+                              :                 +- CometProject
+                              :                    +- CometBroadcastHashJoin
+                              :                       :- CometProject
+                              :                       :  +- CometBroadcastHashJoin
+                              :                       :     :- CometProject
+                              :                       :     :  +- CometBroadcastHashJoin
+                              :                       :     :     :- CometFilter
+                              :                       :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                              :                       :     :     :        +- SubqueryBroadcast
+                              :                       :     :     :           +- BroadcastExchange
+                              :                       :     :     :              +- CometNativeColumnarToRow
+                              :                       :     :     :                 +- CometProject
+                              :                       :     :     :                    +- CometFilter
+                              :                       :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :                       :     :     +- CometBroadcastExchange
+                              :                       :     :        +- CometProject
+                              :                       :     :           +- CometFilter
+                              :                       :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :                       :     +- CometBroadcastExchange
+                              :                       :        +- CometProject
+                              :                       :           +- CometFilter
+                              :                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                              :                       +- CometBroadcastExchange
+                              :                          +- CometProject
+                              :                             +- CometFilter
+                              :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                              :- CometHashAggregate
+                              :  +- CometExchange
+                              :     +- CometHashAggregate
+                              :        +- CometHashAggregate
+                              :           +- CometExchange
+                              :              +- CometHashAggregate
+                              :                 +- CometProject
+                              :                    +- CometBroadcastHashJoin
+                              :                       :- CometProject
+                              :                       :  +- CometBroadcastHashJoin
+                              :                       :     :- CometProject
+                              :                       :     :  +- CometBroadcastHashJoin
+                              :                       :     :     :- CometFilter
+                              :                       :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                              :                       :     :     :        +- SubqueryBroadcast
+                              :                       :     :     :           +- BroadcastExchange
+                              :                       :     :     :              +- CometNativeColumnarToRow
+                              :                       :     :     :                 +- CometProject
+                              :                       :     :     :                    +- CometFilter
+                              :                       :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :                       :     :     +- CometBroadcastExchange
+                              :                       :     :        +- CometProject
+                              :                       :     :           +- CometFilter
+                              :                       :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :                       :     +- CometBroadcastExchange
+                              :                       :        +- CometProject
+                              :                       :           +- CometFilter
+                              :                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                              :                       +- CometBroadcastExchange
+                              :                          +- CometProject
+                              :                             +- CometFilter
+                              :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                              :- CometHashAggregate
+                              :  +- CometExchange
+                              :     +- CometHashAggregate
+                              :        +- CometHashAggregate
+                              :           +- CometExchange
+                              :              +- CometHashAggregate
+                              :                 +- CometProject
+                              :                    +- CometBroadcastHashJoin
+                              :                       :- CometProject
+                              :                       :  +- CometBroadcastHashJoin
+                              :                       :     :- CometProject
+                              :                       :     :  +- CometBroadcastHashJoin
+                              :                       :     :     :- CometFilter
+                              :                       :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                              :                       :     :     :        +- SubqueryBroadcast
+                              :                       :     :     :           +- BroadcastExchange
+                              :                       :     :     :              +- CometNativeColumnarToRow
+                              :                       :     :     :                 +- CometProject
+                              :                       :     :     :                    +- CometFilter
+                              :                       :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :                       :     :     +- CometBroadcastExchange
+                              :                       :     :        +- CometProject
+                              :                       :     :           +- CometFilter
+                              :                       :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :                       :     +- CometBroadcastExchange
+                              :                       :        +- CometProject
+                              :                       :           +- CometFilter
+                              :                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                              :                       +- CometBroadcastExchange
+                              :                          +- CometProject
+                              :                             +- CometFilter
+                              :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                              :- CometHashAggregate
+                              :  +- CometExchange
+                              :     +- CometHashAggregate
+                              :        +- CometHashAggregate
+                              :           +- CometExchange
+                              :              +- CometHashAggregate
+                              :                 +- CometProject
+                              :                    +- CometBroadcastHashJoin
+                              :                       :- CometProject
+                              :                       :  +- CometBroadcastHashJoin
+                              :                       :     :- CometProject
+                              :                       :     :  +- CometBroadcastHashJoin
+                              :                       :     :     :- CometFilter
+                              :                       :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                              :                       :     :     :        +- SubqueryBroadcast
+                              :                       :     :     :           +- BroadcastExchange
+                              :                       :     :     :              +- CometNativeColumnarToRow
+                              :                       :     :     :                 +- CometProject
+                              :                       :     :     :                    +- CometFilter
+                              :                       :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :                       :     :     +- CometBroadcastExchange
+                              :                       :     :        +- CometProject
+                              :                       :     :           +- CometFilter
+                              :                       :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :                       :     +- CometBroadcastExchange
+                              :                       :        +- CometProject
+                              :                       :           +- CometFilter
+                              :                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                              :                       +- CometBroadcastExchange
+                              :                          +- CometProject
+                              :                             +- CometFilter
+                              :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                              :- CometHashAggregate
+                              :  +- CometExchange
+                              :     +- CometHashAggregate
+                              :        +- CometHashAggregate
+                              :           +- CometExchange
+                              :              +- CometHashAggregate
+                              :                 +- CometProject
+                              :                    +- CometBroadcastHashJoin
+                              :                       :- CometProject
+                              :                       :  +- CometBroadcastHashJoin
+                              :                       :     :- CometProject
+                              :                       :     :  +- CometBroadcastHashJoin
+                              :                       :     :     :- CometFilter
+                              :                       :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                              :                       :     :     :        +- SubqueryBroadcast
+                              :                       :     :     :           +- BroadcastExchange
+                              :                       :     :     :              +- CometNativeColumnarToRow
+                              :                       :     :     :                 +- CometProject
+                              :                       :     :     :                    +- CometFilter
+                              :                       :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :                       :     :     +- CometBroadcastExchange
+                              :                       :     :        +- CometProject
+                              :                       :     :           +- CometFilter
+                              :                       :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                              :                       :     +- CometBroadcastExchange
+                              :                       :        +- CometProject
+                              :                       :           +- CometFilter
+                              :                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                              :                       +- CometBroadcastExchange
+                              :                          +- CometProject
+                              :                             +- CometFilter
+                              :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                              +- CometHashAggregate
+                                 +- CometExchange
+                                    +- CometHashAggregate
+                                       +- CometHashAggregate
+                                          +- CometExchange
+                                             +- CometHashAggregate
+                                                +- CometProject
+                                                   +- CometBroadcastHashJoin
+                                                      :- CometProject
+                                                      :  +- CometBroadcastHashJoin
+                                                      :     :- CometProject
+                                                      :     :  +- CometBroadcastHashJoin
+                                                      :     :     :- CometFilter
+                                                      :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                                      :     :     :        +- SubqueryBroadcast
+                                                      :     :     :           +- BroadcastExchange
+                                                      :     :     :              +- CometNativeColumnarToRow
+                                                      :     :     :                 +- CometProject
+                                                      :     :     :                    +- CometFilter
+                                                      :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                      :     :     +- CometBroadcastExchange
+                                                      :     :        +- CometProject
+                                                      :     :           +- CometFilter
+                                                      :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                      :     +- CometBroadcastExchange
+                                                      :        +- CometProject
+                                                      :           +- CometFilter
+                                                      :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                                                      +- CometBroadcastExchange
+                                                         +- CometProject
+                                                            +- CometFilter
+                                                               +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 262 out of 285 eligible operators (91%). Final plan contains 11 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q70a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q70a.native_datafusion/extended.txt
@@ -1,0 +1,168 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometColumnarExchange
+                     +- HashAggregate
+                        +- Union
+                           :- HashAggregate
+                           :  +- Exchange
+                           :     +- HashAggregate
+                           :        +- Project
+                           :           +- BroadcastHashJoin
+                           :              :- CometNativeColumnarToRow
+                           :              :  +- CometProject
+                           :              :     +- CometBroadcastHashJoin
+                           :              :        :- CometFilter
+                           :              :        :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                           :              :        :        +- CometSubqueryBroadcast
+                           :              :        :           +- CometBroadcastExchange
+                           :              :        :              +- CometProject
+                           :              :        :                 +- CometFilter
+                           :              :        :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :              :        +- CometBroadcastExchange
+                           :              :           +- CometProject
+                           :              :              +- CometFilter
+                           :              :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :              +- BroadcastExchange
+                           :                 +- Project
+                           :                    +- BroadcastHashJoin
+                           :                       :- CometNativeColumnarToRow
+                           :                       :  +- CometFilter
+                           :                       :     +- CometNativeScan parquet spark_catalog.default.store
+                           :                       +- BroadcastExchange
+                           :                          +- Project
+                           :                             +- Filter
+                           :                                +- Window
+                           :                                   +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+                           :                                      +- CometNativeColumnarToRow
+                           :                                         +- CometSort
+                           :                                            +- CometHashAggregate
+                           :                                               +- CometExchange
+                           :                                                  +- CometHashAggregate
+                           :                                                     +- CometProject
+                           :                                                        +- CometBroadcastHashJoin
+                           :                                                           :- CometProject
+                           :                                                           :  +- CometBroadcastHashJoin
+                           :                                                           :     :- CometFilter
+                           :                                                           :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                           :                                                           :     :        +- ReusedSubquery
+                           :                                                           :     +- CometBroadcastExchange
+                           :                                                           :        +- CometProject
+                           :                                                           :           +- CometFilter
+                           :                                                           :              +- CometNativeScan parquet spark_catalog.default.store
+                           :                                                           +- CometBroadcastExchange
+                           :                                                              +- CometProject
+                           :                                                                 +- CometFilter
+                           :                                                                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :- HashAggregate
+                           :  +- Exchange
+                           :     +- HashAggregate
+                           :        +- HashAggregate
+                           :           +- Exchange
+                           :              +- HashAggregate
+                           :                 +- Project
+                           :                    +- BroadcastHashJoin
+                           :                       :- CometNativeColumnarToRow
+                           :                       :  +- CometProject
+                           :                       :     +- CometBroadcastHashJoin
+                           :                       :        :- CometFilter
+                           :                       :        :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                           :                       :        :        +- CometSubqueryBroadcast
+                           :                       :        :           +- CometBroadcastExchange
+                           :                       :        :              +- CometProject
+                           :                       :        :                 +- CometFilter
+                           :                       :        :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :                       :        +- CometBroadcastExchange
+                           :                       :           +- CometProject
+                           :                       :              +- CometFilter
+                           :                       :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :                       +- BroadcastExchange
+                           :                          +- Project
+                           :                             +- BroadcastHashJoin
+                           :                                :- CometNativeColumnarToRow
+                           :                                :  +- CometFilter
+                           :                                :     +- CometNativeScan parquet spark_catalog.default.store
+                           :                                +- BroadcastExchange
+                           :                                   +- Project
+                           :                                      +- Filter
+                           :                                         +- Window
+                           :                                            +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+                           :                                               +- CometNativeColumnarToRow
+                           :                                                  +- CometSort
+                           :                                                     +- CometHashAggregate
+                           :                                                        +- CometExchange
+                           :                                                           +- CometHashAggregate
+                           :                                                              +- CometProject
+                           :                                                                 +- CometBroadcastHashJoin
+                           :                                                                    :- CometProject
+                           :                                                                    :  +- CometBroadcastHashJoin
+                           :                                                                    :     :- CometFilter
+                           :                                                                    :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                           :                                                                    :     :        +- ReusedSubquery
+                           :                                                                    :     +- CometBroadcastExchange
+                           :                                                                    :        +- CometProject
+                           :                                                                    :           +- CometFilter
+                           :                                                                    :              +- CometNativeScan parquet spark_catalog.default.store
+                           :                                                                    +- CometBroadcastExchange
+                           :                                                                       +- CometProject
+                           :                                                                          +- CometFilter
+                           :                                                                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                           +- HashAggregate
+                              +- Exchange
+                                 +- HashAggregate
+                                    +- HashAggregate
+                                       +- Exchange
+                                          +- HashAggregate
+                                             +- Project
+                                                +- BroadcastHashJoin
+                                                   :- CometNativeColumnarToRow
+                                                   :  +- CometProject
+                                                   :     +- CometBroadcastHashJoin
+                                                   :        :- CometFilter
+                                                   :        :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                                   :        :        +- CometSubqueryBroadcast
+                                                   :        :           +- CometBroadcastExchange
+                                                   :        :              +- CometProject
+                                                   :        :                 +- CometFilter
+                                                   :        :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                   :        +- CometBroadcastExchange
+                                                   :           +- CometProject
+                                                   :              +- CometFilter
+                                                   :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                   +- BroadcastExchange
+                                                      +- Project
+                                                         +- BroadcastHashJoin
+                                                            :- CometNativeColumnarToRow
+                                                            :  +- CometFilter
+                                                            :     +- CometNativeScan parquet spark_catalog.default.store
+                                                            +- BroadcastExchange
+                                                               +- Project
+                                                                  +- Filter
+                                                                     +- Window
+                                                                        +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+                                                                           +- CometNativeColumnarToRow
+                                                                              +- CometSort
+                                                                                 +- CometHashAggregate
+                                                                                    +- CometExchange
+                                                                                       +- CometHashAggregate
+                                                                                          +- CometProject
+                                                                                             +- CometBroadcastHashJoin
+                                                                                                :- CometProject
+                                                                                                :  +- CometBroadcastHashJoin
+                                                                                                :     :- CometFilter
+                                                                                                :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                                                                                :     :        +- ReusedSubquery
+                                                                                                :     +- CometBroadcastExchange
+                                                                                                :        +- CometProject
+                                                                                                :           +- CometFilter
+                                                                                                :              +- CometNativeScan parquet spark_catalog.default.store
+                                                                                                +- CometBroadcastExchange
+                                                                                                   +- CometProject
+                                                                                                      +- CometFilter
+                                                                                                         +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 100 out of 156 eligible operators (64%). Final plan contains 10 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q70a.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q70a.native_iceberg_compat/extended.txt
@@ -1,0 +1,171 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometColumnarExchange
+                     +- HashAggregate
+                        +- Union
+                           :- HashAggregate
+                           :  +- Exchange
+                           :     +- HashAggregate
+                           :        +- Project
+                           :           +- BroadcastHashJoin
+                           :              :- CometNativeColumnarToRow
+                           :              :  +- CometProject
+                           :              :     +- CometBroadcastHashJoin
+                           :              :        :- CometFilter
+                           :              :        :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                           :              :        :        +- SubqueryBroadcast
+                           :              :        :           +- BroadcastExchange
+                           :              :        :              +- CometNativeColumnarToRow
+                           :              :        :                 +- CometProject
+                           :              :        :                    +- CometFilter
+                           :              :        :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :              :        +- CometBroadcastExchange
+                           :              :           +- CometProject
+                           :              :              +- CometFilter
+                           :              :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :              +- BroadcastExchange
+                           :                 +- Project
+                           :                    +- BroadcastHashJoin
+                           :                       :- CometNativeColumnarToRow
+                           :                       :  +- CometFilter
+                           :                       :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                           :                       +- BroadcastExchange
+                           :                          +- Project
+                           :                             +- Filter
+                           :                                +- Window
+                           :                                   +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+                           :                                      +- CometNativeColumnarToRow
+                           :                                         +- CometSort
+                           :                                            +- CometHashAggregate
+                           :                                               +- CometExchange
+                           :                                                  +- CometHashAggregate
+                           :                                                     +- CometProject
+                           :                                                        +- CometBroadcastHashJoin
+                           :                                                           :- CometProject
+                           :                                                           :  +- CometBroadcastHashJoin
+                           :                                                           :     :- CometFilter
+                           :                                                           :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                           :                                                           :     :        +- ReusedSubquery
+                           :                                                           :     +- CometBroadcastExchange
+                           :                                                           :        +- CometProject
+                           :                                                           :           +- CometFilter
+                           :                                                           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                           :                                                           +- CometBroadcastExchange
+                           :                                                              +- CometProject
+                           :                                                                 +- CometFilter
+                           :                                                                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :- HashAggregate
+                           :  +- Exchange
+                           :     +- HashAggregate
+                           :        +- HashAggregate
+                           :           +- Exchange
+                           :              +- HashAggregate
+                           :                 +- Project
+                           :                    +- BroadcastHashJoin
+                           :                       :- CometNativeColumnarToRow
+                           :                       :  +- CometProject
+                           :                       :     +- CometBroadcastHashJoin
+                           :                       :        :- CometFilter
+                           :                       :        :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                           :                       :        :        +- SubqueryBroadcast
+                           :                       :        :           +- BroadcastExchange
+                           :                       :        :              +- CometNativeColumnarToRow
+                           :                       :        :                 +- CometProject
+                           :                       :        :                    +- CometFilter
+                           :                       :        :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :                       :        +- CometBroadcastExchange
+                           :                       :           +- CometProject
+                           :                       :              +- CometFilter
+                           :                       :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :                       +- BroadcastExchange
+                           :                          +- Project
+                           :                             +- BroadcastHashJoin
+                           :                                :- CometNativeColumnarToRow
+                           :                                :  +- CometFilter
+                           :                                :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                           :                                +- BroadcastExchange
+                           :                                   +- Project
+                           :                                      +- Filter
+                           :                                         +- Window
+                           :                                            +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+                           :                                               +- CometNativeColumnarToRow
+                           :                                                  +- CometSort
+                           :                                                     +- CometHashAggregate
+                           :                                                        +- CometExchange
+                           :                                                           +- CometHashAggregate
+                           :                                                              +- CometProject
+                           :                                                                 +- CometBroadcastHashJoin
+                           :                                                                    :- CometProject
+                           :                                                                    :  +- CometBroadcastHashJoin
+                           :                                                                    :     :- CometFilter
+                           :                                                                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                           :                                                                    :     :        +- ReusedSubquery
+                           :                                                                    :     +- CometBroadcastExchange
+                           :                                                                    :        +- CometProject
+                           :                                                                    :           +- CometFilter
+                           :                                                                    :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                           :                                                                    +- CometBroadcastExchange
+                           :                                                                       +- CometProject
+                           :                                                                          +- CometFilter
+                           :                                                                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           +- HashAggregate
+                              +- Exchange
+                                 +- HashAggregate
+                                    +- HashAggregate
+                                       +- Exchange
+                                          +- HashAggregate
+                                             +- Project
+                                                +- BroadcastHashJoin
+                                                   :- CometNativeColumnarToRow
+                                                   :  +- CometProject
+                                                   :     +- CometBroadcastHashJoin
+                                                   :        :- CometFilter
+                                                   :        :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                                   :        :        +- SubqueryBroadcast
+                                                   :        :           +- BroadcastExchange
+                                                   :        :              +- CometNativeColumnarToRow
+                                                   :        :                 +- CometProject
+                                                   :        :                    +- CometFilter
+                                                   :        :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                   :        +- CometBroadcastExchange
+                                                   :           +- CometProject
+                                                   :              +- CometFilter
+                                                   :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                   +- BroadcastExchange
+                                                      +- Project
+                                                         +- BroadcastHashJoin
+                                                            :- CometNativeColumnarToRow
+                                                            :  +- CometFilter
+                                                            :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                                                            +- BroadcastExchange
+                                                               +- Project
+                                                                  +- Filter
+                                                                     +- Window
+                                                                        +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
+                                                                           +- CometNativeColumnarToRow
+                                                                              +- CometSort
+                                                                                 +- CometHashAggregate
+                                                                                    +- CometExchange
+                                                                                       +- CometHashAggregate
+                                                                                          +- CometProject
+                                                                                             +- CometBroadcastHashJoin
+                                                                                                :- CometProject
+                                                                                                :  +- CometBroadcastHashJoin
+                                                                                                :     :- CometFilter
+                                                                                                :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                                                                                :     :        +- ReusedSubquery
+                                                                                                :     +- CometBroadcastExchange
+                                                                                                :        +- CometProject
+                                                                                                :           +- CometFilter
+                                                                                                :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                                                                                                +- CometBroadcastExchange
+                                                                                                   +- CometProject
+                                                                                                      +- CometFilter
+                                                                                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 97 out of 156 eligible operators (62%). Final plan contains 13 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q72.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q72.native_datafusion/extended.txt
@@ -1,0 +1,71 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometSortMergeJoin
+                  :- CometSort
+                  :  +- CometExchange
+                  :     +- CometProject
+                  :        +- CometBroadcastHashJoin
+                  :           :- CometProject
+                  :           :  +- CometBroadcastHashJoin
+                  :           :     :- CometProject
+                  :           :     :  +- CometBroadcastHashJoin
+                  :           :     :     :- CometProject
+                  :           :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :- CometProject
+                  :           :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :- CometProject
+                  :           :     :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :     :- CometProject
+                  :           :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :     :     :- CometProject
+                  :           :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :     :     :     :- CometProject
+                  :           :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :     :     :     :     :- CometFilter
+                  :           :     :     :     :     :     :     :     :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                  :           :     :     :     :     :     :     :     :     :        +- CometSubqueryBroadcast
+                  :           :     :     :     :     :     :     :     :     :           +- CometBroadcastExchange
+                  :           :     :     :     :     :     :     :     :     :              +- CometProject
+                  :           :     :     :     :     :     :     :     :     :                 +- CometFilter
+                  :           :     :     :     :     :     :     :     :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :           :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :     :     :     :     :        +- CometFilter
+                  :           :     :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.inventory
+                  :           :     :     :     :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :     :     :     :        +- CometFilter
+                  :           :     :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.warehouse
+                  :           :     :     :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :     :     :        +- CometFilter
+                  :           :     :     :     :     :     :           +- CometNativeScan parquet spark_catalog.default.item
+                  :           :     :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :     :        +- CometProject
+                  :           :     :     :     :     :           +- CometFilter
+                  :           :     :     :     :     :              +- CometNativeScan parquet spark_catalog.default.customer_demographics
+                  :           :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :        +- CometProject
+                  :           :     :     :     :           +- CometFilter
+                  :           :     :     :     :              +- CometNativeScan parquet spark_catalog.default.household_demographics
+                  :           :     :     :     +- CometBroadcastExchange
+                  :           :     :     :        +- CometProject
+                  :           :     :     :           +- CometFilter
+                  :           :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :           :     :     +- CometBroadcastExchange
+                  :           :     :        +- CometFilter
+                  :           :     :           +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :           :     +- CometBroadcastExchange
+                  :           :        +- CometFilter
+                  :           :           +- CometNativeScan parquet spark_catalog.default.date_dim
+                  :           +- CometBroadcastExchange
+                  :              +- CometFilter
+                  :                 +- CometNativeScan parquet spark_catalog.default.promotion
+                  +- CometSort
+                     +- CometExchange
+                        +- CometProject
+                           +- CometFilter
+                              +- CometNativeScan parquet spark_catalog.default.catalog_returns
+
+Comet accelerated 67 out of 68 eligible operators (98%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q72.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q72.native_iceberg_compat/extended.txt
@@ -1,0 +1,72 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometProject
+               +- CometSortMergeJoin
+                  :- CometSort
+                  :  +- CometExchange
+                  :     +- CometProject
+                  :        +- CometBroadcastHashJoin
+                  :           :- CometProject
+                  :           :  +- CometBroadcastHashJoin
+                  :           :     :- CometProject
+                  :           :     :  +- CometBroadcastHashJoin
+                  :           :     :     :- CometProject
+                  :           :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :- CometProject
+                  :           :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :- CometProject
+                  :           :     :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :     :- CometProject
+                  :           :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :     :     :- CometProject
+                  :           :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :     :     :     :- CometProject
+                  :           :     :     :     :     :     :     :     :  +- CometBroadcastHashJoin
+                  :           :     :     :     :     :     :     :     :     :- CometFilter
+                  :           :     :     :     :     :     :     :     :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                  :           :     :     :     :     :     :     :     :     :        +- SubqueryBroadcast
+                  :           :     :     :     :     :     :     :     :     :           +- BroadcastExchange
+                  :           :     :     :     :     :     :     :     :     :              +- CometNativeColumnarToRow
+                  :           :     :     :     :     :     :     :     :     :                 +- CometProject
+                  :           :     :     :     :     :     :     :     :     :                    +- CometFilter
+                  :           :     :     :     :     :     :     :     :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :           :     :     :     :     :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :     :     :     :     :        +- CometFilter
+                  :           :     :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.inventory
+                  :           :     :     :     :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :     :     :     :        +- CometFilter
+                  :           :     :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.warehouse
+                  :           :     :     :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :     :     :        +- CometFilter
+                  :           :     :     :     :     :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                  :           :     :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :     :        +- CometProject
+                  :           :     :     :     :     :           +- CometFilter
+                  :           :     :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer_demographics
+                  :           :     :     :     :     +- CometBroadcastExchange
+                  :           :     :     :     :        +- CometProject
+                  :           :     :     :     :           +- CometFilter
+                  :           :     :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.household_demographics
+                  :           :     :     :     +- CometBroadcastExchange
+                  :           :     :     :        +- CometProject
+                  :           :     :     :           +- CometFilter
+                  :           :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :           :     :     +- CometBroadcastExchange
+                  :           :     :        +- CometFilter
+                  :           :     :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :           :     +- CometBroadcastExchange
+                  :           :        +- CometFilter
+                  :           :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                  :           +- CometBroadcastExchange
+                  :              +- CometFilter
+                  :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+                  +- CometSort
+                     +- CometExchange
+                        +- CometProject
+                           +- CometFilter
+                              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+
+Comet accelerated 66 out of 68 eligible operators (97%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q74.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q74.native_datafusion/extended.txt
@@ -1,0 +1,88 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometBroadcastHashJoin
+         :     :  :- CometFilter
+         :     :  :  +- CometHashAggregate
+         :     :  :     +- CometExchange
+         :     :  :        +- CometHashAggregate
+         :     :  :           +- CometProject
+         :     :  :              +- CometBroadcastHashJoin
+         :     :  :                 :- CometProject
+         :     :  :                 :  +- CometBroadcastHashJoin
+         :     :  :                 :     :- CometProject
+         :     :  :                 :     :  +- CometFilter
+         :     :  :                 :     :     +- CometNativeScan parquet spark_catalog.default.customer
+         :     :  :                 :     +- CometBroadcastExchange
+         :     :  :                 :        +- CometFilter
+         :     :  :                 :           +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     :  :                 :                 +- CometSubqueryBroadcast
+         :     :  :                 :                    +- CometBroadcastExchange
+         :     :  :                 :                       +- CometFilter
+         :     :  :                 :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :  :                 +- CometBroadcastExchange
+         :     :  :                    +- CometFilter
+         :     :  :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :  +- CometBroadcastExchange
+         :     :     +- CometHashAggregate
+         :     :        +- CometExchange
+         :     :           +- CometHashAggregate
+         :     :              +- CometProject
+         :     :                 +- CometBroadcastHashJoin
+         :     :                    :- CometProject
+         :     :                    :  +- CometBroadcastHashJoin
+         :     :                    :     :- CometProject
+         :     :                    :     :  +- CometFilter
+         :     :                    :     :     +- CometNativeScan parquet spark_catalog.default.customer
+         :     :                    :     +- CometBroadcastExchange
+         :     :                    :        +- CometFilter
+         :     :                    :           +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     :                    :                 +- CometSubqueryBroadcast
+         :     :                    :                    +- CometBroadcastExchange
+         :     :                    :                       +- CometFilter
+         :     :                    :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :                    +- CometBroadcastExchange
+         :     :                       +- CometFilter
+         :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     +- CometBroadcastExchange
+         :        +- CometFilter
+         :           +- CometHashAggregate
+         :              +- CometExchange
+         :                 +- CometHashAggregate
+         :                    +- CometProject
+         :                       +- CometBroadcastHashJoin
+         :                          :- CometProject
+         :                          :  +- CometBroadcastHashJoin
+         :                          :     :- CometProject
+         :                          :     :  +- CometFilter
+         :                          :     :     +- CometNativeScan parquet spark_catalog.default.customer
+         :                          :     +- CometBroadcastExchange
+         :                          :        +- CometFilter
+         :                          :           +- CometNativeScan parquet spark_catalog.default.web_sales
+         :                          :                 +- ReusedSubquery
+         :                          +- CometBroadcastExchange
+         :                             +- CometFilter
+         :                                +- CometNativeScan parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometFilter
+                           :     :     +- CometNativeScan parquet spark_catalog.default.customer
+                           :     +- CometBroadcastExchange
+                           :        +- CometFilter
+                           :           +- CometNativeScan parquet spark_catalog.default.web_sales
+                           :                 +- ReusedSubquery
+                           +- CometBroadcastExchange
+                              +- CometFilter
+                                 +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 81 out of 85 eligible operators (95%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q74.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q74.native_iceberg_compat/extended.txt
@@ -1,0 +1,90 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometBroadcastHashJoin
+         :- CometProject
+         :  +- CometBroadcastHashJoin
+         :     :- CometBroadcastHashJoin
+         :     :  :- CometFilter
+         :     :  :  +- CometHashAggregate
+         :     :  :     +- CometExchange
+         :     :  :        +- CometHashAggregate
+         :     :  :           +- CometProject
+         :     :  :              +- CometBroadcastHashJoin
+         :     :  :                 :- CometProject
+         :     :  :                 :  +- CometBroadcastHashJoin
+         :     :  :                 :     :- CometProject
+         :     :  :                 :     :  +- CometFilter
+         :     :  :                 :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         :     :  :                 :     +- CometBroadcastExchange
+         :     :  :                 :        +- CometFilter
+         :     :  :                 :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     :  :                 :                 +- SubqueryBroadcast
+         :     :  :                 :                    +- BroadcastExchange
+         :     :  :                 :                       +- CometNativeColumnarToRow
+         :     :  :                 :                          +- CometFilter
+         :     :  :                 :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :  :                 +- CometBroadcastExchange
+         :     :  :                    +- CometFilter
+         :     :  :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :  +- CometBroadcastExchange
+         :     :     +- CometHashAggregate
+         :     :        +- CometExchange
+         :     :           +- CometHashAggregate
+         :     :              +- CometProject
+         :     :                 +- CometBroadcastHashJoin
+         :     :                    :- CometProject
+         :     :                    :  +- CometBroadcastHashJoin
+         :     :                    :     :- CometProject
+         :     :                    :     :  +- CometFilter
+         :     :                    :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         :     :                    :     +- CometBroadcastExchange
+         :     :                    :        +- CometFilter
+         :     :                    :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     :                    :                 +- SubqueryBroadcast
+         :     :                    :                    +- BroadcastExchange
+         :     :                    :                       +- CometNativeColumnarToRow
+         :     :                    :                          +- CometFilter
+         :     :                    :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :                    +- CometBroadcastExchange
+         :     :                       +- CometFilter
+         :     :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     +- CometBroadcastExchange
+         :        +- CometFilter
+         :           +- CometHashAggregate
+         :              +- CometExchange
+         :                 +- CometHashAggregate
+         :                    +- CometProject
+         :                       +- CometBroadcastHashJoin
+         :                          :- CometProject
+         :                          :  +- CometBroadcastHashJoin
+         :                          :     :- CometProject
+         :                          :     :  +- CometFilter
+         :                          :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+         :                          :     +- CometBroadcastExchange
+         :                          :        +- CometFilter
+         :                          :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+         :                          :                 +- ReusedSubquery
+         :                          +- CometBroadcastExchange
+         :                             +- CometFilter
+         :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         +- CometBroadcastExchange
+            +- CometHashAggregate
+               +- CometExchange
+                  +- CometHashAggregate
+                     +- CometProject
+                        +- CometBroadcastHashJoin
+                           :- CometProject
+                           :  +- CometBroadcastHashJoin
+                           :     :- CometProject
+                           :     :  +- CometFilter
+                           :     :     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.customer
+                           :     +- CometBroadcastExchange
+                           :        +- CometFilter
+                           :           +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                           :                 +- ReusedSubquery
+                           +- CometBroadcastExchange
+                              +- CometFilter
+                                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 79 out of 85 eligible operators (92%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q75.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q75.native_datafusion/extended.txt
@@ -1,0 +1,170 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometSortMergeJoin
+         :- CometSort
+         :  +- CometExchange
+         :     +- CometFilter
+         :        +- CometHashAggregate
+         :           +- CometExchange
+         :              +- CometHashAggregate
+         :                 +- CometHashAggregate
+         :                    +- CometExchange
+         :                       +- CometHashAggregate
+         :                          +- CometUnion
+         :                             :- CometProject
+         :                             :  +- CometSortMergeJoin
+         :                             :     :- CometSort
+         :                             :     :  +- CometExchange
+         :                             :     :     +- CometProject
+         :                             :     :        +- CometBroadcastHashJoin
+         :                             :     :           :- CometProject
+         :                             :     :           :  +- CometBroadcastHashJoin
+         :                             :     :           :     :- CometFilter
+         :                             :     :           :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+         :                             :     :           :     :        +- CometSubqueryBroadcast
+         :                             :     :           :     :           +- CometBroadcastExchange
+         :                             :     :           :     :              +- CometFilter
+         :                             :     :           :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+         :                             :     :           :     +- CometBroadcastExchange
+         :                             :     :           :        +- CometProject
+         :                             :     :           :           +- CometFilter
+         :                             :     :           :              +- CometNativeScan parquet spark_catalog.default.item
+         :                             :     :           +- CometBroadcastExchange
+         :                             :     :              +- CometFilter
+         :                             :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+         :                             :     +- CometSort
+         :                             :        +- CometExchange
+         :                             :           +- CometProject
+         :                             :              +- CometFilter
+         :                             :                 +- CometNativeScan parquet spark_catalog.default.catalog_returns
+         :                             :- CometProject
+         :                             :  +- CometSortMergeJoin
+         :                             :     :- CometSort
+         :                             :     :  +- CometExchange
+         :                             :     :     +- CometProject
+         :                             :     :        +- CometBroadcastHashJoin
+         :                             :     :           :- CometProject
+         :                             :     :           :  +- CometBroadcastHashJoin
+         :                             :     :           :     :- CometFilter
+         :                             :     :           :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+         :                             :     :           :     :        +- ReusedSubquery
+         :                             :     :           :     +- CometBroadcastExchange
+         :                             :     :           :        +- CometProject
+         :                             :     :           :           +- CometFilter
+         :                             :     :           :              +- CometNativeScan parquet spark_catalog.default.item
+         :                             :     :           +- CometBroadcastExchange
+         :                             :     :              +- CometFilter
+         :                             :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+         :                             :     +- CometSort
+         :                             :        +- CometExchange
+         :                             :           +- CometProject
+         :                             :              +- CometFilter
+         :                             :                 +- CometNativeScan parquet spark_catalog.default.store_returns
+         :                             +- CometProject
+         :                                +- CometSortMergeJoin
+         :                                   :- CometSort
+         :                                   :  +- CometExchange
+         :                                   :     +- CometProject
+         :                                   :        +- CometBroadcastHashJoin
+         :                                   :           :- CometProject
+         :                                   :           :  +- CometBroadcastHashJoin
+         :                                   :           :     :- CometFilter
+         :                                   :           :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+         :                                   :           :     :        +- ReusedSubquery
+         :                                   :           :     +- CometBroadcastExchange
+         :                                   :           :        +- CometProject
+         :                                   :           :           +- CometFilter
+         :                                   :           :              +- CometNativeScan parquet spark_catalog.default.item
+         :                                   :           +- CometBroadcastExchange
+         :                                   :              +- CometFilter
+         :                                   :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+         :                                   +- CometSort
+         :                                      +- CometExchange
+         :                                         +- CometProject
+         :                                            +- CometFilter
+         :                                               +- CometNativeScan parquet spark_catalog.default.web_returns
+         +- CometSort
+            +- CometExchange
+               +- CometFilter
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometHashAggregate
+                              +- CometExchange
+                                 +- CometHashAggregate
+                                    +- CometUnion
+                                       :- CometProject
+                                       :  +- CometSortMergeJoin
+                                       :     :- CometSort
+                                       :     :  +- CometExchange
+                                       :     :     +- CometProject
+                                       :     :        +- CometBroadcastHashJoin
+                                       :     :           :- CometProject
+                                       :     :           :  +- CometBroadcastHashJoin
+                                       :     :           :     :- CometFilter
+                                       :     :           :     :  +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                                       :     :           :     :        +- CometSubqueryBroadcast
+                                       :     :           :     :           +- CometBroadcastExchange
+                                       :     :           :     :              +- CometFilter
+                                       :     :           :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       :     :           :     +- CometBroadcastExchange
+                                       :     :           :        +- CometProject
+                                       :     :           :           +- CometFilter
+                                       :     :           :              +- CometNativeScan parquet spark_catalog.default.item
+                                       :     :           +- CometBroadcastExchange
+                                       :     :              +- CometFilter
+                                       :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       :     +- CometSort
+                                       :        +- CometExchange
+                                       :           +- CometProject
+                                       :              +- CometFilter
+                                       :                 +- CometNativeScan parquet spark_catalog.default.catalog_returns
+                                       :- CometProject
+                                       :  +- CometSortMergeJoin
+                                       :     :- CometSort
+                                       :     :  +- CometExchange
+                                       :     :     +- CometProject
+                                       :     :        +- CometBroadcastHashJoin
+                                       :     :           :- CometProject
+                                       :     :           :  +- CometBroadcastHashJoin
+                                       :     :           :     :- CometFilter
+                                       :     :           :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                       :     :           :     :        +- ReusedSubquery
+                                       :     :           :     +- CometBroadcastExchange
+                                       :     :           :        +- CometProject
+                                       :     :           :           +- CometFilter
+                                       :     :           :              +- CometNativeScan parquet spark_catalog.default.item
+                                       :     :           +- CometBroadcastExchange
+                                       :     :              +- CometFilter
+                                       :     :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                                       :     +- CometSort
+                                       :        +- CometExchange
+                                       :           +- CometProject
+                                       :              +- CometFilter
+                                       :                 +- CometNativeScan parquet spark_catalog.default.store_returns
+                                       +- CometProject
+                                          +- CometSortMergeJoin
+                                             :- CometSort
+                                             :  +- CometExchange
+                                             :     +- CometProject
+                                             :        +- CometBroadcastHashJoin
+                                             :           :- CometProject
+                                             :           :  +- CometBroadcastHashJoin
+                                             :           :     :- CometFilter
+                                             :           :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                                             :           :     :        +- ReusedSubquery
+                                             :           :     +- CometBroadcastExchange
+                                             :           :        +- CometProject
+                                             :           :           +- CometFilter
+                                             :           :              +- CometNativeScan parquet spark_catalog.default.item
+                                             :           +- CometBroadcastExchange
+                                             :              +- CometFilter
+                                             :                 +- CometNativeScan parquet spark_catalog.default.date_dim
+                                             +- CometSort
+                                                +- CometExchange
+                                                   +- CometProject
+                                                      +- CometFilter
+                                                         +- CometNativeScan parquet spark_catalog.default.web_returns
+
+Comet accelerated 161 out of 167 eligible operators (96%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q75.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q75.native_iceberg_compat/extended.txt
@@ -1,0 +1,172 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometProject
+      +- CometSortMergeJoin
+         :- CometSort
+         :  +- CometExchange
+         :     +- CometFilter
+         :        +- CometHashAggregate
+         :           +- CometExchange
+         :              +- CometHashAggregate
+         :                 +- CometHashAggregate
+         :                    +- CometExchange
+         :                       +- CometHashAggregate
+         :                          +- CometUnion
+         :                             :- CometProject
+         :                             :  +- CometSortMergeJoin
+         :                             :     :- CometSort
+         :                             :     :  +- CometExchange
+         :                             :     :     +- CometProject
+         :                             :     :        +- CometBroadcastHashJoin
+         :                             :     :           :- CometProject
+         :                             :     :           :  +- CometBroadcastHashJoin
+         :                             :     :           :     :- CometFilter
+         :                             :     :           :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+         :                             :     :           :     :        +- SubqueryBroadcast
+         :                             :     :           :     :           +- BroadcastExchange
+         :                             :     :           :     :              +- CometNativeColumnarToRow
+         :                             :     :           :     :                 +- CometFilter
+         :                             :     :           :     :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :                             :     :           :     +- CometBroadcastExchange
+         :                             :     :           :        +- CometProject
+         :                             :     :           :           +- CometFilter
+         :                             :     :           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+         :                             :     :           +- CometBroadcastExchange
+         :                             :     :              +- CometFilter
+         :                             :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :                             :     +- CometSort
+         :                             :        +- CometExchange
+         :                             :           +- CometProject
+         :                             :              +- CometFilter
+         :                             :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+         :                             :- CometProject
+         :                             :  +- CometSortMergeJoin
+         :                             :     :- CometSort
+         :                             :     :  +- CometExchange
+         :                             :     :     +- CometProject
+         :                             :     :        +- CometBroadcastHashJoin
+         :                             :     :           :- CometProject
+         :                             :     :           :  +- CometBroadcastHashJoin
+         :                             :     :           :     :- CometFilter
+         :                             :     :           :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :                             :     :           :     :        +- ReusedSubquery
+         :                             :     :           :     +- CometBroadcastExchange
+         :                             :     :           :        +- CometProject
+         :                             :     :           :           +- CometFilter
+         :                             :     :           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+         :                             :     :           +- CometBroadcastExchange
+         :                             :     :              +- CometFilter
+         :                             :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :                             :     +- CometSort
+         :                             :        +- CometExchange
+         :                             :           +- CometProject
+         :                             :              +- CometFilter
+         :                             :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+         :                             +- CometProject
+         :                                +- CometSortMergeJoin
+         :                                   :- CometSort
+         :                                   :  +- CometExchange
+         :                                   :     +- CometProject
+         :                                   :        +- CometBroadcastHashJoin
+         :                                   :           :- CometProject
+         :                                   :           :  +- CometBroadcastHashJoin
+         :                                   :           :     :- CometFilter
+         :                                   :           :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+         :                                   :           :     :        +- ReusedSubquery
+         :                                   :           :     +- CometBroadcastExchange
+         :                                   :           :        +- CometProject
+         :                                   :           :           +- CometFilter
+         :                                   :           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+         :                                   :           +- CometBroadcastExchange
+         :                                   :              +- CometFilter
+         :                                   :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :                                   +- CometSort
+         :                                      +- CometExchange
+         :                                         +- CometProject
+         :                                            +- CometFilter
+         :                                               +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+         +- CometSort
+            +- CometExchange
+               +- CometFilter
+                  +- CometHashAggregate
+                     +- CometExchange
+                        +- CometHashAggregate
+                           +- CometHashAggregate
+                              +- CometExchange
+                                 +- CometHashAggregate
+                                    +- CometUnion
+                                       :- CometProject
+                                       :  +- CometSortMergeJoin
+                                       :     :- CometSort
+                                       :     :  +- CometExchange
+                                       :     :     +- CometProject
+                                       :     :        +- CometBroadcastHashJoin
+                                       :     :           :- CometProject
+                                       :     :           :  +- CometBroadcastHashJoin
+                                       :     :           :     :- CometFilter
+                                       :     :           :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                                       :     :           :     :        +- SubqueryBroadcast
+                                       :     :           :     :           +- BroadcastExchange
+                                       :     :           :     :              +- CometNativeColumnarToRow
+                                       :     :           :     :                 +- CometFilter
+                                       :     :           :     :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       :     :           :     +- CometBroadcastExchange
+                                       :     :           :        +- CometProject
+                                       :     :           :           +- CometFilter
+                                       :     :           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                       :     :           +- CometBroadcastExchange
+                                       :     :              +- CometFilter
+                                       :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       :     +- CometSort
+                                       :        +- CometExchange
+                                       :           +- CometProject
+                                       :              +- CometFilter
+                                       :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+                                       :- CometProject
+                                       :  +- CometSortMergeJoin
+                                       :     :- CometSort
+                                       :     :  +- CometExchange
+                                       :     :     +- CometProject
+                                       :     :        +- CometBroadcastHashJoin
+                                       :     :           :- CometProject
+                                       :     :           :  +- CometBroadcastHashJoin
+                                       :     :           :     :- CometFilter
+                                       :     :           :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                       :     :           :     :        +- ReusedSubquery
+                                       :     :           :     +- CometBroadcastExchange
+                                       :     :           :        +- CometProject
+                                       :     :           :           +- CometFilter
+                                       :     :           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                       :     :           +- CometBroadcastExchange
+                                       :     :              +- CometFilter
+                                       :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                       :     +- CometSort
+                                       :        +- CometExchange
+                                       :           +- CometProject
+                                       :              +- CometFilter
+                                       :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+                                       +- CometProject
+                                          +- CometSortMergeJoin
+                                             :- CometSort
+                                             :  +- CometExchange
+                                             :     +- CometProject
+                                             :        +- CometBroadcastHashJoin
+                                             :           :- CometProject
+                                             :           :  +- CometBroadcastHashJoin
+                                             :           :     :- CometFilter
+                                             :           :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                             :           :     :        +- ReusedSubquery
+                                             :           :     +- CometBroadcastExchange
+                                             :           :        +- CometProject
+                                             :           :           +- CometFilter
+                                             :           :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                             :           +- CometBroadcastExchange
+                                             :              +- CometFilter
+                                             :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                             +- CometSort
+                                                +- CometExchange
+                                                   +- CometProject
+                                                      +- CometFilter
+                                                         +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+
+Comet accelerated 159 out of 167 eligible operators (95%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q77a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q77a.native_datafusion/extended.txt
@@ -1,0 +1,347 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometColumnarExchange
+         +- HashAggregate
+            +- Union
+               :- HashAggregate
+               :  +- Exchange
+               :     +- HashAggregate
+               :        +- Union
+               :           :- CometNativeColumnarToRow
+               :           :  +- CometProject
+               :           :     +- CometBroadcastHashJoin
+               :           :        :- CometHashAggregate
+               :           :        :  +- CometExchange
+               :           :        :     +- CometHashAggregate
+               :           :        :        +- CometProject
+               :           :        :           +- CometBroadcastHashJoin
+               :           :        :              :- CometProject
+               :           :        :              :  +- CometBroadcastHashJoin
+               :           :        :              :     :- CometFilter
+               :           :        :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :           :        :              :     :        +- CometSubqueryBroadcast
+               :           :        :              :     :           +- CometBroadcastExchange
+               :           :        :              :     :              +- CometProject
+               :           :        :              :     :                 +- CometFilter
+               :           :        :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :           :        :              :     +- CometBroadcastExchange
+               :           :        :              :        +- CometProject
+               :           :        :              :           +- CometFilter
+               :           :        :              :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :           :        :              +- CometBroadcastExchange
+               :           :        :                 +- CometFilter
+               :           :        :                    +- CometNativeScan parquet spark_catalog.default.store
+               :           :        +- CometBroadcastExchange
+               :           :           +- CometHashAggregate
+               :           :              +- CometExchange
+               :           :                 +- CometHashAggregate
+               :           :                    +- CometProject
+               :           :                       +- CometBroadcastHashJoin
+               :           :                          :- CometProject
+               :           :                          :  +- CometBroadcastHashJoin
+               :           :                          :     :- CometFilter
+               :           :                          :     :  +- CometNativeScan parquet spark_catalog.default.store_returns
+               :           :                          :     :        +- ReusedSubquery
+               :           :                          :     +- CometBroadcastExchange
+               :           :                          :        +- CometProject
+               :           :                          :           +- CometFilter
+               :           :                          :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :           :                          +- CometBroadcastExchange
+               :           :                             +- CometFilter
+               :           :                                +- CometNativeScan parquet spark_catalog.default.store
+               :           :- Project
+               :           :  +-  BroadcastNestedLoopJoin [COMET: BroadcastNestedLoopJoin is not supported]
+               :           :     :- BroadcastExchange
+               :           :     :  +- CometNativeColumnarToRow
+               :           :     :     +- CometHashAggregate
+               :           :     :        +- CometExchange
+               :           :     :           +- CometHashAggregate
+               :           :     :              +- CometProject
+               :           :     :                 +- CometBroadcastHashJoin
+               :           :     :                    :- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :           :     :                    :     +- ReusedSubquery
+               :           :     :                    +- CometBroadcastExchange
+               :           :     :                       +- CometProject
+               :           :     :                          +- CometFilter
+               :           :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :           :     +- CometNativeColumnarToRow
+               :           :        +- CometHashAggregate
+               :           :           +- CometExchange
+               :           :              +- CometHashAggregate
+               :           :                 +- CometProject
+               :           :                    +- CometBroadcastHashJoin
+               :           :                       :- CometNativeScan parquet spark_catalog.default.catalog_returns
+               :           :                       :     +- ReusedSubquery
+               :           :                       +- CometBroadcastExchange
+               :           :                          +- CometProject
+               :           :                             +- CometFilter
+               :           :                                +- CometNativeScan parquet spark_catalog.default.date_dim
+               :           +- CometNativeColumnarToRow
+               :              +- CometProject
+               :                 +- CometBroadcastHashJoin
+               :                    :- CometHashAggregate
+               :                    :  +- CometExchange
+               :                    :     +- CometHashAggregate
+               :                    :        +- CometProject
+               :                    :           +- CometBroadcastHashJoin
+               :                    :              :- CometProject
+               :                    :              :  +- CometBroadcastHashJoin
+               :                    :              :     :- CometFilter
+               :                    :              :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                    :              :     :        +- ReusedSubquery
+               :                    :              :     +- CometBroadcastExchange
+               :                    :              :        +- CometProject
+               :                    :              :           +- CometFilter
+               :                    :              :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                    :              +- CometBroadcastExchange
+               :                    :                 +- CometFilter
+               :                    :                    +- CometNativeScan parquet spark_catalog.default.web_page
+               :                    +- CometBroadcastExchange
+               :                       +- CometHashAggregate
+               :                          +- CometExchange
+               :                             +- CometHashAggregate
+               :                                +- CometProject
+               :                                   +- CometBroadcastHashJoin
+               :                                      :- CometProject
+               :                                      :  +- CometBroadcastHashJoin
+               :                                      :     :- CometFilter
+               :                                      :     :  +- CometNativeScan parquet spark_catalog.default.web_returns
+               :                                      :     :        +- ReusedSubquery
+               :                                      :     +- CometBroadcastExchange
+               :                                      :        +- CometProject
+               :                                      :           +- CometFilter
+               :                                      :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                      +- CometBroadcastExchange
+               :                                         +- CometFilter
+               :                                            +- CometNativeScan parquet spark_catalog.default.web_page
+               :- HashAggregate
+               :  +- Exchange
+               :     +- HashAggregate
+               :        +- HashAggregate
+               :           +- Exchange
+               :              +- HashAggregate
+               :                 +- Union
+               :                    :- CometNativeColumnarToRow
+               :                    :  +- CometProject
+               :                    :     +- CometBroadcastHashJoin
+               :                    :        :- CometHashAggregate
+               :                    :        :  +- CometExchange
+               :                    :        :     +- CometHashAggregate
+               :                    :        :        +- CometProject
+               :                    :        :           +- CometBroadcastHashJoin
+               :                    :        :              :- CometProject
+               :                    :        :              :  +- CometBroadcastHashJoin
+               :                    :        :              :     :- CometFilter
+               :                    :        :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                    :        :              :     :        +- CometSubqueryBroadcast
+               :                    :        :              :     :           +- CometBroadcastExchange
+               :                    :        :              :     :              +- CometProject
+               :                    :        :              :     :                 +- CometFilter
+               :                    :        :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                    :        :              :     +- CometBroadcastExchange
+               :                    :        :              :        +- CometProject
+               :                    :        :              :           +- CometFilter
+               :                    :        :              :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                    :        :              +- CometBroadcastExchange
+               :                    :        :                 +- CometFilter
+               :                    :        :                    +- CometNativeScan parquet spark_catalog.default.store
+               :                    :        +- CometBroadcastExchange
+               :                    :           +- CometHashAggregate
+               :                    :              +- CometExchange
+               :                    :                 +- CometHashAggregate
+               :                    :                    +- CometProject
+               :                    :                       +- CometBroadcastHashJoin
+               :                    :                          :- CometProject
+               :                    :                          :  +- CometBroadcastHashJoin
+               :                    :                          :     :- CometFilter
+               :                    :                          :     :  +- CometNativeScan parquet spark_catalog.default.store_returns
+               :                    :                          :     :        +- ReusedSubquery
+               :                    :                          :     +- CometBroadcastExchange
+               :                    :                          :        +- CometProject
+               :                    :                          :           +- CometFilter
+               :                    :                          :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                    :                          +- CometBroadcastExchange
+               :                    :                             +- CometFilter
+               :                    :                                +- CometNativeScan parquet spark_catalog.default.store
+               :                    :- Project
+               :                    :  +-  BroadcastNestedLoopJoin [COMET: BroadcastNestedLoopJoin is not supported]
+               :                    :     :- BroadcastExchange
+               :                    :     :  +- CometNativeColumnarToRow
+               :                    :     :     +- CometHashAggregate
+               :                    :     :        +- CometExchange
+               :                    :     :           +- CometHashAggregate
+               :                    :     :              +- CometProject
+               :                    :     :                 +- CometBroadcastHashJoin
+               :                    :     :                    :- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                    :     :                    :     +- ReusedSubquery
+               :                    :     :                    +- CometBroadcastExchange
+               :                    :     :                       +- CometProject
+               :                    :     :                          +- CometFilter
+               :                    :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                    :     +- CometNativeColumnarToRow
+               :                    :        +- CometHashAggregate
+               :                    :           +- CometExchange
+               :                    :              +- CometHashAggregate
+               :                    :                 +- CometProject
+               :                    :                    +- CometBroadcastHashJoin
+               :                    :                       :- CometNativeScan parquet spark_catalog.default.catalog_returns
+               :                    :                       :     +- ReusedSubquery
+               :                    :                       +- CometBroadcastExchange
+               :                    :                          +- CometProject
+               :                    :                             +- CometFilter
+               :                    :                                +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                    +- CometNativeColumnarToRow
+               :                       +- CometProject
+               :                          +- CometBroadcastHashJoin
+               :                             :- CometHashAggregate
+               :                             :  +- CometExchange
+               :                             :     +- CometHashAggregate
+               :                             :        +- CometProject
+               :                             :           +- CometBroadcastHashJoin
+               :                             :              :- CometProject
+               :                             :              :  +- CometBroadcastHashJoin
+               :                             :              :     :- CometFilter
+               :                             :              :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                             :              :     :        +- ReusedSubquery
+               :                             :              :     +- CometBroadcastExchange
+               :                             :              :        +- CometProject
+               :                             :              :           +- CometFilter
+               :                             :              :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                             :              +- CometBroadcastExchange
+               :                             :                 +- CometFilter
+               :                             :                    +- CometNativeScan parquet spark_catalog.default.web_page
+               :                             +- CometBroadcastExchange
+               :                                +- CometHashAggregate
+               :                                   +- CometExchange
+               :                                      +- CometHashAggregate
+               :                                         +- CometProject
+               :                                            +- CometBroadcastHashJoin
+               :                                               :- CometProject
+               :                                               :  +- CometBroadcastHashJoin
+               :                                               :     :- CometFilter
+               :                                               :     :  +- CometNativeScan parquet spark_catalog.default.web_returns
+               :                                               :     :        +- ReusedSubquery
+               :                                               :     +- CometBroadcastExchange
+               :                                               :        +- CometProject
+               :                                               :           +- CometFilter
+               :                                               :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                               +- CometBroadcastExchange
+               :                                                  +- CometFilter
+               :                                                     +- CometNativeScan parquet spark_catalog.default.web_page
+               +- HashAggregate
+                  +- Exchange
+                     +- HashAggregate
+                        +- HashAggregate
+                           +- Exchange
+                              +- HashAggregate
+                                 +- Union
+                                    :- CometNativeColumnarToRow
+                                    :  +- CometProject
+                                    :     +- CometBroadcastHashJoin
+                                    :        :- CometHashAggregate
+                                    :        :  +- CometExchange
+                                    :        :     +- CometHashAggregate
+                                    :        :        +- CometProject
+                                    :        :           +- CometBroadcastHashJoin
+                                    :        :              :- CometProject
+                                    :        :              :  +- CometBroadcastHashJoin
+                                    :        :              :     :- CometFilter
+                                    :        :              :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                    :        :              :     :        +- CometSubqueryBroadcast
+                                    :        :              :     :           +- CometBroadcastExchange
+                                    :        :              :     :              +- CometProject
+                                    :        :              :     :                 +- CometFilter
+                                    :        :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                    :        :              :     +- CometBroadcastExchange
+                                    :        :              :        +- CometProject
+                                    :        :              :           +- CometFilter
+                                    :        :              :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                    :        :              +- CometBroadcastExchange
+                                    :        :                 +- CometFilter
+                                    :        :                    +- CometNativeScan parquet spark_catalog.default.store
+                                    :        +- CometBroadcastExchange
+                                    :           +- CometHashAggregate
+                                    :              +- CometExchange
+                                    :                 +- CometHashAggregate
+                                    :                    +- CometProject
+                                    :                       +- CometBroadcastHashJoin
+                                    :                          :- CometProject
+                                    :                          :  +- CometBroadcastHashJoin
+                                    :                          :     :- CometFilter
+                                    :                          :     :  +- CometNativeScan parquet spark_catalog.default.store_returns
+                                    :                          :     :        +- ReusedSubquery
+                                    :                          :     +- CometBroadcastExchange
+                                    :                          :        +- CometProject
+                                    :                          :           +- CometFilter
+                                    :                          :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                    :                          +- CometBroadcastExchange
+                                    :                             +- CometFilter
+                                    :                                +- CometNativeScan parquet spark_catalog.default.store
+                                    :- Project
+                                    :  +-  BroadcastNestedLoopJoin [COMET: BroadcastNestedLoopJoin is not supported]
+                                    :     :- BroadcastExchange
+                                    :     :  +- CometNativeColumnarToRow
+                                    :     :     +- CometHashAggregate
+                                    :     :        +- CometExchange
+                                    :     :           +- CometHashAggregate
+                                    :     :              +- CometProject
+                                    :     :                 +- CometBroadcastHashJoin
+                                    :     :                    :- CometNativeScan parquet spark_catalog.default.catalog_sales
+                                    :     :                    :     +- ReusedSubquery
+                                    :     :                    +- CometBroadcastExchange
+                                    :     :                       +- CometProject
+                                    :     :                          +- CometFilter
+                                    :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
+                                    :     +- CometNativeColumnarToRow
+                                    :        +- CometHashAggregate
+                                    :           +- CometExchange
+                                    :              +- CometHashAggregate
+                                    :                 +- CometProject
+                                    :                    +- CometBroadcastHashJoin
+                                    :                       :- CometNativeScan parquet spark_catalog.default.catalog_returns
+                                    :                       :     +- ReusedSubquery
+                                    :                       +- CometBroadcastExchange
+                                    :                          +- CometProject
+                                    :                             +- CometFilter
+                                    :                                +- CometNativeScan parquet spark_catalog.default.date_dim
+                                    +- CometNativeColumnarToRow
+                                       +- CometProject
+                                          +- CometBroadcastHashJoin
+                                             :- CometHashAggregate
+                                             :  +- CometExchange
+                                             :     +- CometHashAggregate
+                                             :        +- CometProject
+                                             :           +- CometBroadcastHashJoin
+                                             :              :- CometProject
+                                             :              :  +- CometBroadcastHashJoin
+                                             :              :     :- CometFilter
+                                             :              :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                                             :              :     :        +- ReusedSubquery
+                                             :              :     +- CometBroadcastExchange
+                                             :              :        +- CometProject
+                                             :              :           +- CometFilter
+                                             :              :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                             :              +- CometBroadcastExchange
+                                             :                 +- CometFilter
+                                             :                    +- CometNativeScan parquet spark_catalog.default.web_page
+                                             +- CometBroadcastExchange
+                                                +- CometHashAggregate
+                                                   +- CometExchange
+                                                      +- CometHashAggregate
+                                                         +- CometProject
+                                                            +- CometBroadcastHashJoin
+                                                               :- CometProject
+                                                               :  +- CometBroadcastHashJoin
+                                                               :     :- CometFilter
+                                                               :     :  +- CometNativeScan parquet spark_catalog.default.web_returns
+                                                               :     :        +- ReusedSubquery
+                                                               :     +- CometBroadcastExchange
+                                                               :        +- CometProject
+                                                               :           +- CometFilter
+                                                               :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                               +- CometBroadcastExchange
+                                                                  +- CometFilter
+                                                                     +- CometNativeScan parquet spark_catalog.default.web_page
+
+Comet accelerated 285 out of 332 eligible operators (85%). Final plan contains 13 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q77a.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q77a.native_iceberg_compat/extended.txt
@@ -1,0 +1,350 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometColumnarExchange
+         +- HashAggregate
+            +- Union
+               :- HashAggregate
+               :  +- Exchange
+               :     +- HashAggregate
+               :        +- Union
+               :           :- CometNativeColumnarToRow
+               :           :  +- CometProject
+               :           :     +- CometBroadcastHashJoin
+               :           :        :- CometHashAggregate
+               :           :        :  +- CometExchange
+               :           :        :     +- CometHashAggregate
+               :           :        :        +- CometProject
+               :           :        :           +- CometBroadcastHashJoin
+               :           :        :              :- CometProject
+               :           :        :              :  +- CometBroadcastHashJoin
+               :           :        :              :     :- CometFilter
+               :           :        :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :           :        :              :     :        +- SubqueryBroadcast
+               :           :        :              :     :           +- BroadcastExchange
+               :           :        :              :     :              +- CometNativeColumnarToRow
+               :           :        :              :     :                 +- CometProject
+               :           :        :              :     :                    +- CometFilter
+               :           :        :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :           :        :              :     +- CometBroadcastExchange
+               :           :        :              :        +- CometProject
+               :           :        :              :           +- CometFilter
+               :           :        :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :           :        :              +- CometBroadcastExchange
+               :           :        :                 +- CometFilter
+               :           :        :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+               :           :        +- CometBroadcastExchange
+               :           :           +- CometHashAggregate
+               :           :              +- CometExchange
+               :           :                 +- CometHashAggregate
+               :           :                    +- CometProject
+               :           :                       +- CometBroadcastHashJoin
+               :           :                          :- CometProject
+               :           :                          :  +- CometBroadcastHashJoin
+               :           :                          :     :- CometFilter
+               :           :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+               :           :                          :     :        +- ReusedSubquery
+               :           :                          :     +- CometBroadcastExchange
+               :           :                          :        +- CometProject
+               :           :                          :           +- CometFilter
+               :           :                          :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :           :                          +- CometBroadcastExchange
+               :           :                             +- CometFilter
+               :           :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+               :           :- Project
+               :           :  +-  BroadcastNestedLoopJoin [COMET: BroadcastNestedLoopJoin is not supported]
+               :           :     :- BroadcastExchange
+               :           :     :  +- CometNativeColumnarToRow
+               :           :     :     +- CometHashAggregate
+               :           :     :        +- CometExchange
+               :           :     :           +- CometHashAggregate
+               :           :     :              +- CometProject
+               :           :     :                 +- CometBroadcastHashJoin
+               :           :     :                    :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :           :     :                    :     +- ReusedSubquery
+               :           :     :                    +- CometBroadcastExchange
+               :           :     :                       +- CometProject
+               :           :     :                          +- CometFilter
+               :           :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :           :     +- CometNativeColumnarToRow
+               :           :        +- CometHashAggregate
+               :           :           +- CometExchange
+               :           :              +- CometHashAggregate
+               :           :                 +- CometProject
+               :           :                    +- CometBroadcastHashJoin
+               :           :                       :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+               :           :                       :     +- ReusedSubquery
+               :           :                       +- CometBroadcastExchange
+               :           :                          +- CometProject
+               :           :                             +- CometFilter
+               :           :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :           +- CometNativeColumnarToRow
+               :              +- CometProject
+               :                 +- CometBroadcastHashJoin
+               :                    :- CometHashAggregate
+               :                    :  +- CometExchange
+               :                    :     +- CometHashAggregate
+               :                    :        +- CometProject
+               :                    :           +- CometBroadcastHashJoin
+               :                    :              :- CometProject
+               :                    :              :  +- CometBroadcastHashJoin
+               :                    :              :     :- CometFilter
+               :                    :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                    :              :     :        +- ReusedSubquery
+               :                    :              :     +- CometBroadcastExchange
+               :                    :              :        +- CometProject
+               :                    :              :           +- CometFilter
+               :                    :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                    :              +- CometBroadcastExchange
+               :                    :                 +- CometFilter
+               :                    :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_page
+               :                    +- CometBroadcastExchange
+               :                       +- CometHashAggregate
+               :                          +- CometExchange
+               :                             +- CometHashAggregate
+               :                                +- CometProject
+               :                                   +- CometBroadcastHashJoin
+               :                                      :- CometProject
+               :                                      :  +- CometBroadcastHashJoin
+               :                                      :     :- CometFilter
+               :                                      :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+               :                                      :     :        +- ReusedSubquery
+               :                                      :     +- CometBroadcastExchange
+               :                                      :        +- CometProject
+               :                                      :           +- CometFilter
+               :                                      :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                      +- CometBroadcastExchange
+               :                                         +- CometFilter
+               :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_page
+               :- HashAggregate
+               :  +- Exchange
+               :     +- HashAggregate
+               :        +- HashAggregate
+               :           +- Exchange
+               :              +- HashAggregate
+               :                 +- Union
+               :                    :- CometNativeColumnarToRow
+               :                    :  +- CometProject
+               :                    :     +- CometBroadcastHashJoin
+               :                    :        :- CometHashAggregate
+               :                    :        :  +- CometExchange
+               :                    :        :     +- CometHashAggregate
+               :                    :        :        +- CometProject
+               :                    :        :           +- CometBroadcastHashJoin
+               :                    :        :              :- CometProject
+               :                    :        :              :  +- CometBroadcastHashJoin
+               :                    :        :              :     :- CometFilter
+               :                    :        :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                    :        :              :     :        +- SubqueryBroadcast
+               :                    :        :              :     :           +- BroadcastExchange
+               :                    :        :              :     :              +- CometNativeColumnarToRow
+               :                    :        :              :     :                 +- CometProject
+               :                    :        :              :     :                    +- CometFilter
+               :                    :        :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                    :        :              :     +- CometBroadcastExchange
+               :                    :        :              :        +- CometProject
+               :                    :        :              :           +- CometFilter
+               :                    :        :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                    :        :              +- CometBroadcastExchange
+               :                    :        :                 +- CometFilter
+               :                    :        :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+               :                    :        +- CometBroadcastExchange
+               :                    :           +- CometHashAggregate
+               :                    :              +- CometExchange
+               :                    :                 +- CometHashAggregate
+               :                    :                    +- CometProject
+               :                    :                       +- CometBroadcastHashJoin
+               :                    :                          :- CometProject
+               :                    :                          :  +- CometBroadcastHashJoin
+               :                    :                          :     :- CometFilter
+               :                    :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+               :                    :                          :     :        +- ReusedSubquery
+               :                    :                          :     +- CometBroadcastExchange
+               :                    :                          :        +- CometProject
+               :                    :                          :           +- CometFilter
+               :                    :                          :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                    :                          +- CometBroadcastExchange
+               :                    :                             +- CometFilter
+               :                    :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+               :                    :- Project
+               :                    :  +-  BroadcastNestedLoopJoin [COMET: BroadcastNestedLoopJoin is not supported]
+               :                    :     :- BroadcastExchange
+               :                    :     :  +- CometNativeColumnarToRow
+               :                    :     :     +- CometHashAggregate
+               :                    :     :        +- CometExchange
+               :                    :     :           +- CometHashAggregate
+               :                    :     :              +- CometProject
+               :                    :     :                 +- CometBroadcastHashJoin
+               :                    :     :                    :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                    :     :                    :     +- ReusedSubquery
+               :                    :     :                    +- CometBroadcastExchange
+               :                    :     :                       +- CometProject
+               :                    :     :                          +- CometFilter
+               :                    :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                    :     +- CometNativeColumnarToRow
+               :                    :        +- CometHashAggregate
+               :                    :           +- CometExchange
+               :                    :              +- CometHashAggregate
+               :                    :                 +- CometProject
+               :                    :                    +- CometBroadcastHashJoin
+               :                    :                       :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+               :                    :                       :     +- ReusedSubquery
+               :                    :                       +- CometBroadcastExchange
+               :                    :                          +- CometProject
+               :                    :                             +- CometFilter
+               :                    :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                    +- CometNativeColumnarToRow
+               :                       +- CometProject
+               :                          +- CometBroadcastHashJoin
+               :                             :- CometHashAggregate
+               :                             :  +- CometExchange
+               :                             :     +- CometHashAggregate
+               :                             :        +- CometProject
+               :                             :           +- CometBroadcastHashJoin
+               :                             :              :- CometProject
+               :                             :              :  +- CometBroadcastHashJoin
+               :                             :              :     :- CometFilter
+               :                             :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                             :              :     :        +- ReusedSubquery
+               :                             :              :     +- CometBroadcastExchange
+               :                             :              :        +- CometProject
+               :                             :              :           +- CometFilter
+               :                             :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                             :              +- CometBroadcastExchange
+               :                             :                 +- CometFilter
+               :                             :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_page
+               :                             +- CometBroadcastExchange
+               :                                +- CometHashAggregate
+               :                                   +- CometExchange
+               :                                      +- CometHashAggregate
+               :                                         +- CometProject
+               :                                            +- CometBroadcastHashJoin
+               :                                               :- CometProject
+               :                                               :  +- CometBroadcastHashJoin
+               :                                               :     :- CometFilter
+               :                                               :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+               :                                               :     :        +- ReusedSubquery
+               :                                               :     +- CometBroadcastExchange
+               :                                               :        +- CometProject
+               :                                               :           +- CometFilter
+               :                                               :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                               +- CometBroadcastExchange
+               :                                                  +- CometFilter
+               :                                                     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_page
+               +- HashAggregate
+                  +- Exchange
+                     +- HashAggregate
+                        +- HashAggregate
+                           +- Exchange
+                              +- HashAggregate
+                                 +- Union
+                                    :- CometNativeColumnarToRow
+                                    :  +- CometProject
+                                    :     +- CometBroadcastHashJoin
+                                    :        :- CometHashAggregate
+                                    :        :  +- CometExchange
+                                    :        :     +- CometHashAggregate
+                                    :        :        +- CometProject
+                                    :        :           +- CometBroadcastHashJoin
+                                    :        :              :- CometProject
+                                    :        :              :  +- CometBroadcastHashJoin
+                                    :        :              :     :- CometFilter
+                                    :        :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                    :        :              :     :        +- SubqueryBroadcast
+                                    :        :              :     :           +- BroadcastExchange
+                                    :        :              :     :              +- CometNativeColumnarToRow
+                                    :        :              :     :                 +- CometProject
+                                    :        :              :     :                    +- CometFilter
+                                    :        :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                    :        :              :     +- CometBroadcastExchange
+                                    :        :              :        +- CometProject
+                                    :        :              :           +- CometFilter
+                                    :        :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                    :        :              +- CometBroadcastExchange
+                                    :        :                 +- CometFilter
+                                    :        :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                                    :        +- CometBroadcastExchange
+                                    :           +- CometHashAggregate
+                                    :              +- CometExchange
+                                    :                 +- CometHashAggregate
+                                    :                    +- CometProject
+                                    :                       +- CometBroadcastHashJoin
+                                    :                          :- CometProject
+                                    :                          :  +- CometBroadcastHashJoin
+                                    :                          :     :- CometFilter
+                                    :                          :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+                                    :                          :     :        +- ReusedSubquery
+                                    :                          :     +- CometBroadcastExchange
+                                    :                          :        +- CometProject
+                                    :                          :           +- CometFilter
+                                    :                          :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                    :                          +- CometBroadcastExchange
+                                    :                             +- CometFilter
+                                    :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                                    :- Project
+                                    :  +-  BroadcastNestedLoopJoin [COMET: BroadcastNestedLoopJoin is not supported]
+                                    :     :- BroadcastExchange
+                                    :     :  +- CometNativeColumnarToRow
+                                    :     :     +- CometHashAggregate
+                                    :     :        +- CometExchange
+                                    :     :           +- CometHashAggregate
+                                    :     :              +- CometProject
+                                    :     :                 +- CometBroadcastHashJoin
+                                    :     :                    :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                                    :     :                    :     +- ReusedSubquery
+                                    :     :                    +- CometBroadcastExchange
+                                    :     :                       +- CometProject
+                                    :     :                          +- CometFilter
+                                    :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                    :     +- CometNativeColumnarToRow
+                                    :        +- CometHashAggregate
+                                    :           +- CometExchange
+                                    :              +- CometHashAggregate
+                                    :                 +- CometProject
+                                    :                    +- CometBroadcastHashJoin
+                                    :                       :- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+                                    :                       :     +- ReusedSubquery
+                                    :                       +- CometBroadcastExchange
+                                    :                          +- CometProject
+                                    :                             +- CometFilter
+                                    :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                    +- CometNativeColumnarToRow
+                                       +- CometProject
+                                          +- CometBroadcastHashJoin
+                                             :- CometHashAggregate
+                                             :  +- CometExchange
+                                             :     +- CometHashAggregate
+                                             :        +- CometProject
+                                             :           +- CometBroadcastHashJoin
+                                             :              :- CometProject
+                                             :              :  +- CometBroadcastHashJoin
+                                             :              :     :- CometFilter
+                                             :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                             :              :     :        +- ReusedSubquery
+                                             :              :     +- CometBroadcastExchange
+                                             :              :        +- CometProject
+                                             :              :           +- CometFilter
+                                             :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                             :              +- CometBroadcastExchange
+                                             :                 +- CometFilter
+                                             :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_page
+                                             +- CometBroadcastExchange
+                                                +- CometHashAggregate
+                                                   +- CometExchange
+                                                      +- CometHashAggregate
+                                                         +- CometProject
+                                                            +- CometBroadcastHashJoin
+                                                               :- CometProject
+                                                               :  +- CometBroadcastHashJoin
+                                                               :     :- CometFilter
+                                                               :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+                                                               :     :        +- ReusedSubquery
+                                                               :     +- CometBroadcastExchange
+                                                               :        +- CometProject
+                                                               :           +- CometFilter
+                                                               :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                               +- CometBroadcastExchange
+                                                                  +- CometFilter
+                                                                     +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_page
+
+Comet accelerated 282 out of 332 eligible operators (84%). Final plan contains 16 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q78.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q78.native_datafusion/extended.txt
@@ -1,0 +1,79 @@
+TakeOrderedAndProject
++-  Project [COMET: Comet does not support Spark's BigDecimal rounding]
+   +- CometNativeColumnarToRow
+      +- CometSortMergeJoin
+         :- CometProject
+         :  +- CometSortMergeJoin
+         :     :- CometSort
+         :     :  +- CometHashAggregate
+         :     :     +- CometExchange
+         :     :        +- CometHashAggregate
+         :     :           +- CometProject
+         :     :              +- CometBroadcastHashJoin
+         :     :                 :- CometProject
+         :     :                 :  +- CometFilter
+         :     :                 :     +- CometSortMergeJoin
+         :     :                 :        :- CometSort
+         :     :                 :        :  +- CometExchange
+         :     :                 :        :     +- CometFilter
+         :     :                 :        :        +- CometNativeScan parquet spark_catalog.default.store_sales
+         :     :                 :        :              +- CometSubqueryBroadcast
+         :     :                 :        :                 +- CometBroadcastExchange
+         :     :                 :        :                    +- CometFilter
+         :     :                 :        :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     :                 :        +- CometSort
+         :     :                 :           +- CometExchange
+         :     :                 :              +- CometProject
+         :     :                 :                 +- CometFilter
+         :     :                 :                    +- CometNativeScan parquet spark_catalog.default.store_returns
+         :     :                 +- CometBroadcastExchange
+         :     :                    +- CometFilter
+         :     :                       +- CometNativeScan parquet spark_catalog.default.date_dim
+         :     +- CometSort
+         :        +- CometFilter
+         :           +- CometHashAggregate
+         :              +- CometExchange
+         :                 +- CometHashAggregate
+         :                    +- CometProject
+         :                       +- CometBroadcastHashJoin
+         :                          :- CometProject
+         :                          :  +- CometFilter
+         :                          :     +- CometSortMergeJoin
+         :                          :        :- CometSort
+         :                          :        :  +- CometExchange
+         :                          :        :     +- CometFilter
+         :                          :        :        +- CometNativeScan parquet spark_catalog.default.web_sales
+         :                          :        :              +- ReusedSubquery
+         :                          :        +- CometSort
+         :                          :           +- CometExchange
+         :                          :              +- CometProject
+         :                          :                 +- CometFilter
+         :                          :                    +- CometNativeScan parquet spark_catalog.default.web_returns
+         :                          +- CometBroadcastExchange
+         :                             +- CometFilter
+         :                                +- CometNativeScan parquet spark_catalog.default.date_dim
+         +- CometSort
+            +- CometFilter
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometFilter
+                              :     +- CometSortMergeJoin
+                              :        :- CometSort
+                              :        :  +- CometExchange
+                              :        :     +- CometFilter
+                              :        :        +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                              :        :              +- ReusedSubquery
+                              :        +- CometSort
+                              :           +- CometExchange
+                              :              +- CometProject
+                              :                 +- CometFilter
+                              :                    +- CometNativeScan parquet spark_catalog.default.catalog_returns
+                              +- CometBroadcastExchange
+                                 +- CometFilter
+                                    +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 71 out of 76 eligible operators (93%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q78.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q78.native_iceberg_compat/extended.txt
@@ -1,0 +1,80 @@
+TakeOrderedAndProject
++-  Project [COMET: Comet does not support Spark's BigDecimal rounding]
+   +- CometNativeColumnarToRow
+      +- CometSortMergeJoin
+         :- CometProject
+         :  +- CometSortMergeJoin
+         :     :- CometSort
+         :     :  +- CometHashAggregate
+         :     :     +- CometExchange
+         :     :        +- CometHashAggregate
+         :     :           +- CometProject
+         :     :              +- CometBroadcastHashJoin
+         :     :                 :- CometProject
+         :     :                 :  +- CometFilter
+         :     :                 :     +- CometSortMergeJoin
+         :     :                 :        :- CometSort
+         :     :                 :        :  +- CometExchange
+         :     :                 :        :     +- CometFilter
+         :     :                 :        :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+         :     :                 :        :              +- SubqueryBroadcast
+         :     :                 :        :                 +- BroadcastExchange
+         :     :                 :        :                    +- CometNativeColumnarToRow
+         :     :                 :        :                       +- CometFilter
+         :     :                 :        :                          +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     :                 :        +- CometSort
+         :     :                 :           +- CometExchange
+         :     :                 :              +- CometProject
+         :     :                 :                 +- CometFilter
+         :     :                 :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+         :     :                 +- CometBroadcastExchange
+         :     :                    +- CometFilter
+         :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         :     +- CometSort
+         :        +- CometFilter
+         :           +- CometHashAggregate
+         :              +- CometExchange
+         :                 +- CometHashAggregate
+         :                    +- CometProject
+         :                       +- CometBroadcastHashJoin
+         :                          :- CometProject
+         :                          :  +- CometFilter
+         :                          :     +- CometSortMergeJoin
+         :                          :        :- CometSort
+         :                          :        :  +- CometExchange
+         :                          :        :     +- CometFilter
+         :                          :        :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+         :                          :        :              +- ReusedSubquery
+         :                          :        +- CometSort
+         :                          :           +- CometExchange
+         :                          :              +- CometProject
+         :                          :                 +- CometFilter
+         :                          :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+         :                          +- CometBroadcastExchange
+         :                             +- CometFilter
+         :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+         +- CometSort
+            +- CometFilter
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometProject
+                           +- CometBroadcastHashJoin
+                              :- CometProject
+                              :  +- CometFilter
+                              :     +- CometSortMergeJoin
+                              :        :- CometSort
+                              :        :  +- CometExchange
+                              :        :     +- CometFilter
+                              :        :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                              :        :              +- ReusedSubquery
+                              :        +- CometSort
+                              :           +- CometExchange
+                              :              +- CometProject
+                              :                 +- CometFilter
+                              :                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+                              +- CometBroadcastExchange
+                                 +- CometFilter
+                                    +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 70 out of 76 eligible operators (92%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q80a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q80a.native_datafusion/extended.txt
@@ -1,0 +1,389 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometUnion
+               :- CometHashAggregate
+               :  +- CometExchange
+               :     +- CometHashAggregate
+               :        +- CometUnion
+               :           :- CometHashAggregate
+               :           :  +- CometExchange
+               :           :     +- CometHashAggregate
+               :           :        +- CometProject
+               :           :           +- CometBroadcastHashJoin
+               :           :              :- CometProject
+               :           :              :  +- CometBroadcastHashJoin
+               :           :              :     :- CometProject
+               :           :              :     :  +- CometBroadcastHashJoin
+               :           :              :     :     :- CometProject
+               :           :              :     :     :  +- CometBroadcastHashJoin
+               :           :              :     :     :     :- CometProject
+               :           :              :     :     :     :  +- CometSortMergeJoin
+               :           :              :     :     :     :     :- CometSort
+               :           :              :     :     :     :     :  +- CometExchange
+               :           :              :     :     :     :     :     +- CometFilter
+               :           :              :     :     :     :     :        +- CometNativeScan parquet spark_catalog.default.store_sales
+               :           :              :     :     :     :     :              +- CometSubqueryBroadcast
+               :           :              :     :     :     :     :                 +- CometBroadcastExchange
+               :           :              :     :     :     :     :                    +- CometProject
+               :           :              :     :     :     :     :                       +- CometFilter
+               :           :              :     :     :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+               :           :              :     :     :     :     +- CometSort
+               :           :              :     :     :     :        +- CometExchange
+               :           :              :     :     :     :           +- CometProject
+               :           :              :     :     :     :              +- CometFilter
+               :           :              :     :     :     :                 +- CometNativeScan parquet spark_catalog.default.store_returns
+               :           :              :     :     :     +- CometBroadcastExchange
+               :           :              :     :     :        +- CometProject
+               :           :              :     :     :           +- CometFilter
+               :           :              :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :           :              :     :     +- CometBroadcastExchange
+               :           :              :     :        +- CometProject
+               :           :              :     :           +- CometFilter
+               :           :              :     :              +- CometNativeScan parquet spark_catalog.default.store
+               :           :              :     +- CometBroadcastExchange
+               :           :              :        +- CometProject
+               :           :              :           +- CometFilter
+               :           :              :              +- CometNativeScan parquet spark_catalog.default.item
+               :           :              +- CometBroadcastExchange
+               :           :                 +- CometProject
+               :           :                    +- CometFilter
+               :           :                       +- CometNativeScan parquet spark_catalog.default.promotion
+               :           :- CometHashAggregate
+               :           :  +- CometExchange
+               :           :     +- CometHashAggregate
+               :           :        +- CometProject
+               :           :           +- CometBroadcastHashJoin
+               :           :              :- CometProject
+               :           :              :  +- CometBroadcastHashJoin
+               :           :              :     :- CometProject
+               :           :              :     :  +- CometBroadcastHashJoin
+               :           :              :     :     :- CometProject
+               :           :              :     :     :  +- CometBroadcastHashJoin
+               :           :              :     :     :     :- CometProject
+               :           :              :     :     :     :  +- CometSortMergeJoin
+               :           :              :     :     :     :     :- CometSort
+               :           :              :     :     :     :     :  +- CometExchange
+               :           :              :     :     :     :     :     +- CometFilter
+               :           :              :     :     :     :     :        +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :           :              :     :     :     :     :              +- ReusedSubquery
+               :           :              :     :     :     :     +- CometSort
+               :           :              :     :     :     :        +- CometExchange
+               :           :              :     :     :     :           +- CometProject
+               :           :              :     :     :     :              +- CometFilter
+               :           :              :     :     :     :                 +- CometNativeScan parquet spark_catalog.default.catalog_returns
+               :           :              :     :     :     +- CometBroadcastExchange
+               :           :              :     :     :        +- CometProject
+               :           :              :     :     :           +- CometFilter
+               :           :              :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :           :              :     :     +- CometBroadcastExchange
+               :           :              :     :        +- CometProject
+               :           :              :     :           +- CometFilter
+               :           :              :     :              +- CometNativeScan parquet spark_catalog.default.catalog_page
+               :           :              :     +- CometBroadcastExchange
+               :           :              :        +- CometProject
+               :           :              :           +- CometFilter
+               :           :              :              +- CometNativeScan parquet spark_catalog.default.item
+               :           :              +- CometBroadcastExchange
+               :           :                 +- CometProject
+               :           :                    +- CometFilter
+               :           :                       +- CometNativeScan parquet spark_catalog.default.promotion
+               :           +- CometHashAggregate
+               :              +- CometExchange
+               :                 +- CometHashAggregate
+               :                    +- CometProject
+               :                       +- CometBroadcastHashJoin
+               :                          :- CometProject
+               :                          :  +- CometBroadcastHashJoin
+               :                          :     :- CometProject
+               :                          :     :  +- CometBroadcastHashJoin
+               :                          :     :     :- CometProject
+               :                          :     :     :  +- CometBroadcastHashJoin
+               :                          :     :     :     :- CometProject
+               :                          :     :     :     :  +- CometSortMergeJoin
+               :                          :     :     :     :     :- CometSort
+               :                          :     :     :     :     :  +- CometExchange
+               :                          :     :     :     :     :     +- CometFilter
+               :                          :     :     :     :     :        +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                          :     :     :     :     :              +- ReusedSubquery
+               :                          :     :     :     :     +- CometSort
+               :                          :     :     :     :        +- CometExchange
+               :                          :     :     :     :           +- CometProject
+               :                          :     :     :     :              +- CometFilter
+               :                          :     :     :     :                 +- CometNativeScan parquet spark_catalog.default.web_returns
+               :                          :     :     :     +- CometBroadcastExchange
+               :                          :     :     :        +- CometProject
+               :                          :     :     :           +- CometFilter
+               :                          :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                          :     :     +- CometBroadcastExchange
+               :                          :     :        +- CometProject
+               :                          :     :           +- CometFilter
+               :                          :     :              +- CometNativeScan parquet spark_catalog.default.web_site
+               :                          :     +- CometBroadcastExchange
+               :                          :        +- CometProject
+               :                          :           +- CometFilter
+               :                          :              +- CometNativeScan parquet spark_catalog.default.item
+               :                          +- CometBroadcastExchange
+               :                             +- CometProject
+               :                                +- CometFilter
+               :                                   +- CometNativeScan parquet spark_catalog.default.promotion
+               :- CometHashAggregate
+               :  +- CometExchange
+               :     +- CometHashAggregate
+               :        +- CometHashAggregate
+               :           +- CometExchange
+               :              +- CometHashAggregate
+               :                 +- CometUnion
+               :                    :- CometHashAggregate
+               :                    :  +- CometExchange
+               :                    :     +- CometHashAggregate
+               :                    :        +- CometProject
+               :                    :           +- CometBroadcastHashJoin
+               :                    :              :- CometProject
+               :                    :              :  +- CometBroadcastHashJoin
+               :                    :              :     :- CometProject
+               :                    :              :     :  +- CometBroadcastHashJoin
+               :                    :              :     :     :- CometProject
+               :                    :              :     :     :  +- CometBroadcastHashJoin
+               :                    :              :     :     :     :- CometProject
+               :                    :              :     :     :     :  +- CometSortMergeJoin
+               :                    :              :     :     :     :     :- CometSort
+               :                    :              :     :     :     :     :  +- CometExchange
+               :                    :              :     :     :     :     :     +- CometFilter
+               :                    :              :     :     :     :     :        +- CometNativeScan parquet spark_catalog.default.store_sales
+               :                    :              :     :     :     :     :              +- CometSubqueryBroadcast
+               :                    :              :     :     :     :     :                 +- CometBroadcastExchange
+               :                    :              :     :     :     :     :                    +- CometProject
+               :                    :              :     :     :     :     :                       +- CometFilter
+               :                    :              :     :     :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                    :              :     :     :     :     +- CometSort
+               :                    :              :     :     :     :        +- CometExchange
+               :                    :              :     :     :     :           +- CometProject
+               :                    :              :     :     :     :              +- CometFilter
+               :                    :              :     :     :     :                 +- CometNativeScan parquet spark_catalog.default.store_returns
+               :                    :              :     :     :     +- CometBroadcastExchange
+               :                    :              :     :     :        +- CometProject
+               :                    :              :     :     :           +- CometFilter
+               :                    :              :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                    :              :     :     +- CometBroadcastExchange
+               :                    :              :     :        +- CometProject
+               :                    :              :     :           +- CometFilter
+               :                    :              :     :              +- CometNativeScan parquet spark_catalog.default.store
+               :                    :              :     +- CometBroadcastExchange
+               :                    :              :        +- CometProject
+               :                    :              :           +- CometFilter
+               :                    :              :              +- CometNativeScan parquet spark_catalog.default.item
+               :                    :              +- CometBroadcastExchange
+               :                    :                 +- CometProject
+               :                    :                    +- CometFilter
+               :                    :                       +- CometNativeScan parquet spark_catalog.default.promotion
+               :                    :- CometHashAggregate
+               :                    :  +- CometExchange
+               :                    :     +- CometHashAggregate
+               :                    :        +- CometProject
+               :                    :           +- CometBroadcastHashJoin
+               :                    :              :- CometProject
+               :                    :              :  +- CometBroadcastHashJoin
+               :                    :              :     :- CometProject
+               :                    :              :     :  +- CometBroadcastHashJoin
+               :                    :              :     :     :- CometProject
+               :                    :              :     :     :  +- CometBroadcastHashJoin
+               :                    :              :     :     :     :- CometProject
+               :                    :              :     :     :     :  +- CometSortMergeJoin
+               :                    :              :     :     :     :     :- CometSort
+               :                    :              :     :     :     :     :  +- CometExchange
+               :                    :              :     :     :     :     :     +- CometFilter
+               :                    :              :     :     :     :     :        +- CometNativeScan parquet spark_catalog.default.catalog_sales
+               :                    :              :     :     :     :     :              +- ReusedSubquery
+               :                    :              :     :     :     :     +- CometSort
+               :                    :              :     :     :     :        +- CometExchange
+               :                    :              :     :     :     :           +- CometProject
+               :                    :              :     :     :     :              +- CometFilter
+               :                    :              :     :     :     :                 +- CometNativeScan parquet spark_catalog.default.catalog_returns
+               :                    :              :     :     :     +- CometBroadcastExchange
+               :                    :              :     :     :        +- CometProject
+               :                    :              :     :     :           +- CometFilter
+               :                    :              :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                    :              :     :     +- CometBroadcastExchange
+               :                    :              :     :        +- CometProject
+               :                    :              :     :           +- CometFilter
+               :                    :              :     :              +- CometNativeScan parquet spark_catalog.default.catalog_page
+               :                    :              :     +- CometBroadcastExchange
+               :                    :              :        +- CometProject
+               :                    :              :           +- CometFilter
+               :                    :              :              +- CometNativeScan parquet spark_catalog.default.item
+               :                    :              +- CometBroadcastExchange
+               :                    :                 +- CometProject
+               :                    :                    +- CometFilter
+               :                    :                       +- CometNativeScan parquet spark_catalog.default.promotion
+               :                    +- CometHashAggregate
+               :                       +- CometExchange
+               :                          +- CometHashAggregate
+               :                             +- CometProject
+               :                                +- CometBroadcastHashJoin
+               :                                   :- CometProject
+               :                                   :  +- CometBroadcastHashJoin
+               :                                   :     :- CometProject
+               :                                   :     :  +- CometBroadcastHashJoin
+               :                                   :     :     :- CometProject
+               :                                   :     :     :  +- CometBroadcastHashJoin
+               :                                   :     :     :     :- CometProject
+               :                                   :     :     :     :  +- CometSortMergeJoin
+               :                                   :     :     :     :     :- CometSort
+               :                                   :     :     :     :     :  +- CometExchange
+               :                                   :     :     :     :     :     +- CometFilter
+               :                                   :     :     :     :     :        +- CometNativeScan parquet spark_catalog.default.web_sales
+               :                                   :     :     :     :     :              +- ReusedSubquery
+               :                                   :     :     :     :     +- CometSort
+               :                                   :     :     :     :        +- CometExchange
+               :                                   :     :     :     :           +- CometProject
+               :                                   :     :     :     :              +- CometFilter
+               :                                   :     :     :     :                 +- CometNativeScan parquet spark_catalog.default.web_returns
+               :                                   :     :     :     +- CometBroadcastExchange
+               :                                   :     :     :        +- CometProject
+               :                                   :     :     :           +- CometFilter
+               :                                   :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+               :                                   :     :     +- CometBroadcastExchange
+               :                                   :     :        +- CometProject
+               :                                   :     :           +- CometFilter
+               :                                   :     :              +- CometNativeScan parquet spark_catalog.default.web_site
+               :                                   :     +- CometBroadcastExchange
+               :                                   :        +- CometProject
+               :                                   :           +- CometFilter
+               :                                   :              +- CometNativeScan parquet spark_catalog.default.item
+               :                                   +- CometBroadcastExchange
+               :                                      +- CometProject
+               :                                         +- CometFilter
+               :                                            +- CometNativeScan parquet spark_catalog.default.promotion
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometHashAggregate
+                           +- CometExchange
+                              +- CometHashAggregate
+                                 +- CometUnion
+                                    :- CometHashAggregate
+                                    :  +- CometExchange
+                                    :     +- CometHashAggregate
+                                    :        +- CometProject
+                                    :           +- CometBroadcastHashJoin
+                                    :              :- CometProject
+                                    :              :  +- CometBroadcastHashJoin
+                                    :              :     :- CometProject
+                                    :              :     :  +- CometBroadcastHashJoin
+                                    :              :     :     :- CometProject
+                                    :              :     :     :  +- CometBroadcastHashJoin
+                                    :              :     :     :     :- CometProject
+                                    :              :     :     :     :  +- CometSortMergeJoin
+                                    :              :     :     :     :     :- CometSort
+                                    :              :     :     :     :     :  +- CometExchange
+                                    :              :     :     :     :     :     +- CometFilter
+                                    :              :     :     :     :     :        +- CometNativeScan parquet spark_catalog.default.store_sales
+                                    :              :     :     :     :     :              +- CometSubqueryBroadcast
+                                    :              :     :     :     :     :                 +- CometBroadcastExchange
+                                    :              :     :     :     :     :                    +- CometProject
+                                    :              :     :     :     :     :                       +- CometFilter
+                                    :              :     :     :     :     :                          +- CometNativeScan parquet spark_catalog.default.date_dim
+                                    :              :     :     :     :     +- CometSort
+                                    :              :     :     :     :        +- CometExchange
+                                    :              :     :     :     :           +- CometProject
+                                    :              :     :     :     :              +- CometFilter
+                                    :              :     :     :     :                 +- CometNativeScan parquet spark_catalog.default.store_returns
+                                    :              :     :     :     +- CometBroadcastExchange
+                                    :              :     :     :        +- CometProject
+                                    :              :     :     :           +- CometFilter
+                                    :              :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                    :              :     :     +- CometBroadcastExchange
+                                    :              :     :        +- CometProject
+                                    :              :     :           +- CometFilter
+                                    :              :     :              +- CometNativeScan parquet spark_catalog.default.store
+                                    :              :     +- CometBroadcastExchange
+                                    :              :        +- CometProject
+                                    :              :           +- CometFilter
+                                    :              :              +- CometNativeScan parquet spark_catalog.default.item
+                                    :              +- CometBroadcastExchange
+                                    :                 +- CometProject
+                                    :                    +- CometFilter
+                                    :                       +- CometNativeScan parquet spark_catalog.default.promotion
+                                    :- CometHashAggregate
+                                    :  +- CometExchange
+                                    :     +- CometHashAggregate
+                                    :        +- CometProject
+                                    :           +- CometBroadcastHashJoin
+                                    :              :- CometProject
+                                    :              :  +- CometBroadcastHashJoin
+                                    :              :     :- CometProject
+                                    :              :     :  +- CometBroadcastHashJoin
+                                    :              :     :     :- CometProject
+                                    :              :     :     :  +- CometBroadcastHashJoin
+                                    :              :     :     :     :- CometProject
+                                    :              :     :     :     :  +- CometSortMergeJoin
+                                    :              :     :     :     :     :- CometSort
+                                    :              :     :     :     :     :  +- CometExchange
+                                    :              :     :     :     :     :     +- CometFilter
+                                    :              :     :     :     :     :        +- CometNativeScan parquet spark_catalog.default.catalog_sales
+                                    :              :     :     :     :     :              +- ReusedSubquery
+                                    :              :     :     :     :     +- CometSort
+                                    :              :     :     :     :        +- CometExchange
+                                    :              :     :     :     :           +- CometProject
+                                    :              :     :     :     :              +- CometFilter
+                                    :              :     :     :     :                 +- CometNativeScan parquet spark_catalog.default.catalog_returns
+                                    :              :     :     :     +- CometBroadcastExchange
+                                    :              :     :     :        +- CometProject
+                                    :              :     :     :           +- CometFilter
+                                    :              :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                    :              :     :     +- CometBroadcastExchange
+                                    :              :     :        +- CometProject
+                                    :              :     :           +- CometFilter
+                                    :              :     :              +- CometNativeScan parquet spark_catalog.default.catalog_page
+                                    :              :     +- CometBroadcastExchange
+                                    :              :        +- CometProject
+                                    :              :           +- CometFilter
+                                    :              :              +- CometNativeScan parquet spark_catalog.default.item
+                                    :              +- CometBroadcastExchange
+                                    :                 +- CometProject
+                                    :                    +- CometFilter
+                                    :                       +- CometNativeScan parquet spark_catalog.default.promotion
+                                    +- CometHashAggregate
+                                       +- CometExchange
+                                          +- CometHashAggregate
+                                             +- CometProject
+                                                +- CometBroadcastHashJoin
+                                                   :- CometProject
+                                                   :  +- CometBroadcastHashJoin
+                                                   :     :- CometProject
+                                                   :     :  +- CometBroadcastHashJoin
+                                                   :     :     :- CometProject
+                                                   :     :     :  +- CometBroadcastHashJoin
+                                                   :     :     :     :- CometProject
+                                                   :     :     :     :  +- CometSortMergeJoin
+                                                   :     :     :     :     :- CometSort
+                                                   :     :     :     :     :  +- CometExchange
+                                                   :     :     :     :     :     +- CometFilter
+                                                   :     :     :     :     :        +- CometNativeScan parquet spark_catalog.default.web_sales
+                                                   :     :     :     :     :              +- ReusedSubquery
+                                                   :     :     :     :     +- CometSort
+                                                   :     :     :     :        +- CometExchange
+                                                   :     :     :     :           +- CometProject
+                                                   :     :     :     :              +- CometFilter
+                                                   :     :     :     :                 +- CometNativeScan parquet spark_catalog.default.web_returns
+                                                   :     :     :     +- CometBroadcastExchange
+                                                   :     :     :        +- CometProject
+                                                   :     :     :           +- CometFilter
+                                                   :     :     :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                   :     :     +- CometBroadcastExchange
+                                                   :     :        +- CometProject
+                                                   :     :           +- CometFilter
+                                                   :     :              +- CometNativeScan parquet spark_catalog.default.web_site
+                                                   :     +- CometBroadcastExchange
+                                                   :        +- CometProject
+                                                   :           +- CometFilter
+                                                   :              +- CometNativeScan parquet spark_catalog.default.item
+                                                   +- CometBroadcastExchange
+                                                      +- CometProject
+                                                         +- CometFilter
+                                                            +- CometNativeScan parquet spark_catalog.default.promotion
+
+Comet accelerated 377 out of 386 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q80a.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q80a.native_iceberg_compat/extended.txt
@@ -1,0 +1,392 @@
+CometNativeColumnarToRow
++- CometTakeOrderedAndProject
+   +- CometHashAggregate
+      +- CometExchange
+         +- CometHashAggregate
+            +- CometUnion
+               :- CometHashAggregate
+               :  +- CometExchange
+               :     +- CometHashAggregate
+               :        +- CometUnion
+               :           :- CometHashAggregate
+               :           :  +- CometExchange
+               :           :     +- CometHashAggregate
+               :           :        +- CometProject
+               :           :           +- CometBroadcastHashJoin
+               :           :              :- CometProject
+               :           :              :  +- CometBroadcastHashJoin
+               :           :              :     :- CometProject
+               :           :              :     :  +- CometBroadcastHashJoin
+               :           :              :     :     :- CometProject
+               :           :              :     :     :  +- CometBroadcastHashJoin
+               :           :              :     :     :     :- CometProject
+               :           :              :     :     :     :  +- CometSortMergeJoin
+               :           :              :     :     :     :     :- CometSort
+               :           :              :     :     :     :     :  +- CometExchange
+               :           :              :     :     :     :     :     +- CometFilter
+               :           :              :     :     :     :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :           :              :     :     :     :     :              +- SubqueryBroadcast
+               :           :              :     :     :     :     :                 +- BroadcastExchange
+               :           :              :     :     :     :     :                    +- CometNativeColumnarToRow
+               :           :              :     :     :     :     :                       +- CometProject
+               :           :              :     :     :     :     :                          +- CometFilter
+               :           :              :     :     :     :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :           :              :     :     :     :     +- CometSort
+               :           :              :     :     :     :        +- CometExchange
+               :           :              :     :     :     :           +- CometProject
+               :           :              :     :     :     :              +- CometFilter
+               :           :              :     :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+               :           :              :     :     :     +- CometBroadcastExchange
+               :           :              :     :     :        +- CometProject
+               :           :              :     :     :           +- CometFilter
+               :           :              :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :           :              :     :     +- CometBroadcastExchange
+               :           :              :     :        +- CometProject
+               :           :              :     :           +- CometFilter
+               :           :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+               :           :              :     +- CometBroadcastExchange
+               :           :              :        +- CometProject
+               :           :              :           +- CometFilter
+               :           :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :           :              +- CometBroadcastExchange
+               :           :                 +- CometProject
+               :           :                    +- CometFilter
+               :           :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+               :           :- CometHashAggregate
+               :           :  +- CometExchange
+               :           :     +- CometHashAggregate
+               :           :        +- CometProject
+               :           :           +- CometBroadcastHashJoin
+               :           :              :- CometProject
+               :           :              :  +- CometBroadcastHashJoin
+               :           :              :     :- CometProject
+               :           :              :     :  +- CometBroadcastHashJoin
+               :           :              :     :     :- CometProject
+               :           :              :     :     :  +- CometBroadcastHashJoin
+               :           :              :     :     :     :- CometProject
+               :           :              :     :     :     :  +- CometSortMergeJoin
+               :           :              :     :     :     :     :- CometSort
+               :           :              :     :     :     :     :  +- CometExchange
+               :           :              :     :     :     :     :     +- CometFilter
+               :           :              :     :     :     :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :           :              :     :     :     :     :              +- ReusedSubquery
+               :           :              :     :     :     :     +- CometSort
+               :           :              :     :     :     :        +- CometExchange
+               :           :              :     :     :     :           +- CometProject
+               :           :              :     :     :     :              +- CometFilter
+               :           :              :     :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+               :           :              :     :     :     +- CometBroadcastExchange
+               :           :              :     :     :        +- CometProject
+               :           :              :     :     :           +- CometFilter
+               :           :              :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :           :              :     :     +- CometBroadcastExchange
+               :           :              :     :        +- CometProject
+               :           :              :     :           +- CometFilter
+               :           :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_page
+               :           :              :     +- CometBroadcastExchange
+               :           :              :        +- CometProject
+               :           :              :           +- CometFilter
+               :           :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :           :              +- CometBroadcastExchange
+               :           :                 +- CometProject
+               :           :                    +- CometFilter
+               :           :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+               :           +- CometHashAggregate
+               :              +- CometExchange
+               :                 +- CometHashAggregate
+               :                    +- CometProject
+               :                       +- CometBroadcastHashJoin
+               :                          :- CometProject
+               :                          :  +- CometBroadcastHashJoin
+               :                          :     :- CometProject
+               :                          :     :  +- CometBroadcastHashJoin
+               :                          :     :     :- CometProject
+               :                          :     :     :  +- CometBroadcastHashJoin
+               :                          :     :     :     :- CometProject
+               :                          :     :     :     :  +- CometSortMergeJoin
+               :                          :     :     :     :     :- CometSort
+               :                          :     :     :     :     :  +- CometExchange
+               :                          :     :     :     :     :     +- CometFilter
+               :                          :     :     :     :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                          :     :     :     :     :              +- ReusedSubquery
+               :                          :     :     :     :     +- CometSort
+               :                          :     :     :     :        +- CometExchange
+               :                          :     :     :     :           +- CometProject
+               :                          :     :     :     :              +- CometFilter
+               :                          :     :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+               :                          :     :     :     +- CometBroadcastExchange
+               :                          :     :     :        +- CometProject
+               :                          :     :     :           +- CometFilter
+               :                          :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                          :     :     +- CometBroadcastExchange
+               :                          :     :        +- CometProject
+               :                          :     :           +- CometFilter
+               :                          :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_site
+               :                          :     +- CometBroadcastExchange
+               :                          :        +- CometProject
+               :                          :           +- CometFilter
+               :                          :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                          +- CometBroadcastExchange
+               :                             +- CometProject
+               :                                +- CometFilter
+               :                                   +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+               :- CometHashAggregate
+               :  +- CometExchange
+               :     +- CometHashAggregate
+               :        +- CometHashAggregate
+               :           +- CometExchange
+               :              +- CometHashAggregate
+               :                 +- CometUnion
+               :                    :- CometHashAggregate
+               :                    :  +- CometExchange
+               :                    :     +- CometHashAggregate
+               :                    :        +- CometProject
+               :                    :           +- CometBroadcastHashJoin
+               :                    :              :- CometProject
+               :                    :              :  +- CometBroadcastHashJoin
+               :                    :              :     :- CometProject
+               :                    :              :     :  +- CometBroadcastHashJoin
+               :                    :              :     :     :- CometProject
+               :                    :              :     :     :  +- CometBroadcastHashJoin
+               :                    :              :     :     :     :- CometProject
+               :                    :              :     :     :     :  +- CometSortMergeJoin
+               :                    :              :     :     :     :     :- CometSort
+               :                    :              :     :     :     :     :  +- CometExchange
+               :                    :              :     :     :     :     :     +- CometFilter
+               :                    :              :     :     :     :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+               :                    :              :     :     :     :     :              +- SubqueryBroadcast
+               :                    :              :     :     :     :     :                 +- BroadcastExchange
+               :                    :              :     :     :     :     :                    +- CometNativeColumnarToRow
+               :                    :              :     :     :     :     :                       +- CometProject
+               :                    :              :     :     :     :     :                          +- CometFilter
+               :                    :              :     :     :     :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                    :              :     :     :     :     +- CometSort
+               :                    :              :     :     :     :        +- CometExchange
+               :                    :              :     :     :     :           +- CometProject
+               :                    :              :     :     :     :              +- CometFilter
+               :                    :              :     :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+               :                    :              :     :     :     +- CometBroadcastExchange
+               :                    :              :     :     :        +- CometProject
+               :                    :              :     :     :           +- CometFilter
+               :                    :              :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                    :              :     :     +- CometBroadcastExchange
+               :                    :              :     :        +- CometProject
+               :                    :              :     :           +- CometFilter
+               :                    :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+               :                    :              :     +- CometBroadcastExchange
+               :                    :              :        +- CometProject
+               :                    :              :           +- CometFilter
+               :                    :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                    :              +- CometBroadcastExchange
+               :                    :                 +- CometProject
+               :                    :                    +- CometFilter
+               :                    :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+               :                    :- CometHashAggregate
+               :                    :  +- CometExchange
+               :                    :     +- CometHashAggregate
+               :                    :        +- CometProject
+               :                    :           +- CometBroadcastHashJoin
+               :                    :              :- CometProject
+               :                    :              :  +- CometBroadcastHashJoin
+               :                    :              :     :- CometProject
+               :                    :              :     :  +- CometBroadcastHashJoin
+               :                    :              :     :     :- CometProject
+               :                    :              :     :     :  +- CometBroadcastHashJoin
+               :                    :              :     :     :     :- CometProject
+               :                    :              :     :     :     :  +- CometSortMergeJoin
+               :                    :              :     :     :     :     :- CometSort
+               :                    :              :     :     :     :     :  +- CometExchange
+               :                    :              :     :     :     :     :     +- CometFilter
+               :                    :              :     :     :     :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+               :                    :              :     :     :     :     :              +- ReusedSubquery
+               :                    :              :     :     :     :     +- CometSort
+               :                    :              :     :     :     :        +- CometExchange
+               :                    :              :     :     :     :           +- CometProject
+               :                    :              :     :     :     :              +- CometFilter
+               :                    :              :     :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+               :                    :              :     :     :     +- CometBroadcastExchange
+               :                    :              :     :     :        +- CometProject
+               :                    :              :     :     :           +- CometFilter
+               :                    :              :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                    :              :     :     +- CometBroadcastExchange
+               :                    :              :     :        +- CometProject
+               :                    :              :     :           +- CometFilter
+               :                    :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_page
+               :                    :              :     +- CometBroadcastExchange
+               :                    :              :        +- CometProject
+               :                    :              :           +- CometFilter
+               :                    :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                    :              +- CometBroadcastExchange
+               :                    :                 +- CometProject
+               :                    :                    +- CometFilter
+               :                    :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+               :                    +- CometHashAggregate
+               :                       +- CometExchange
+               :                          +- CometHashAggregate
+               :                             +- CometProject
+               :                                +- CometBroadcastHashJoin
+               :                                   :- CometProject
+               :                                   :  +- CometBroadcastHashJoin
+               :                                   :     :- CometProject
+               :                                   :     :  +- CometBroadcastHashJoin
+               :                                   :     :     :- CometProject
+               :                                   :     :     :  +- CometBroadcastHashJoin
+               :                                   :     :     :     :- CometProject
+               :                                   :     :     :     :  +- CometSortMergeJoin
+               :                                   :     :     :     :     :- CometSort
+               :                                   :     :     :     :     :  +- CometExchange
+               :                                   :     :     :     :     :     +- CometFilter
+               :                                   :     :     :     :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+               :                                   :     :     :     :     :              +- ReusedSubquery
+               :                                   :     :     :     :     +- CometSort
+               :                                   :     :     :     :        +- CometExchange
+               :                                   :     :     :     :           +- CometProject
+               :                                   :     :     :     :              +- CometFilter
+               :                                   :     :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+               :                                   :     :     :     +- CometBroadcastExchange
+               :                                   :     :     :        +- CometProject
+               :                                   :     :     :           +- CometFilter
+               :                                   :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+               :                                   :     :     +- CometBroadcastExchange
+               :                                   :     :        +- CometProject
+               :                                   :     :           +- CometFilter
+               :                                   :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_site
+               :                                   :     +- CometBroadcastExchange
+               :                                   :        +- CometProject
+               :                                   :           +- CometFilter
+               :                                   :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+               :                                   +- CometBroadcastExchange
+               :                                      +- CometProject
+               :                                         +- CometFilter
+               :                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometHashAggregate
+                           +- CometExchange
+                              +- CometHashAggregate
+                                 +- CometUnion
+                                    :- CometHashAggregate
+                                    :  +- CometExchange
+                                    :     +- CometHashAggregate
+                                    :        +- CometProject
+                                    :           +- CometBroadcastHashJoin
+                                    :              :- CometProject
+                                    :              :  +- CometBroadcastHashJoin
+                                    :              :     :- CometProject
+                                    :              :     :  +- CometBroadcastHashJoin
+                                    :              :     :     :- CometProject
+                                    :              :     :     :  +- CometBroadcastHashJoin
+                                    :              :     :     :     :- CometProject
+                                    :              :     :     :     :  +- CometSortMergeJoin
+                                    :              :     :     :     :     :- CometSort
+                                    :              :     :     :     :     :  +- CometExchange
+                                    :              :     :     :     :     :     +- CometFilter
+                                    :              :     :     :     :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                    :              :     :     :     :     :              +- SubqueryBroadcast
+                                    :              :     :     :     :     :                 +- BroadcastExchange
+                                    :              :     :     :     :     :                    +- CometNativeColumnarToRow
+                                    :              :     :     :     :     :                       +- CometProject
+                                    :              :     :     :     :     :                          +- CometFilter
+                                    :              :     :     :     :     :                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                    :              :     :     :     :     +- CometSort
+                                    :              :     :     :     :        +- CometExchange
+                                    :              :     :     :     :           +- CometProject
+                                    :              :     :     :     :              +- CometFilter
+                                    :              :     :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_returns
+                                    :              :     :     :     +- CometBroadcastExchange
+                                    :              :     :     :        +- CometProject
+                                    :              :     :     :           +- CometFilter
+                                    :              :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                    :              :     :     +- CometBroadcastExchange
+                                    :              :     :        +- CometProject
+                                    :              :     :           +- CometFilter
+                                    :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store
+                                    :              :     +- CometBroadcastExchange
+                                    :              :        +- CometProject
+                                    :              :           +- CometFilter
+                                    :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                    :              +- CometBroadcastExchange
+                                    :                 +- CometProject
+                                    :                    +- CometFilter
+                                    :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+                                    :- CometHashAggregate
+                                    :  +- CometExchange
+                                    :     +- CometHashAggregate
+                                    :        +- CometProject
+                                    :           +- CometBroadcastHashJoin
+                                    :              :- CometProject
+                                    :              :  +- CometBroadcastHashJoin
+                                    :              :     :- CometProject
+                                    :              :     :  +- CometBroadcastHashJoin
+                                    :              :     :     :- CometProject
+                                    :              :     :     :  +- CometBroadcastHashJoin
+                                    :              :     :     :     :- CometProject
+                                    :              :     :     :     :  +- CometSortMergeJoin
+                                    :              :     :     :     :     :- CometSort
+                                    :              :     :     :     :     :  +- CometExchange
+                                    :              :     :     :     :     :     +- CometFilter
+                                    :              :     :     :     :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_sales
+                                    :              :     :     :     :     :              +- ReusedSubquery
+                                    :              :     :     :     :     +- CometSort
+                                    :              :     :     :     :        +- CometExchange
+                                    :              :     :     :     :           +- CometProject
+                                    :              :     :     :     :              +- CometFilter
+                                    :              :     :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_returns
+                                    :              :     :     :     +- CometBroadcastExchange
+                                    :              :     :     :        +- CometProject
+                                    :              :     :     :           +- CometFilter
+                                    :              :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                    :              :     :     +- CometBroadcastExchange
+                                    :              :     :        +- CometProject
+                                    :              :     :           +- CometFilter
+                                    :              :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.catalog_page
+                                    :              :     +- CometBroadcastExchange
+                                    :              :        +- CometProject
+                                    :              :           +- CometFilter
+                                    :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                    :              +- CometBroadcastExchange
+                                    :                 +- CometProject
+                                    :                    +- CometFilter
+                                    :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+                                    +- CometHashAggregate
+                                       +- CometExchange
+                                          +- CometHashAggregate
+                                             +- CometProject
+                                                +- CometBroadcastHashJoin
+                                                   :- CometProject
+                                                   :  +- CometBroadcastHashJoin
+                                                   :     :- CometProject
+                                                   :     :  +- CometBroadcastHashJoin
+                                                   :     :     :- CometProject
+                                                   :     :     :  +- CometBroadcastHashJoin
+                                                   :     :     :     :- CometProject
+                                                   :     :     :     :  +- CometSortMergeJoin
+                                                   :     :     :     :     :- CometSort
+                                                   :     :     :     :     :  +- CometExchange
+                                                   :     :     :     :     :     +- CometFilter
+                                                   :     :     :     :     :        +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                                   :     :     :     :     :              +- ReusedSubquery
+                                                   :     :     :     :     +- CometSort
+                                                   :     :     :     :        +- CometExchange
+                                                   :     :     :     :           +- CometProject
+                                                   :     :     :     :              +- CometFilter
+                                                   :     :     :     :                 +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_returns
+                                                   :     :     :     +- CometBroadcastExchange
+                                                   :     :     :        +- CometProject
+                                                   :     :     :           +- CometFilter
+                                                   :     :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                   :     :     +- CometBroadcastExchange
+                                                   :     :        +- CometProject
+                                                   :     :           +- CometFilter
+                                                   :     :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_site
+                                                   :     +- CometBroadcastExchange
+                                                   :        +- CometProject
+                                                   :           +- CometFilter
+                                                   :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                                   +- CometBroadcastExchange
+                                                      +- CometProject
+                                                         +- CometFilter
+                                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.promotion
+
+Comet accelerated 374 out of 386 eligible operators (96%). Final plan contains 4 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q86a.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q86a.native_datafusion/extended.txt
@@ -1,0 +1,84 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometUnion
+                           :- CometHashAggregate
+                           :  +- CometExchange
+                           :     +- CometHashAggregate
+                           :        +- CometProject
+                           :           +- CometBroadcastHashJoin
+                           :              :- CometProject
+                           :              :  +- CometBroadcastHashJoin
+                           :              :     :- CometFilter
+                           :              :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                           :              :     :        +- CometSubqueryBroadcast
+                           :              :     :           +- CometBroadcastExchange
+                           :              :     :              +- CometProject
+                           :              :     :                 +- CometFilter
+                           :              :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :              :     +- CometBroadcastExchange
+                           :              :        +- CometProject
+                           :              :           +- CometFilter
+                           :              :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :              +- CometBroadcastExchange
+                           :                 +- CometProject
+                           :                    +- CometFilter
+                           :                       +- CometNativeScan parquet spark_catalog.default.item
+                           :- CometHashAggregate
+                           :  +- CometExchange
+                           :     +- CometHashAggregate
+                           :        +- CometHashAggregate
+                           :           +- CometExchange
+                           :              +- CometHashAggregate
+                           :                 +- CometProject
+                           :                    +- CometBroadcastHashJoin
+                           :                       :- CometProject
+                           :                       :  +- CometBroadcastHashJoin
+                           :                       :     :- CometFilter
+                           :                       :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                           :                       :     :        +- CometSubqueryBroadcast
+                           :                       :     :           +- CometBroadcastExchange
+                           :                       :     :              +- CometProject
+                           :                       :     :                 +- CometFilter
+                           :                       :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :                       :     +- CometBroadcastExchange
+                           :                       :        +- CometProject
+                           :                       :           +- CometFilter
+                           :                       :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                           :                       +- CometBroadcastExchange
+                           :                          +- CometProject
+                           :                             +- CometFilter
+                           :                                +- CometNativeScan parquet spark_catalog.default.item
+                           +- CometHashAggregate
+                              +- CometExchange
+                                 +- CometHashAggregate
+                                    +- CometHashAggregate
+                                       +- CometExchange
+                                          +- CometHashAggregate
+                                             +- CometProject
+                                                +- CometBroadcastHashJoin
+                                                   :- CometProject
+                                                   :  +- CometBroadcastHashJoin
+                                                   :     :- CometFilter
+                                                   :     :  +- CometNativeScan parquet spark_catalog.default.web_sales
+                                                   :     :        +- CometSubqueryBroadcast
+                                                   :     :           +- CometBroadcastExchange
+                                                   :     :              +- CometProject
+                                                   :     :                 +- CometFilter
+                                                   :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                   :     +- CometBroadcastExchange
+                                                   :        +- CometProject
+                                                   :           +- CometFilter
+                                                   :              +- CometNativeScan parquet spark_catalog.default.date_dim
+                                                   +- CometBroadcastExchange
+                                                      +- CometProject
+                                                         +- CometFilter
+                                                            +- CometNativeScan parquet spark_catalog.default.item
+
+Comet accelerated 75 out of 81 eligible operators (92%). Final plan contains 1 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q86a.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q86a.native_iceberg_compat/extended.txt
@@ -1,0 +1,87 @@
+TakeOrderedAndProject
++- Project
+   +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+      +- CometNativeColumnarToRow
+         +- CometSort
+            +- CometExchange
+               +- CometHashAggregate
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometUnion
+                           :- CometHashAggregate
+                           :  +- CometExchange
+                           :     +- CometHashAggregate
+                           :        +- CometProject
+                           :           +- CometBroadcastHashJoin
+                           :              :- CometProject
+                           :              :  +- CometBroadcastHashJoin
+                           :              :     :- CometFilter
+                           :              :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                           :              :     :        +- SubqueryBroadcast
+                           :              :     :           +- BroadcastExchange
+                           :              :     :              +- CometNativeColumnarToRow
+                           :              :     :                 +- CometProject
+                           :              :     :                    +- CometFilter
+                           :              :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :              :     +- CometBroadcastExchange
+                           :              :        +- CometProject
+                           :              :           +- CometFilter
+                           :              :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :              +- CometBroadcastExchange
+                           :                 +- CometProject
+                           :                    +- CometFilter
+                           :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           :- CometHashAggregate
+                           :  +- CometExchange
+                           :     +- CometHashAggregate
+                           :        +- CometHashAggregate
+                           :           +- CometExchange
+                           :              +- CometHashAggregate
+                           :                 +- CometProject
+                           :                    +- CometBroadcastHashJoin
+                           :                       :- CometProject
+                           :                       :  +- CometBroadcastHashJoin
+                           :                       :     :- CometFilter
+                           :                       :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                           :                       :     :        +- SubqueryBroadcast
+                           :                       :     :           +- BroadcastExchange
+                           :                       :     :              +- CometNativeColumnarToRow
+                           :                       :     :                 +- CometProject
+                           :                       :     :                    +- CometFilter
+                           :                       :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :                       :     +- CometBroadcastExchange
+                           :                       :        +- CometProject
+                           :                       :           +- CometFilter
+                           :                       :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                           :                       +- CometBroadcastExchange
+                           :                          +- CometProject
+                           :                             +- CometFilter
+                           :                                +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                           +- CometHashAggregate
+                              +- CometExchange
+                                 +- CometHashAggregate
+                                    +- CometHashAggregate
+                                       +- CometExchange
+                                          +- CometHashAggregate
+                                             +- CometProject
+                                                +- CometBroadcastHashJoin
+                                                   :- CometProject
+                                                   :  +- CometBroadcastHashJoin
+                                                   :     :- CometFilter
+                                                   :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.web_sales
+                                                   :     :        +- SubqueryBroadcast
+                                                   :     :           +- BroadcastExchange
+                                                   :     :              +- CometNativeColumnarToRow
+                                                   :     :                 +- CometProject
+                                                   :     :                    +- CometFilter
+                                                   :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                   :     +- CometBroadcastExchange
+                                                   :        +- CometProject
+                                                   :           +- CometFilter
+                                                   :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                                   +- CometBroadcastExchange
+                                                      +- CometProject
+                                                         +- CometFilter
+                                                            +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+
+Comet accelerated 72 out of 81 eligible operators (88%). Final plan contains 4 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q98.native_datafusion/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q98.native_datafusion/extended.txt
@@ -1,0 +1,32 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometColumnarExchange
+      +- Project
+         +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+            +- CometNativeColumnarToRow
+               +- CometSort
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometExchange
+                           +- CometHashAggregate
+                              +- CometProject
+                                 +- CometBroadcastHashJoin
+                                    :- CometProject
+                                    :  +- CometBroadcastHashJoin
+                                    :     :- CometFilter
+                                    :     :  +- CometNativeScan parquet spark_catalog.default.store_sales
+                                    :     :        +- CometSubqueryBroadcast
+                                    :     :           +- CometBroadcastExchange
+                                    :     :              +- CometProject
+                                    :     :                 +- CometFilter
+                                    :     :                    +- CometNativeScan parquet spark_catalog.default.date_dim
+                                    :     +- CometBroadcastExchange
+                                    :        +- CometProject
+                                    :           +- CometFilter
+                                    :              +- CometNativeScan parquet spark_catalog.default.item
+                                    +- CometBroadcastExchange
+                                       +- CometProject
+                                          +- CometFilter
+                                             +- CometNativeScan parquet spark_catalog.default.date_dim
+
+Comet accelerated 25 out of 28 eligible operators (89%). Final plan contains 2 transitions between Spark and Comet.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q98.native_iceberg_compat/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q98.native_iceberg_compat/extended.txt
@@ -1,0 +1,33 @@
+CometNativeColumnarToRow
++- CometSort
+   +- CometColumnarExchange
+      +- Project
+         +-  Window [COMET: WindowExec is not fully compatible with Spark (Native WindowExec has known correctness issues). To enable it anyway, set spark.comet.operator.WindowExec.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
+            +- CometNativeColumnarToRow
+               +- CometSort
+                  +- CometExchange
+                     +- CometHashAggregate
+                        +- CometExchange
+                           +- CometHashAggregate
+                              +- CometProject
+                                 +- CometBroadcastHashJoin
+                                    :- CometProject
+                                    :  +- CometBroadcastHashJoin
+                                    :     :- CometFilter
+                                    :     :  +- CometScan [native_iceberg_compat] parquet spark_catalog.default.store_sales
+                                    :     :        +- SubqueryBroadcast
+                                    :     :           +- BroadcastExchange
+                                    :     :              +- CometNativeColumnarToRow
+                                    :     :                 +- CometProject
+                                    :     :                    +- CometFilter
+                                    :     :                       +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+                                    :     +- CometBroadcastExchange
+                                    :        +- CometProject
+                                    :           +- CometFilter
+                                    :              +- CometScan [native_iceberg_compat] parquet spark_catalog.default.item
+                                    +- CometBroadcastExchange
+                                       +- CometProject
+                                          +- CometFilter
+                                             +- CometScan [native_iceberg_compat] parquet spark_catalog.default.date_dim
+
+Comet accelerated 24 out of 28 eligible operators (85%). Final plan contains 3 transitions between Spark and Comet.

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.SESSION_LOCAL_TIMEZONE
 import org.apache.spark.sql.types._
 
-import org.apache.comet.CometSparkSessionExtensions.{isSpark40Plus, isSpark41Plus}
+import org.apache.comet.CometSparkSessionExtensions.{isSpark40Plus, isSpark41Plus, isSpark42Plus}
 import org.apache.comet.testing.{DataGenOptions, FuzzDataGenerator}
 
 class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
@@ -2123,6 +2123,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("unary negative integer overflow test") {
+    assume(!isSpark42Plus, "https://github.com/apache/datafusion-comet/issues/4142")
     def withAnsiMode(enabled: Boolean)(f: => Unit): Unit = {
       withSQLConf(
         SQLConf.ANSI_ENABLED.key -> enabled.toString,
@@ -2717,6 +2718,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("ANSI support for add") {
+    assume(!isSpark42Plus, "https://github.com/apache/datafusion-comet/issues/4142")
     val data = Seq((Integer.MAX_VALUE, 1), (Integer.MIN_VALUE, -1))
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
       withParquetTable(data, "tbl") {
@@ -2737,6 +2739,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("ANSI support for subtract") {
+    assume(!isSpark42Plus, "https://github.com/apache/datafusion-comet/issues/4142")
     val data = Seq((Integer.MIN_VALUE, 1))
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
       withParquetTable(data, "tbl") {
@@ -2756,6 +2759,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("ANSI support for multiply") {
+    assume(!isSpark42Plus, "https://github.com/apache/datafusion-comet/issues/4142")
     val data = Seq((Integer.MAX_VALUE, 10))
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
       withParquetTable(data, "tbl") {

--- a/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{StringType, TimestampType}
 
+import org.apache.comet.CometSparkSessionExtensions.isSpark42Plus
 import org.apache.comet.iceberg.RESTCatalogHelper
 import org.apache.comet.testing.{FuzzDataGenerator, SchemaGenOptions}
 
@@ -2471,6 +2472,7 @@ class CometIcebergNativeSuite extends CometTestBase with RESTCatalogHelper {
   }
 
   test("REST catalog with native Iceberg scan") {
+    assume(!isSpark42Plus, "https://github.com/apache/datafusion-comet/issues/4142")
     assume(icebergAvailable, "Iceberg not available in classpath")
 
     withRESTCatalog { (restUri, _, warehouseDir) =>

--- a/spark/src/test/scala/org/apache/comet/exec/CometExec3_4PlusSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExec3_4PlusSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.util.sketch.BloomFilter
 
 import org.apache.comet.CometConf
-import org.apache.comet.CometSparkSessionExtensions.isSpark41Plus
+import org.apache.comet.CometSparkSessionExtensions.{isSpark41Plus, isSpark42Plus}
 
 /**
  * This test suite contains tests for only Spark 3.4+.
@@ -45,15 +45,19 @@ class CometExec3_4PlusSuite extends CometTestBase {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    // Register 'might_contain' to builtin.
-    spark.sessionState.functionRegistry.registerFunction(
-      func_might_contain,
-      new ExpressionInfo(classOf[BloomFilterMightContain].getName, "might_contain"),
-      (children: Seq[Expression]) => BloomFilterMightContain(children.head, children(1)))
+    if (!isSpark42Plus) {
+      // Register 'might_contain' to builtin.
+      spark.sessionState.functionRegistry.registerFunction(
+        func_might_contain,
+        new ExpressionInfo(classOf[BloomFilterMightContain].getName, "might_contain"),
+        (children: Seq[Expression]) => BloomFilterMightContain(children.head, children(1)))
+    }
   }
 
   override def afterAll(): Unit = {
-    spark.sessionState.functionRegistry.dropFunction(func_might_contain)
+    if (!isSpark42Plus) {
+      spark.sessionState.functionRegistry.dropFunction(func_might_contain)
+    }
     super.afterAll()
   }
 
@@ -128,6 +132,7 @@ class CometExec3_4PlusSuite extends CometTestBase {
   }
 
   test("test BloomFilterMightContain can take a constant value input") {
+    assume(!isSpark42Plus, "https://github.com/apache/datafusion-comet/issues/4142")
     val table = "test"
 
     withTable(table) {
@@ -141,6 +146,7 @@ class CometExec3_4PlusSuite extends CometTestBase {
   }
 
   test("test NULL inputs for BloomFilterMightContain") {
+    assume(!isSpark42Plus, "https://github.com/apache/datafusion-comet/issues/4142")
     val table = "test"
 
     withTable(table) {

--- a/spark/src/test/scala/org/apache/spark/sql/comet/CometPlanStabilitySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/CometPlanStabilitySuite.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.TestSparkSession
 
 import org.apache.comet.{CometConf, ExtendedExplainInfo}
-import org.apache.comet.CometSparkSessionExtensions.{isSpark35Plus, isSpark40Plus, isSpark41Plus}
+import org.apache.comet.CometSparkSessionExtensions.{isSpark35Plus, isSpark40Plus, isSpark41Plus, isSpark42Plus}
 
 /**
  * Similar to [[org.apache.spark.sql.PlanStabilitySuite]], checks that TPC-DS Comet plans don't
@@ -262,7 +262,9 @@ trait CometPlanStabilitySuite extends DisableAdaptiveExecutionSuite with TPCDSBa
 }
 
 class CometTPCDSV1_4_PlanStabilitySuite extends CometPlanStabilitySuite {
-  private val planName = if (isSpark41Plus) {
+  private val planName = if (isSpark42Plus) {
+    "approved-plans-v1_4-spark4_2"
+  } else if (isSpark41Plus) {
     "approved-plans-v1_4-spark4_1"
   } else if (isSpark40Plus) {
     "approved-plans-v1_4-spark4_0"
@@ -286,7 +288,9 @@ class CometTPCDSV1_4_PlanStabilitySuite extends CometPlanStabilitySuite {
 }
 
 class CometTPCDSV2_7_PlanStabilitySuite extends CometPlanStabilitySuite {
-  private val planName = if (isSpark41Plus) {
+  private val planName = if (isSpark42Plus) {
+    "approved-plans-v2_7-spark4_2"
+  } else if (isSpark41Plus) {
     "approved-plans-v2_7-spark4_1"
   } else if (isSpark40Plus) {
     "approved-plans-v2_7-spark4_0"


### PR DESCRIPTION
## Which issue does this PR close?

Part of #4113.

## Rationale for this change

#4119 added a build-only `spark-4.2` Maven profile targeting Spark 4.2.0-preview4. To start exercising Comet against 4.2 in CI (rather than discovering everything at once when 4.2 GA lands), this PR turns on the existing PR test matrices for Spark 4.2 and adds dedicated TPC-DS plan-stability goldens.

This mirrors the approach previously used to bring Spark 4.1 online before reverting (see commits `622e851e1` and `75e3b3116` on the `spark-4.1.1` branch).

## What changes are included in this PR?

- `.github/workflows/pr_build_linux.yml`: add `Spark 4.2, JDK 17` to the `linux-test` matrix and a comment explaining why 4.1/4.2 are skipped from the `lint-java` matrix (semanticdb-scalac is not yet published for Scala 2.13.17/2.13.18).
- `.github/workflows/pr_build_macos.yml`: add `Spark 4.2, JDK 17, Scala 2.13` to the `macos-aarch64-test` matrix.
- `spark/pom.xml`: wire iceberg/jetty test dependencies into the `spark-4.2` profile (Iceberg falls back to the 4.0 runtime since 4.2 is not yet published; Jetty pinned at 11.0.26).
- `spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala`: add `isSpark42Plus` helper.
- `spark/src/test/scala/org/apache/spark/sql/comet/CometPlanStabilitySuite.scala`: route `isSpark42Plus` to the new `approved-plans-{v1_4,v2_7}-spark4_2` directories.
- `dev/regenerate-golden-files.sh`: accept `--spark-version 4.2` and include 4.2 in the default version list.
- `spark/src/test/resources/tpcds-plan-stability/approved-plans-{v1_4,v2_7}-spark4_2/`: regenerated golden files. 22 of the generated files differ from the `spark4_0` directory (`q2`, `q5`, `q33`, `q49`, `q54`, `q56`, `q60`, `q66` in v1_4 and `q5a`, `q14a`, `q49` in v2_7, both `native_datafusion` and `native_iceberg_compat` per query); the rest are byte-identical.

This PR does not attempt to fix any 4.2-specific runtime/test failures the new matrix entries surface; those will be tracked and addressed in follow-up PRs as we did for Spark 4.1.

## How are these changes tested?

- Local: built `-Pspark-4.2` end-to-end with JDK 17.
- Local: ran `CometTPCDSV1_4_PlanStabilitySuite` (194 tests) and `CometTPCDSV2_7_PlanStabilitySuite` (64 tests) against `-Pspark-4.2` with `SPARK_GENERATE_GOLDEN_FILES` unset; both pass with 0 failures.
- CI: this PR will exercise the new Linux and macOS matrix entries.