### PR TITLE
fix: [Spark 4.1.1] preserve stored allowDecimalPrecisionLoss in DecimalPrecision rule

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -370,6 +370,7 @@ jobs:
               org.apache.spark.sql.comet.CometTaskMetricsSuite
               org.apache.spark.sql.comet.CometDppFallbackRepro3949Suite
               org.apache.spark.sql.comet.CometShuffleFallbackStickinessSuite
+              org.apache.spark.sql.comet.CometDecimalArithmeticViewSuite
               org.apache.comet.objectstore.NativeConfigSuite
           - name: "expressions"
             value: |

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -209,6 +209,7 @@ jobs:
               org.apache.spark.sql.comet.CometTaskMetricsSuite
               org.apache.spark.sql.comet.CometDppFallbackRepro3949Suite
               org.apache.spark.sql.comet.CometShuffleFallbackStickinessSuite
+              org.apache.spark.sql.comet.CometDecimalArithmeticViewSuite
               org.apache.comet.objectstore.NativeConfigSuite
           - name: "expressions"
             value: |

--- a/dev/diffs/4.1.1.diff
+++ b/dev/diffs/4.1.1.diff
@@ -2034,16 +2034,6 @@ index 050a004a935..96d982f2829 100644
      withTable("t") {
        Seq(2, 3, 1).toDF("c1").write.format("parquet").saveAsTable("t")
        withView("v1") {
-@@ -1334,7 +1335,8 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
-     }
-   }
- 
--  test("SPARK-53968 reading the view after allowPrecisionLoss is changed") {
-+  test("SPARK-53968 reading the view after allowPrecisionLoss is changed",
-+    IgnoreComet("TODO: https://github.com/apache/datafusion-comet/issues/4124")) {
-     import org.apache.spark.sql.internal.SQLConf
-     val partsTableName = "parts_tbl"
-     val ordersTableName = "orders_tbl"
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
 index aed11badb71..1a365b5aacf 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala

--- a/dev/diffs/4.1.1.diff
+++ b/dev/diffs/4.1.1.diff
@@ -697,7 +697,7 @@ index 6df8d66ee7f..35e270c7241 100644
      assert(exchanges.size == 2)
    }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
-index e1a2fd33c7c..9a93daa8f5a 100644
+index e1a2fd33c7c..632f4b695df 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
 @@ -22,6 +22,7 @@ import org.scalatest.GivenWhenThen
@@ -757,35 +757,7 @@ index e1a2fd33c7c..9a93daa8f5a 100644
  
        assert(countSubqueryBroadcasts == 1)
        assert(countReusedSubqueryBroadcasts == 1)
-@@ -1215,7 +1231,8 @@ abstract class DynamicPartitionPruningSuiteBase
-   }
- 
-   test("SPARK-32509: Unused Dynamic Pruning filter shouldn't affect " +
--    "canonicalization and exchange reuse") {
-+    "canonicalization and exchange reuse",
-+    IgnoreComet("TODO: https://github.com/apache/datafusion-comet/issues/4045")) {
-     withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "true") {
-       withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
-           SQLConf.V2_BUCKETING_ENABLED.key -> "false") {
-@@ -1331,6 +1348,7 @@ abstract class DynamicPartitionPruningSuiteBase
-   }
- 
-   test("Subquery reuse across the whole plan",
-+    IgnoreCometNativeDataFusion("https://github.com/apache/datafusion-comet/issues/3313"),
-     DisableAdaptiveExecution("DPP in AQE must reuse broadcast")) {
-     withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
-       SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "false",
-@@ -1425,7 +1443,8 @@ abstract class DynamicPartitionPruningSuiteBase
-     }
-   }
- 
--  test("SPARK-34637: DPP side broadcast query stage is created firstly") {
-+  test("SPARK-34637: DPP side broadcast query stage is created firstly",
-+    IgnoreComet("TODO: https://github.com/apache/datafusion-comet/issues/4045")) {
-     withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "true") {
-       val df = sql(
-         """ WITH v as (
-@@ -1579,6 +1598,7 @@ abstract class DynamicPartitionPruningSuiteBase
+@@ -1579,6 +1595,7 @@ abstract class DynamicPartitionPruningSuiteBase
  
          val subqueryBroadcastExecs = collectWithSubqueries(df.queryExecution.executedPlan) {
            case s: SubqueryBroadcastExec => s
@@ -793,7 +765,7 @@ index e1a2fd33c7c..9a93daa8f5a 100644
          }
          assert(subqueryBroadcastExecs.size === 1)
          subqueryBroadcastExecs.foreach { subqueryBroadcastExec =>
-@@ -1731,6 +1751,10 @@ abstract class DynamicPartitionPruningV1Suite extends DynamicPartitionPruningDat
+@@ -1731,6 +1748,10 @@ abstract class DynamicPartitionPruningV1Suite extends DynamicPartitionPruningDat
                case s: BatchScanExec =>
                  // we use f1 col for v2 tables due to schema pruning
                  s.output.exists(_.exists(_.argString(maxFields = 100).contains("f1")))
@@ -830,41 +802,18 @@ index b27122a8de2..a4c5aac8212 100644
  
    test("SPARK-35884: Explain Formatted") {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
-index 95e86fe4311..0f7ed3271d4 100644
+index 95e86fe4311..fb2b6363af6 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
-@@ -33,6 +33,8 @@ import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GreaterTha
+@@ -33,6 +33,7 @@ import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GreaterTha
  import org.apache.spark.sql.catalyst.expressions.IntegralLiteralTestUtils.{negativeInt, positiveInt}
  import org.apache.spark.sql.catalyst.plans.logical.Filter
  import org.apache.spark.sql.catalyst.types.DataTypeUtils
-+import org.apache.spark.sql.catalyst.util.quietly
 +import org.apache.spark.sql.comet.{CometBatchScanExec, CometNativeScanExec, CometScanExec, CometSortMergeJoinExec}
  import org.apache.spark.sql.execution.{FileSourceScanLike, SimpleMode}
  import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
  import org.apache.spark.sql.execution.datasources.FilePartition
-@@ -204,7 +206,11 @@ class FileBasedDataSourceSuite extends QueryTest
-   }
- 
-   allFileBasedDataSources.foreach { format =>
--    testQuietly(s"Enabling/disabling ignoreMissingFiles using $format") {
-+    val ignoreMissingTags: Seq[org.scalatest.Tag] = if (format == "parquet") {
-+      Seq(IgnoreCometNativeDataFusion(
-+        "https://github.com/apache/datafusion-comet/issues/3314"))
-+    } else Seq.empty
-+    test(s"Enabling/disabling ignoreMissingFiles using $format", ignoreMissingTags: _*) { quietly {
-       def testIgnoreMissingFiles(options: Map[String, String]): Unit = {
-         withTempDir { dir =>
-           val basePath = dir.getCanonicalPath
-@@ -264,7 +270,7 @@ class FileBasedDataSourceSuite extends QueryTest
-           }
-         }
-       }
--    }
-+    }}
-   }
- 
-   Seq("json", "orc").foreach { format =>
-@@ -655,18 +661,25 @@ class FileBasedDataSourceSuite extends QueryTest
+@@ -655,18 +656,25 @@ class FileBasedDataSourceSuite extends QueryTest
              checkAnswer(sql(s"select A from $tableName"), data.select("A"))
  
              // RuntimeException is triggered at executor side, which is then wrapped as
@@ -897,7 +846,7 @@ index 95e86fe4311..0f7ed3271d4 100644
                condition = "_LEGACY_ERROR_TEMP_2093",
                parameters = Map("requiredFieldName" -> "b", "matchedOrcFields" -> "[b, B]")
              )
-@@ -954,6 +967,7 @@ class FileBasedDataSourceSuite extends QueryTest
+@@ -954,6 +962,7 @@ class FileBasedDataSourceSuite extends QueryTest
              assert(bJoinExec.isEmpty)
              val smJoinExec = collect(joinedDF.queryExecution.executedPlan) {
                case smJoin: SortMergeJoinExec => smJoin
@@ -905,7 +854,7 @@ index 95e86fe4311..0f7ed3271d4 100644
              }
              assert(smJoinExec.nonEmpty)
            }
-@@ -1014,6 +1028,7 @@ class FileBasedDataSourceSuite extends QueryTest
+@@ -1014,6 +1023,7 @@ class FileBasedDataSourceSuite extends QueryTest
  
            val fileScan = df.queryExecution.executedPlan collectFirst {
              case BatchScanExec(_, f: FileScan, _, _, _, _) => f
@@ -913,7 +862,7 @@ index 95e86fe4311..0f7ed3271d4 100644
            }
            assert(fileScan.nonEmpty)
            assert(fileScan.get.partitionFilters.nonEmpty)
-@@ -1055,6 +1070,7 @@ class FileBasedDataSourceSuite extends QueryTest
+@@ -1055,6 +1065,7 @@ class FileBasedDataSourceSuite extends QueryTest
  
            val fileScan = df.queryExecution.executedPlan collectFirst {
              case BatchScanExec(_, f: FileScan, _, _, _, _) => f
@@ -921,7 +870,7 @@ index 95e86fe4311..0f7ed3271d4 100644
            }
            assert(fileScan.nonEmpty)
            assert(fileScan.get.partitionFilters.isEmpty)
-@@ -1239,6 +1255,9 @@ class FileBasedDataSourceSuite extends QueryTest
+@@ -1239,6 +1250,9 @@ class FileBasedDataSourceSuite extends QueryTest
            val filters = df.queryExecution.executedPlan.collect {
              case f: FileSourceScanLike => f.dataFilters
              case b: BatchScanExec => b.scan.asInstanceOf[FileScan].dataFilters
@@ -2020,20 +1969,6 @@ index 47679ed7865..9ffbaecb98e 100644
      }.length == hashAggCount)
      assert(collectWithSubqueries(plan) { case s: SortAggregateExec => s }.length == sortAggCount)
    }
-diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
-index 050a004a935..96d982f2829 100644
---- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
-+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
-@@ -1054,7 +1054,8 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
-     }
-   }
- 
--  test("alter temporary view should follow current storeAnalyzedPlanForView config") {
-+  test("alter temporary view should follow current storeAnalyzedPlanForView config",
-+    IgnoreCometNativeDataFusion("https://github.com/apache/datafusion-comet/issues/3314")) {
-     withTable("t") {
-       Seq(2, 3, 1).toDF("c1").write.format("parquet").saveAsTable("t")
-       withView("v1") {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
 index aed11badb71..1a365b5aacf 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
@@ -3089,7 +3024,7 @@ index 3072657a095..b2293ccab17 100644
        checkAnswer(
          // "fruit" column in this file is encoded using DELTA_LENGTH_BYTE_ARRAY.
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
-index c530dc0d3df..abf36a7ab09 100644
+index c530dc0d3df..418d5ea4b4d 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
 @@ -27,6 +27,7 @@ import org.apache.parquet.hadoop.ParquetOutputFormat
@@ -3110,17 +3045,7 @@ index c530dc0d3df..abf36a7ab09 100644
      val providedSchema = StructType(Seq(StructField("time", TimestampNTZType, false)))
  
      Seq("INT96", "TIMESTAMP_MICROS", "TIMESTAMP_MILLIS").foreach { tsType =>
-@@ -318,7 +320,8 @@ abstract class ParquetQuerySuite extends QueryTest with ParquetTest with SharedS
-     }
-   }
- 
--  test("Enabling/disabling ignoreCorruptFiles") {
-+  test("Enabling/disabling ignoreCorruptFiles",
-+    IgnoreCometNativeDataFusion("https://github.com/apache/datafusion-comet/issues/3314")) {
-     def testIgnoreCorruptFiles(options: Map[String, String]): Unit = {
-       withTempDir { dir =>
-         val basePath = dir.getCanonicalPath
-@@ -996,7 +999,11 @@ abstract class ParquetQuerySuite extends QueryTest with ParquetTest with SharedS
+@@ -996,7 +998,11 @@ abstract class ParquetQuerySuite extends QueryTest with ParquetTest with SharedS
          Seq(Some("A"), Some("A"), None).toDF().repartition(1)
            .write.parquet(path.getAbsolutePath)
          val df = spark.read.parquet(path.getAbsolutePath)
@@ -3133,7 +3058,7 @@ index c530dc0d3df..abf36a7ab09 100644
        }
      }
    }
-@@ -1042,7 +1049,8 @@ abstract class ParquetQuerySuite extends QueryTest with ParquetTest with SharedS
+@@ -1042,7 +1048,8 @@ abstract class ParquetQuerySuite extends QueryTest with ParquetTest with SharedS
      testMigration(fromTsType = "TIMESTAMP_MICROS", toTsType = "INT96")
    }
  
@@ -3143,7 +3068,7 @@ index c530dc0d3df..abf36a7ab09 100644
      def readParquet(schema: String, path: File): DataFrame = {
        spark.read.schema(schema).parquet(path.toString)
      }
-@@ -1060,7 +1068,8 @@ abstract class ParquetQuerySuite extends QueryTest with ParquetTest with SharedS
+@@ -1060,7 +1067,8 @@ abstract class ParquetQuerySuite extends QueryTest with ParquetTest with SharedS
          checkAnswer(readParquet(schema2, path), df)
        }
  
@@ -3153,7 +3078,7 @@ index c530dc0d3df..abf36a7ab09 100644
          val schema1 = "a DECIMAL(3, 2), b DECIMAL(18, 3), c DECIMAL(37, 3)"
          checkAnswer(readParquet(schema1, path), df)
          val schema2 = "a DECIMAL(3, 0), b DECIMAL(18, 1), c DECIMAL(37, 1)"
-@@ -1084,7 +1093,8 @@ abstract class ParquetQuerySuite extends QueryTest with ParquetTest with SharedS
+@@ -1084,7 +1092,8 @@ abstract class ParquetQuerySuite extends QueryTest with ParquetTest with SharedS
        val df = sql(s"SELECT 1 a, 123456 b, ${Int.MaxValue.toLong * 10} c, CAST('1.2' AS BINARY) d")
        df.write.parquet(path.toString)
  
@@ -3163,7 +3088,7 @@ index c530dc0d3df..abf36a7ab09 100644
          checkAnswer(readParquet("a DECIMAL(3, 2)", path), sql("SELECT 1.00"))
          checkAnswer(readParquet("a DECIMAL(11, 2)", path), sql("SELECT 1.00"))
          checkAnswer(readParquet("b DECIMAL(3, 2)", path), Row(null))
-@@ -1131,7 +1141,8 @@ abstract class ParquetQuerySuite extends QueryTest with ParquetTest with SharedS
+@@ -1131,7 +1140,8 @@ abstract class ParquetQuerySuite extends QueryTest with ParquetTest with SharedS
      }
    }
  

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -585,9 +585,7 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
       inputs: Seq[Attribute],
       binding: Boolean = true): Option[Expr] = {
 
-    val conf = SQLConf.get
-    val newExpr =
-      DecimalPrecision.promote(conf.decimalOperationsAllowPrecisionLoss, expr, !conf.ansiEnabled)
+    val newExpr = DecimalPrecision.promote(expr, !SQLConf.get.ansiEnabled)
     exprToProtoInternal(newExpr, inputs, binding)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/DecimalPrecision.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/DecimalPrecision.scala
@@ -19,90 +19,47 @@
 
 package org.apache.spark.sql.comet
 
-import scala.math.{max, min}
-
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types.DecimalType
 
 /**
- * This is mostly copied from the `decimalAndDecimal` method in Spark's [[DecimalPrecision]] which
- * existed before Spark 3.4.
+ * Wraps decimal binary arithmetic expressions in [[CheckOverflow]] so the native side has an
+ * explicit target type for the result.
  *
- * In Spark 3.4 and up, the method `decimalAndDecimal` is removed from Spark, and for binary
- * expressions with different decimal precisions from children, the difference is handled in the
- * expression evaluation instead (see SPARK-39316).
- *
- * However in Comet, we still have to rely on the type coercion to ensure the decimal precision is
- * the same for both children of a binary expression, since our arithmetic kernels do not yet
- * handle the case where precision is different. Therefore, this re-apply the logic in the
- * original rule, and rely on `Cast` and `CheckOverflow` for decimal binary operation.
- *
- * TODO: instead of relying on this rule, it's probably better to enhance arithmetic kernels to
- * handle different decimal precisions
+ * Spark itself stopped wrapping these in `CheckOverflow` in 3.4 (SPARK-39316), but Comet's native
+ * `CheckOverflow` only validates precision (it does not rescale), so the target type must equal
+ * the child's actual `dataType`. Always using `expr.dataType` is the safe choice: on Spark 3.4 -
+ * 4.0 it equals the value the rule would otherwise recompute from `SQLConf`, and on Spark 4.1+
+ * (SPARK-53968) it preserves the per-expression `allowDecimalPrecisionLoss` captured at view
+ * creation time. Recomputing from the live `SQLConf` would re-label a stored DEC(38, 17) result
+ * as DEC(38, 18) (or vice versa) and shift values by 10x (issue #4124).
  */
 object DecimalPrecision {
-  def promote(
-      allowPrecisionLoss: Boolean,
-      expr: Expression,
-      nullOnOverflow: Boolean): Expression = {
+  def promote(expr: Expression, nullOnOverflow: Boolean): Expression = {
     expr.transformUp {
       // This means the binary expression is already optimized with the rule in Spark. This can
       // happen if the Spark version is < 3.4
       case e: BinaryArithmetic if e.left.prettyName == "promote_precision" => e
 
-      case add @ Add(DecimalExpression(p1, s1), DecimalExpression(p2, s2), _) =>
-        val resultScale = max(s1, s2)
-        val resultType = if (allowPrecisionLoss) {
-          DecimalType.adjustPrecisionScale(max(p1 - s1, p2 - s2) + resultScale + 1, resultScale)
-        } else {
-          DecimalType.bounded(max(p1 - s1, p2 - s2) + resultScale + 1, resultScale)
-        }
-        CheckOverflow(add, resultType, nullOnOverflow)
+      case add @ Add(DecimalExpression(_, _), DecimalExpression(_, _), _)
+          if add.dataType.isInstanceOf[DecimalType] =>
+        CheckOverflow(add, add.dataType.asInstanceOf[DecimalType], nullOnOverflow)
 
-      case sub @ Subtract(DecimalExpression(p1, s1), DecimalExpression(p2, s2), _) =>
-        val resultScale = max(s1, s2)
-        val resultType = if (allowPrecisionLoss) {
-          DecimalType.adjustPrecisionScale(max(p1 - s1, p2 - s2) + resultScale + 1, resultScale)
-        } else {
-          DecimalType.bounded(max(p1 - s1, p2 - s2) + resultScale + 1, resultScale)
-        }
-        CheckOverflow(sub, resultType, nullOnOverflow)
+      case sub @ Subtract(DecimalExpression(_, _), DecimalExpression(_, _), _)
+          if sub.dataType.isInstanceOf[DecimalType] =>
+        CheckOverflow(sub, sub.dataType.asInstanceOf[DecimalType], nullOnOverflow)
 
-      case mul @ Multiply(DecimalExpression(p1, s1), DecimalExpression(p2, s2), _) =>
-        val resultType = if (allowPrecisionLoss) {
-          DecimalType.adjustPrecisionScale(p1 + p2 + 1, s1 + s2)
-        } else {
-          DecimalType.bounded(p1 + p2 + 1, s1 + s2)
-        }
-        CheckOverflow(mul, resultType, nullOnOverflow)
+      case mul @ Multiply(DecimalExpression(_, _), DecimalExpression(_, _), _)
+          if mul.dataType.isInstanceOf[DecimalType] =>
+        CheckOverflow(mul, mul.dataType.asInstanceOf[DecimalType], nullOnOverflow)
 
-      case div @ Divide(DecimalExpression(p1, s1), DecimalExpression(p2, s2), _) =>
-        val resultType = if (allowPrecisionLoss) {
-          // Precision: p1 - s1 + s2 + max(6, s1 + p2 + 1)
-          // Scale: max(6, s1 + p2 + 1)
-          val intDig = p1 - s1 + s2
-          val scale = max(DecimalType.MINIMUM_ADJUSTED_SCALE, s1 + p2 + 1)
-          val prec = intDig + scale
-          DecimalType.adjustPrecisionScale(prec, scale)
-        } else {
-          var intDig = min(DecimalType.MAX_SCALE, p1 - s1 + s2)
-          var decDig = min(DecimalType.MAX_SCALE, max(6, s1 + p2 + 1))
-          val diff = (intDig + decDig) - DecimalType.MAX_SCALE
-          if (diff > 0) {
-            decDig -= diff / 2 + 1
-            intDig = DecimalType.MAX_SCALE - decDig
-          }
-          DecimalType.bounded(intDig + decDig, decDig)
-        }
-        CheckOverflow(div, resultType, nullOnOverflow)
+      case div @ Divide(DecimalExpression(_, _), DecimalExpression(_, _), _)
+          if div.dataType.isInstanceOf[DecimalType] =>
+        CheckOverflow(div, div.dataType.asInstanceOf[DecimalType], nullOnOverflow)
 
-      case rem @ Remainder(DecimalExpression(p1, s1), DecimalExpression(p2, s2), _) =>
-        val resultType = if (allowPrecisionLoss) {
-          DecimalType.adjustPrecisionScale(min(p1 - s1, p2 - s2) + max(s1, s2), max(s1, s2))
-        } else {
-          DecimalType.bounded(min(p1 - s1, p2 - s2) + max(s1, s2), max(s1, s2))
-        }
-        CheckOverflow(rem, resultType, nullOnOverflow)
+      case rem @ Remainder(DecimalExpression(_, _), DecimalExpression(_, _), _)
+          if rem.dataType.isInstanceOf[DecimalType] =>
+        CheckOverflow(rem, rem.dataType.asInstanceOf[DecimalType], nullOnOverflow)
 
       case e => e
     }

--- a/spark/src/test/spark-4.1/org/apache/spark/sql/comet/CometDecimalArithmeticViewSuite.scala
+++ b/spark/src/test/spark-4.1/org/apache/spark/sql/comet/CometDecimalArithmeticViewSuite.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet
+
+import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.catalyst.expressions.{Add, AttributeReference, CheckOverflow, EvalMode, NumericEvalContext}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.DecimalType
+
+class CometDecimalArithmeticViewSuite extends CometTestBase {
+
+  // Spark 4.1.1 (SPARK-53968) stores `spark.sql.decimalOperations.allowPrecisionLoss` per
+  // arithmetic expression so a view's analyzed plan keeps a stable result type across config
+  // changes. Comet's DecimalPrecision rule used to recompute the result type from the current
+  // SQLConf, producing a CheckOverflow target that disagreed with the stored Add.dataType and
+  // re-labelling the Decimal128 buffer at the wrong scale (issue #4124). The repro requires a
+  // mismatch between the stored evalContext and the live SQLConf, which is why we construct
+  // Add directly rather than going through SQL parsing.
+  test("issue #4124: DecimalPrecision.promote honours per-expression allowPrecisionLoss") {
+    val left = AttributeReference("a", DecimalType(38, 18))()
+    val right = AttributeReference("b", DecimalType(38, 18))()
+    val storedTrue =
+      Add(left, right, NumericEvalContext(EvalMode.LEGACY, allowDecimalPrecisionLoss = true))
+    val storedFalse =
+      Add(left, right, NumericEvalContext(EvalMode.LEGACY, allowDecimalPrecisionLoss = false))
+    assert(storedTrue.dataType === DecimalType(38, 17))
+    assert(storedFalse.dataType === DecimalType(38, 18))
+
+    // Current SQLConf disagrees with the stored evalContext on each Add. The promoted
+    // CheckOverflow's target type must come from Add.dataType (which honours the stored
+    // evalContext), not from the current SQLConf. Otherwise the native CheckOverflow
+    // re-labels the Decimal128 buffer at the wrong scale and values come out 10x off.
+    Seq((true, storedFalse), (false, storedTrue)).foreach { case (currentConf, add) =>
+      withSQLConf(SQLConf.DECIMAL_OPERATIONS_ALLOW_PREC_LOSS.key -> currentConf.toString) {
+        val promoted = org.apache.spark.sql.comet.DecimalPrecision
+          .promote(add, nullOnOverflow = true)
+        promoted match {
+          case CheckOverflow(_, dt, _) =>
+            assert(
+              dt === add.dataType,
+              s"CheckOverflow target $dt must match Add.dataType ${add.dataType}; mismatch " +
+                s"causes the decimal buffer to be re-labelled at the wrong scale.")
+          case other =>
+            fail(s"Expected DecimalPrecision.promote to wrap Add in CheckOverflow, got: $other")
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4124.

## Rationale for this change

The new Spark 4.1 test `SPARK-53968 reading the view after allowPrecisionLoss is changed` in `SQLViewSuite` returns values 10x smaller than expected when run with Comet. The reproducer stores `DECIMAL(38, 18)` values in a view whose plan does `unit_price + COALESCE(shipping_price, 0)`, then re-reads the view after toggling `spark.sql.decimalOperations.allowPrecisionLoss`.

Spark 4.1.1 (SPARK-53968) added a `NumericEvalContext` to `Add`/`Subtract`/`Multiply`/`Divide`/`IntegralDivide` that captures `allowDecimalPrecisionLoss` at construction time, so a view's analyzed plan keeps a stable decimal result type across config changes. Comet's `DecimalPrecision.promote` rule, however, recomputed the result type from the **live** `SQLConf` and wrapped the expression in `CheckOverflow` with that recomputed type. When the two disagreed (which is the SPARK-53968 scenario), the wrapper's target type no longer matched the child's `dataType`.

Comet's native `CheckOverflow` (`native/spark-expr/src/math_funcs/internal/checkoverflow.rs`) only validates that values fit the target precision; it does **not** rescale. So a `Decimal128Array` produced at scale 17 ended up relabelled as scale 18 (or vice versa), shifting every value by a factor of 10. With view created at `allowPrecisionLoss=true` and read at `false`, expected `100.00000000000000000` came back as `10.00000000000000000`.

## What changes are included in this PR?

- `DecimalPrecision.promote` now sets the `CheckOverflow` target type to `expr.dataType` directly. On Spark 3.4 - 4.0 this is equivalent to the previous recomputation; on Spark 4.1+ it preserves the per-expression `allowDecimalPrecisionLoss` captured at view creation time.
- The unused `allowPrecisionLoss` parameter is dropped from the rule and its single call site in `QueryPlanSerde.exprToProto`.
- The `IgnoreComet` annotation on `SPARK-53968 reading the view after allowPrecisionLoss is changed` is removed from `dev/diffs/4.1.1.diff`.

## How are these changes tested?

- New unit test `CometDecimalArithmeticViewSuite` (under `spark/src/test/spark-4.1/`) constructs `Add` with a `NumericEvalContext` whose `allowDecimalPrecisionLoss` disagrees with the live `SQLConf`, and asserts that the promoted `CheckOverflow` target tracks `Add.dataType`. The test fails before the fix (target was `DecimalType(38,17)`/`DecimalType(38,18)` instead of the stored type) and passes after.
- The existing `decimal division result type matches Spark` regression test in `CometExpressionSuite`, which already targeted a closely-related Spark 4 path, continues to pass.
- The `SQLViewSuite.SPARK-53968` Spark SQL test will be exercised by the Spark SQL CI workflow once it is no longer ignored.