### PR TITLE
fix: honor strictFloatingPoint in RangePartitioning

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
@@ -309,7 +309,6 @@ object CometShuffleExchangeExec
    */
   private def nativeShuffleFailureReasons(s: ShuffleExchangeExec): Seq[String] = {
     val conf = SQLConf.get
-    val strictFloatingPoint = CometConf.COMET_EXEC_STRICT_FLOATING_POINT.get(conf)
 
     /**
      * Determine which data types are supported as partition columns in native shuffle.
@@ -331,26 +330,6 @@ object CometShuffleExchangeExec
         // https://github.com/apache/datafusion-comet/issues/3079
         // Decimals with precision > 18 require Java BigDecimal conversion before hashing
         // d.precision <= 18
-        true
-      case _ =>
-        false
-    }
-
-    /**
-     * Determine which data types are supported as partition columns in native shuffle.
-     *
-     * For RangePartitioning this defines the key that determines how data should be collocated
-     * for operations like `orderBy`, `repartitionByRange`. Native code does not support sorting
-     * complex types.
-     */
-    def supportedRangePartitioningDataType(dt: DataType): Boolean = dt match {
-      // Collated strings require collation-aware ordering; Comet only compares raw bytes.
-      case st: StringType if isStringCollationType(st) => false
-      case _: FloatType | _: DoubleType =>
-        !strictFloatingPoint
-      case _: BooleanType | _: ByteType | _: ShortType | _: IntegerType | _: LongType |
-          _: StringType | _: BinaryType | _: TimestampType | _: TimestampNTZType |
-          _: DecimalType | _: DateType =>
         true
       case _ =>
         false
@@ -413,6 +392,28 @@ object CometShuffleExchangeExec
       case SinglePartition =>
       // we already checked that the input types are supported
       case RangePartitioning(orderings, _) =>
+        val strictFloatingPoint = CometConf.COMET_EXEC_STRICT_FLOATING_POINT.get(conf)
+
+        /**
+         * Determine which data types are supported as partition columns in native shuffle.
+         *
+         * For RangePartitioning this defines the key that determines how data should be
+         * collocated for operations like `orderBy`, `repartitionByRange`. Native code does not
+         * support sorting complex types.
+         */
+        def supportedRangePartitioningDataType(dt: DataType): Boolean = dt match {
+          // Collated strings require collation-aware ordering; Comet only compares raw bytes.
+          case st: StringType if isStringCollationType(st) => false
+          case _: FloatType | _: DoubleType =>
+            !strictFloatingPoint
+          case _: BooleanType | _: ByteType | _: ShortType | _: IntegerType | _: LongType |
+              _: StringType | _: BinaryType | _: TimestampType | _: TimestampNTZType |
+              _: DecimalType | _: DateType =>
+            true
+          case _ =>
+            false
+        }
+
         if (!CometConf.COMET_EXEC_SHUFFLE_WITH_RANGE_PARTITIONING_ENABLED.get(conf)) {
           reasons +=
             s"${CometConf.COMET_EXEC_SHUFFLE_WITH_RANGE_PARTITIONING_ENABLED.key} is disabled"

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
@@ -308,6 +308,8 @@ object CometShuffleExchangeExec
    * Pure: does not tag the node.
    */
   private def nativeShuffleFailureReasons(s: ShuffleExchangeExec): Seq[String] = {
+    val conf = SQLConf.get
+    val strictFloatingPoint = CometConf.COMET_EXEC_STRICT_FLOATING_POINT.get(conf)
 
     /**
      * Determine which data types are supported as partition columns in native shuffle.
@@ -344,9 +346,11 @@ object CometShuffleExchangeExec
     def supportedRangePartitioningDataType(dt: DataType): Boolean = dt match {
       // Collated strings require collation-aware ordering; Comet only compares raw bytes.
       case st: StringType if isStringCollationType(st) => false
+      case _: FloatType | _: DoubleType =>
+        !strictFloatingPoint
       case _: BooleanType | _: ByteType | _: ShortType | _: IntegerType | _: LongType |
-          _: FloatType | _: DoubleType | _: StringType | _: BinaryType | _: TimestampType |
-          _: TimestampNTZType | _: DecimalType | _: DateType =>
+          _: StringType | _: BinaryType | _: TimestampType | _: TimestampNTZType |
+          _: DecimalType | _: DateType =>
         true
       case _ =>
         false
@@ -390,7 +394,6 @@ object CometShuffleExchangeExec
     }
 
     val partitioning = s.outputPartitioning
-    val conf = SQLConf.get
     partitioning match {
       case HashPartitioning(expressions, _) =>
         if (!CometConf.COMET_EXEC_SHUFFLE_WITH_HASH_PARTITIONING_ENABLED.get(conf)) {
@@ -425,7 +428,15 @@ object CometShuffleExchangeExec
         }
         for (dt <- orderings.map(_.dataType).distinct) {
           if (!supportedRangePartitioningDataType(dt)) {
-            reasons += s"unsupported range partitioning data type for native shuffle: $dt"
+            val reason = dt match {
+              case _: FloatType | _: DoubleType if strictFloatingPoint =>
+                s"Range partitioning on $dt is not 100% compatible with Spark, and Comet is " +
+                  s"running with ${CometConf.COMET_EXEC_STRICT_FLOATING_POINT.key}=true. " +
+                  s"${CometConf.COMPAT_GUIDE}"
+              case _ =>
+                s"unsupported range partitioning data type for native shuffle: $dt"
+            }
+            reasons += reason
           }
         }
       case RoundRobinPartitioning(_) =>

--- a/spark/src/test/scala/org/apache/comet/exec/CometNativeShuffleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometNativeShuffleSuite.scala
@@ -281,6 +281,16 @@ class CometNativeShuffleSuite extends CometTestBase with AdaptiveSparkPlanHelper
     }
   }
 
+  private val floatingPointRangePartitionData: Seq[(Double, Int)] = (0 until 100).map { i =>
+    val doubleValue = i % 4 match {
+      case 0 => Double.NaN
+      case 1 => -0.0d
+      case 2 => 0.0d
+      case _ => i.toDouble
+    }
+    (doubleValue, i)
+  }
+
   test("range partitioning on floating-point falls back when strictFloatingPoint=true") {
     withSQLConf(
       CometConf.COMET_EXEC_SHUFFLE_WITH_RANGE_PARTITIONING_ENABLED.key -> "true",
@@ -288,16 +298,7 @@ class CometNativeShuffleSuite extends CometTestBase with AdaptiveSparkPlanHelper
       // Bypass the CometSortOrder-level Incompatible check so that only
       // supportedRangePartitioningDataType is exercised as the guard.
       CometConf.getExprAllowIncompatConfigKey("SortOrder") -> "true") {
-      val data = (0 until 100).map { i =>
-        val doubleValue = i % 4 match {
-          case 0 => Double.NaN
-          case 1 => -0.0d
-          case 2 => 0.0d
-          case _ => i.toDouble
-        }
-        (doubleValue, i)
-      }
-      withParquetTable(data, "tbl") {
+      withParquetTable(floatingPointRangePartitionData, "tbl") {
         Seq(("FLOAT", "FloatType"), ("DOUBLE", "DoubleType")).foreach {
           case (sqlType, sparkType) =>
             val df = sql(s"SELECT CAST(_1 AS $sqlType) AS c, _2 FROM tbl")
@@ -316,16 +317,7 @@ class CometNativeShuffleSuite extends CometTestBase with AdaptiveSparkPlanHelper
     withSQLConf(
       CometConf.COMET_EXEC_SHUFFLE_WITH_RANGE_PARTITIONING_ENABLED.key -> "true",
       CometConf.COMET_EXEC_STRICT_FLOATING_POINT.key -> "false") {
-      val data = (0 until 100).map { i =>
-        val doubleValue = i % 4 match {
-          case 0 => Double.NaN
-          case 1 => -0.0d
-          case 2 => 0.0d
-          case _ => i.toDouble
-        }
-        (doubleValue, i)
-      }
-      withParquetTable(data, "tbl") {
+      withParquetTable(floatingPointRangePartitionData, "tbl") {
         Seq("FLOAT", "DOUBLE").foreach { sqlType =>
           val df = sql(s"SELECT CAST(_1 AS $sqlType) AS c, _2 FROM tbl")
             .repartitionByRange(4, $"c")

--- a/spark/src/test/scala/org/apache/comet/exec/CometNativeShuffleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometNativeShuffleSuite.scala
@@ -281,6 +281,61 @@ class CometNativeShuffleSuite extends CometTestBase with AdaptiveSparkPlanHelper
     }
   }
 
+  test("range partitioning on floating-point falls back when strictFloatingPoint=true") {
+    withSQLConf(
+      CometConf.COMET_EXEC_SHUFFLE_WITH_RANGE_PARTITIONING_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_STRICT_FLOATING_POINT.key -> "true",
+      // Bypass the CometSortOrder-level Incompatible check so that only
+      // supportedRangePartitioningDataType is exercised as the guard.
+      CometConf.getExprAllowIncompatConfigKey("SortOrder") -> "true") {
+      val data = (0 until 100).map { i =>
+        val doubleValue = i % 4 match {
+          case 0 => Double.NaN
+          case 1 => -0.0d
+          case 2 => 0.0d
+          case _ => i.toDouble
+        }
+        (doubleValue, i)
+      }
+      withParquetTable(data, "tbl") {
+        Seq(("FLOAT", "FloatType"), ("DOUBLE", "DoubleType")).foreach {
+          case (sqlType, sparkType) =>
+            val df = sql(s"SELECT CAST(_1 AS $sqlType) AS c, _2 FROM tbl")
+              .repartitionByRange(4, $"c")
+
+            checkSparkAnswerAndFallbackReason(
+              df,
+              s"Range partitioning on $sparkType is not 100% compatible with Spark")
+        }
+      }
+    }
+  }
+
+  test(
+    "range partitioning on floating-point uses native shuffle when strictFloatingPoint=false") {
+    withSQLConf(
+      CometConf.COMET_EXEC_SHUFFLE_WITH_RANGE_PARTITIONING_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_STRICT_FLOATING_POINT.key -> "false") {
+      val data = (0 until 100).map { i =>
+        val doubleValue = i % 4 match {
+          case 0 => Double.NaN
+          case 1 => -0.0d
+          case 2 => 0.0d
+          case _ => i.toDouble
+        }
+        (doubleValue, i)
+      }
+      withParquetTable(data, "tbl") {
+        Seq("FLOAT", "DOUBLE").foreach { sqlType =>
+          val df = sql(s"SELECT CAST(_1 AS $sqlType) AS c, _2 FROM tbl")
+            .repartitionByRange(4, $"c")
+
+          checkShuffleAnswer(df, 1)
+        }
+      }
+    }
+  }
+
   // Asserts ordering properties of partitions in a Dataset that has been RangePartitioned
   private def checkRangePartitionedDataset(df_range_partitioned: Dataset[Row]): Unit = {
     val partition_bounds = df_range_partitioned.rdd


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4130 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
`RangePartitioning` should honor `spark.comet.exec.strictFloatingPoint` for floating-point ordering, consistent with other ordering-dependent operations. When strict floating-point compatibility is enabled, native range partitioning on `FloatType` and `DoubleType` can differ from Spark for values such as `NaN`, `-0.0`, and `0.0`, so Comet should fall back.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Make native shuffle range partitioning reject `FloatType` and `DoubleType` when `spark.comet.exec.strictFloatingPoint=true`.
- Add a more specific fallback reason that points to `spark.comet.exec.strictFloatingPoint` and the compatibility guide.
- Add tests for both `FloatType` and `DoubleType`.
- Add a regression test that verifies floating-point range partitioning still uses native shuffle when `spark.comet.exec.strictFloatingPoint=false`.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
`./mvnw test -Dtest=none -Dsuites="org.apache.comet.exec.CometNativeShuffleSuite"`