### PR TITLE
feat: add config to gate converting Spark shuffle to Comet shuffle when child is non-Comet plan

### DIFF
--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -427,6 +427,17 @@ object CometConf extends ShimCometConf {
         "The maximum number of columns to hash for round robin partitioning must be non-negative.")
       .createWithDefault(0)
 
+  val COMET_EXEC_SHUFFLE_CONVERT_FROM_SPARK_PLAN_ENABLED: ConfigEntry[Boolean] =
+    conf(s"$COMET_EXEC_CONFIG_PREFIX.shuffle.convertFromSparkPlan.enabled")
+      .category(CATEGORY_SHUFFLE)
+      .doc(
+        "When enabled, Comet will convert a Spark `ShuffleExchangeExec` to a Comet columnar " +
+          "shuffle even when its child is a non-Comet (Spark) plan. Disable to leave such " +
+          "shuffles as native Spark shuffles, restricting Comet shuffle to cases where the " +
+          "child is already a Comet plan.")
+      .booleanConf
+      .createWithDefault(true)
+
   val COMET_EXEC_SHUFFLE_REVERT_REDUNDANT_COLUMNAR_ENABLED: ConfigEntry[Boolean] =
     conf(s"$COMET_EXEC_CONFIG_PREFIX.shuffle.revertRedundantColumnar.enabled")
       .category(CATEGORY_SHUFFLE)

--- a/docs/source/user-guide/latest/tuning.md
+++ b/docs/source/user-guide/latest/tuning.md
@@ -155,10 +155,12 @@ Comet Columnar shuffle is JVM-based and supports `HashPartitioning`, `RoundRobin
 `SinglePartitioning`. This shuffle implementation supports complex data types as partitioning keys.
 
 By default, Comet will convert a Spark `ShuffleExchangeExec` to columnar shuffle even when the shuffle's child is a
-non-Comet (Spark) plan. This pays for a `row -> Arrow` conversion at the shuffle boundary in exchange for Comet's
-shuffle implementation. To restrict columnar shuffle to cases where the child is already a Comet plan, set
+non-Comet (Spark) plan. The benefit is that the next query stage can start as native Comet execution, since the
+shuffle output is already in Arrow format. The cost is a `row -> Arrow` conversion at the shuffle boundary on the
+write side. To restrict columnar shuffle to cases where the child is already a Comet plan, set
 `spark.comet.exec.shuffle.convertFromSparkPlan.enabled=false`. Shuffles whose child is a Spark plan will then be left
-as native Spark shuffles.
+as native Spark shuffles, which avoids the row-to-Arrow conversion but means the downstream stage will also start
+on Spark.
 
 #### Automatic Revert to Spark Shuffle
 

--- a/docs/source/user-guide/latest/tuning.md
+++ b/docs/source/user-guide/latest/tuning.md
@@ -154,6 +154,12 @@ partitioning keys. Columns that are not partitioning keys may contain complex ty
 Comet Columnar shuffle is JVM-based and supports `HashPartitioning`, `RoundRobinPartitioning`, `RangePartitioning`, and
 `SinglePartitioning`. This shuffle implementation supports complex data types as partitioning keys.
 
+By default, Comet will convert a Spark `ShuffleExchangeExec` to columnar shuffle even when the shuffle's child is a
+non-Comet (Spark) plan. This pays for a `row -> Arrow` conversion at the shuffle boundary in exchange for Comet's
+shuffle implementation. To restrict columnar shuffle to cases where the child is already a Comet plan, set
+`spark.comet.exec.shuffle.convertFromSparkPlan.enabled=false`. Shuffles whose child is a Spark plan will then be left
+as native Spark shuffles.
+
 #### Automatic Revert to Spark Shuffle
 
 When a Comet columnar shuffle ends up between two non-Comet operators (for example, a partial/final hash aggregate

--- a/docs/source/user-guide/latest/tuning.md
+++ b/docs/source/user-guide/latest/tuning.md
@@ -156,10 +156,10 @@ Comet Columnar shuffle is JVM-based and supports `HashPartitioning`, `RoundRobin
 
 By default, Comet will convert a Spark `ShuffleExchangeExec` to columnar shuffle even when the shuffle's child is a
 non-Comet (Spark) plan. The benefit is that the next query stage can start as native Comet execution, since the
-shuffle output is already in Arrow format. The cost is a `row -> Arrow` conversion at the shuffle boundary on the
+shuffle output is already in Arrow format. The cost is a row to columnar conversion at the shuffle boundary on the
 write side. To restrict columnar shuffle to cases where the child is already a Comet plan, set
 `spark.comet.exec.shuffle.convertFromSparkPlan.enabled=false`. Shuffles whose child is a Spark plan will then be left
-as native Spark shuffles, which avoids the row-to-Arrow conversion but means the downstream stage will also start
+as native Spark shuffles, which avoids the row to columnar conversion but means the downstream stage will also start
 on Spark.
 
 #### Automatic Revert to Spark Shuffle

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
@@ -293,6 +293,16 @@ object CometShuffleExchangeExec
       return Some(CometNativeShuffle)
     }
 
+    if (!isCometPlan(s.child) &&
+      !CometConf.COMET_EXEC_SHUFFLE_CONVERT_FROM_SPARK_PLAN_ENABLED.get(s.conf)) {
+      withInfos(
+        s,
+        Set(
+          s"${CometConf.COMET_EXEC_SHUFFLE_CONVERT_FROM_SPARK_PLAN_ENABLED.key} is disabled " +
+            "and child is not a Comet plan"))
+      return None
+    }
+
     val columnarReasons = columnarShuffleFailureReasons(s)
     if (columnarReasons.isEmpty) {
       return Some(CometColumnarShuffle)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

Comet currently always converts a Spark `ShuffleExchangeExec` into a Comet columnar (JVM) shuffle, even when the shuffle's child is a plain Spark plan with no Comet operator beneath it. In that case the conversion only buys us Comet's shuffle implementation, while paying for a row to Arrow conversion at the shuffle boundary. There are workloads where it is preferable to leave such shuffles as regular Spark shuffles and reserve Comet shuffle for cases where the child is already a Comet plan.

This PR introduces a config so users can opt out of that conversion without disabling Comet shuffle entirely.

## What changes are included in this PR?

- New config `spark.comet.exec.shuffle.convertFromSparkPlan.enabled` (default `true`, preserves current behavior).
- In `CometShuffleExchangeExec.shuffleSupported`, when the child is not a Comet plan and the new config is `false`, tag the node with an explain reason and return `None` so the shuffle stays as a native Spark `ShuffleExchangeExec`. The native shuffle path (which already requires a Comet child) is unaffected.

## How are these changes tested?

Default behavior is unchanged so existing test coverage applies. Manual verification that the project compiles. Happy to add a targeted test if reviewers prefer.