### PR TITLE
test: add explicit negative-count cases for array_repeat

### DIFF
--- a/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
@@ -761,6 +761,9 @@ class CometArrayExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelp
 
             checkSparkAnswerAndOperator(sql("SELECT array_repeat(_4, null) from t1"))
             checkSparkAnswerAndOperator(sql("SELECT array_repeat(_4, 0) from t1"))
+            checkSparkAnswerAndOperator(sql("SELECT array_repeat(_4, -1) from t1"))
+            checkSparkAnswerAndOperator(
+              sql("SELECT array_repeat(cast(_3 as string), -5) from t1"))
             checkSparkAnswerAndOperator(
               sql("SELECT array_repeat(_2, 5) from t1 where _2 is not null"))
             checkSparkAnswerAndOperator(


### PR DESCRIPTION
Spark treats negative counts as zero in array_repeat, returning an empty array. DataFusion's array_repeat (used by Comet since #3516) already matches this: get_count_with_validity clamps c <= 0 to 0.

The existing SQL-file test covers a (1, -1) row, but the Scala-level test in CometArrayExpressionSuite did not assert this case. Add two assertions (integer column + string-cast column) so the parity is locked in against future regressions.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3176

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
