### PR TITLE
fix: resolve Scala compiler warnings for auto-tupling and bare try

### DIFF
--- a/spark/src/main/scala/org/apache/comet/GenerateDocs.scala
+++ b/spark/src/main/scala/org/apache/comet/GenerateDocs.scala
@@ -50,78 +50,86 @@ object GenerateDocs {
    * that category from the serde maps in `QueryPlanSerde`.
    */
   private def categoryPages: Map[String, (String, () => CategoryNotes)] = Map(
-    "array" -> ("compatibility/expressions/array.md",
-    () =>
-      QueryPlanSerde.arrayExpressions.toSeq.map { case (cls, serde) =>
-        (
-          cls.getSimpleName,
-          serde.getCompatibleNotes(),
-          serde.getIncompatibleReasons(),
-          serde.getUnsupportedReasons())
-      }),
-    "datetime" -> ("compatibility/expressions/datetime.md",
-    () =>
-      QueryPlanSerde.temporalExpressions.toSeq.map { case (cls, serde) =>
-        (
-          cls.getSimpleName,
-          serde.getCompatibleNotes(),
-          serde.getIncompatibleReasons(),
-          serde.getUnsupportedReasons())
-      }),
-    "math" -> ("compatibility/expressions/math.md",
-    () =>
-      QueryPlanSerde.mathExpressions.toSeq.map { case (cls, serde) =>
-        (
-          cls.getSimpleName,
-          serde.getCompatibleNotes(),
-          serde.getIncompatibleReasons(),
-          serde.getUnsupportedReasons())
-      }),
-    "struct" -> ("compatibility/expressions/struct.md",
-    () =>
-      QueryPlanSerde.structExpressions.toSeq.map { case (cls, serde) =>
-        (
-          cls.getSimpleName,
-          serde.getCompatibleNotes(),
-          serde.getIncompatibleReasons(),
-          serde.getUnsupportedReasons())
-      }),
-    "aggregate" -> ("compatibility/expressions/aggregate.md",
-    () =>
-      QueryPlanSerde.aggrSerdeMap.toSeq.map { case (cls, serde) =>
-        (
-          cls.getSimpleName,
-          serde.getCompatibleNotes(),
-          serde.getIncompatibleReasons(),
-          serde.getUnsupportedReasons())
-      }),
-    "string" -> ("compatibility/expressions/string.md",
-    () =>
-      QueryPlanSerde.stringExpressions.toSeq.map { case (cls, serde) =>
-        (
-          cls.getSimpleName,
-          serde.getCompatibleNotes(),
-          serde.getIncompatibleReasons(),
-          serde.getUnsupportedReasons())
-      }),
-    "map" -> ("compatibility/expressions/map.md",
-    () =>
-      QueryPlanSerde.mapExpressions.toSeq.map { case (cls, serde) =>
-        (
-          cls.getSimpleName,
-          serde.getCompatibleNotes(),
-          serde.getIncompatibleReasons(),
-          serde.getUnsupportedReasons())
-      }),
-    "misc" -> ("compatibility/expressions/misc.md",
-    () =>
-      QueryPlanSerde.miscExpressions.toSeq.map { case (cls, serde) =>
-        (
-          cls.getSimpleName,
-          serde.getCompatibleNotes(),
-          serde.getIncompatibleReasons(),
-          serde.getUnsupportedReasons())
-      }))
+    "array" -> ((
+      "compatibility/expressions/array.md",
+      () =>
+        QueryPlanSerde.arrayExpressions.toSeq.map { case (cls, serde) =>
+          (
+            cls.getSimpleName,
+            serde.getCompatibleNotes(),
+            serde.getIncompatibleReasons(),
+            serde.getUnsupportedReasons())
+        })),
+    "datetime" -> ((
+      "compatibility/expressions/datetime.md",
+      () =>
+        QueryPlanSerde.temporalExpressions.toSeq.map { case (cls, serde) =>
+          (
+            cls.getSimpleName,
+            serde.getCompatibleNotes(),
+            serde.getIncompatibleReasons(),
+            serde.getUnsupportedReasons())
+        })),
+    "math" -> ((
+      "compatibility/expressions/math.md",
+      () =>
+        QueryPlanSerde.mathExpressions.toSeq.map { case (cls, serde) =>
+          (
+            cls.getSimpleName,
+            serde.getCompatibleNotes(),
+            serde.getIncompatibleReasons(),
+            serde.getUnsupportedReasons())
+        })),
+    "struct" -> ((
+      "compatibility/expressions/struct.md",
+      () =>
+        QueryPlanSerde.structExpressions.toSeq.map { case (cls, serde) =>
+          (
+            cls.getSimpleName,
+            serde.getCompatibleNotes(),
+            serde.getIncompatibleReasons(),
+            serde.getUnsupportedReasons())
+        })),
+    "aggregate" -> ((
+      "compatibility/expressions/aggregate.md",
+      () =>
+        QueryPlanSerde.aggrSerdeMap.toSeq.map { case (cls, serde) =>
+          (
+            cls.getSimpleName,
+            serde.getCompatibleNotes(),
+            serde.getIncompatibleReasons(),
+            serde.getUnsupportedReasons())
+        })),
+    "string" -> ((
+      "compatibility/expressions/string.md",
+      () =>
+        QueryPlanSerde.stringExpressions.toSeq.map { case (cls, serde) =>
+          (
+            cls.getSimpleName,
+            serde.getCompatibleNotes(),
+            serde.getIncompatibleReasons(),
+            serde.getUnsupportedReasons())
+        })),
+    "map" -> ((
+      "compatibility/expressions/map.md",
+      () =>
+        QueryPlanSerde.mapExpressions.toSeq.map { case (cls, serde) =>
+          (
+            cls.getSimpleName,
+            serde.getCompatibleNotes(),
+            serde.getIncompatibleReasons(),
+            serde.getUnsupportedReasons())
+        })),
+    "misc" -> ((
+      "compatibility/expressions/misc.md",
+      () =>
+        QueryPlanSerde.miscExpressions.toSeq.map { case (cls, serde) =>
+          (
+            cls.getSimpleName,
+            serde.getCompatibleNotes(),
+            serde.getIncompatibleReasons(),
+            serde.getUnsupportedReasons())
+        })))
 
   def main(args: Array[String]): Unit = {
     val userGuideLocation = args(0)

--- a/spark/src/main/scala/org/apache/comet/parquet/SourceFilterSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/parquet/SourceFilterSerde.scala
@@ -50,11 +50,12 @@ object SourceFilterSerde extends Logging {
           .setDatatype(dataType.get)
           .build()
         Some(
-          field.dataType,
-          ExprOuterClass.Expr
-            .newBuilder()
-            .setBound(boundExpr)
-            .build())
+          (
+            field.dataType,
+            ExprOuterClass.Expr
+              .newBuilder()
+              .setBound(boundExpr)
+              .build()))
       } else {
         None
       }

--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
@@ -819,7 +819,7 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
           inputPartitions.foreach { inputPartition =>
             val inputPartClass = inputPartition.getClass
 
-            try {
+            {
               val taskGroupMethod = inputPartClass.getDeclaredMethod("taskGroup")
               taskGroupMethod.setAccessible(true)
               val taskGroup = taskGroupMethod.invoke(inputPartition)

--- a/spark/src/main/spark-3.5/org/apache/spark/sql/comet/shims/ShimCometScanExec.scala
+++ b/spark/src/main/spark-3.5/org/apache/spark/sql/comet/shims/ShimCometScanExec.scala
@@ -41,7 +41,7 @@ trait ShimCometScanExec {
 
   def isSparkVersionAtLeast355: Boolean = {
     VersionUtils.majorMinorPatchVersion(SPARK_VERSION_SHORT) match {
-      case Some((major, minor, patch)) => (major, minor, patch) >= (3, 5, 5)
+      case Some((major, minor, patch)) => (major, minor, patch) >= ((3, 5, 5))
       case None =>
         throw new IllegalArgumentException(s"Malformed Spark version: $SPARK_VERSION_SHORT")
     }

--- a/spark/src/main/spark-3.5/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
+++ b/spark/src/main/spark-3.5/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
@@ -162,8 +162,7 @@ trait ShimSparkErrorConverter {
       case "CollectionSizeLimitExceeded" =>
         Some(
           QueryExecutionErrors.createArrayWithElementsExceedLimitError(
-            "array",
-            params("numElements").toString.toLong))
+            ("array", params("numElements").toString.toLong)))
 
       case "NotNullAssertViolation" =>
         Some(

--- a/spark/src/test/scala/org/apache/comet/CometStringExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometStringExpressionSuite.scala
@@ -582,7 +582,7 @@ class CometStringExpressionSuite extends CometTestBase {
   }
 
   test("substring - decomposed and combining unicode characters") {
-    val data = edgeCases.map(s => (s, "")) :+ ("", "") :+ (null, "")
+    val data = edgeCases.map(s => (s, "")) :+ (("", "")) :+ ((null, ""))
     withParquetTable(data, "tbl") {
       // first code point only — exposes decomposed vs precomposed difference
       checkSparkAnswerAndOperator("SELECT substring(_1, 1, 1) FROM tbl")

--- a/spark/src/test/scala/org/apache/comet/exec/CometColumnarShuffleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometColumnarShuffleSuite.scala
@@ -189,7 +189,7 @@ abstract class CometColumnarShuffleSuite extends CometTestBase with AdaptiveSpar
               checkShuffleAnswer(df, complexKeyShuffles)
             }
 
-            withParquetTable((0 until 50).map(i => (Map(i -> (i, i.toString)), i + 1)), "tbl") {
+            withParquetTable((0 until 50).map(i => (Map(i -> ((i, i.toString))), i + 1)), "tbl") {
               val df = sql("SELECT * FROM tbl")
                 .filter($"_2" > 10)
                 .repartition(numPartitions, $"_1", $"_2")


### PR DESCRIPTION
## Summary

- Add explicit tuple parentheses to eliminate all "Adapting argument list by creating a N-tuple" Scala compiler warnings (16 total across main and test compilation)
- Remove a bare `try` block without `catch`/`finally` in `CometIcebergNativeScan.scala`

## Which issue does this PR close?

N/A - code hygiene

## Test plan

- Clean build passes with `mvn clean compile test-compile -DskipTests`
- Zero Scala "warnings found" messages (previously 12 in main compile + 4 in test compile)
- `spotless:check` passes