### PR TITLE
chore: [branch-0.16] prettier-format cast.md to unblock lint

### DIFF
--- a/docs/source/user-guide/latest/compatibility/expressions/cast.md
+++ b/docs/source/user-guide/latest/compatibility/expressions/cast.md
@@ -150,87 +150,93 @@ as `"1.23E+4"`).
 
 <!--BEGIN:CAST_LEGACY_TABLE-->
 <!-- prettier-ignore-start -->
-| | binary | boolean | byte | date | decimal | double | float | integer | long | short | string | timestamp | timestamp_ntz |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| binary | - | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | C | N/A | N/A |
-| boolean | N/A | - | C | N/A | C | C | C | C | C | C | C | C | N/A |
-| byte | C | C | - | N/A | C | C | C | C | C | C | C | C | N/A |
-| date | N/A | C | C | - | C | C | C | C | C | C | C | C | C |
-| decimal | N/A | C | C | N/A | - | C | C | C | C | C | C | C | N/A |
-| double | N/A | C | C | N/A | I | - | C | C | C | C | C | C | N/A |
-| float | N/A | C | C | N/A | I | C | - | C | C | C | C | C | N/A |
-| integer | C | C | C | N/A | C | C | C | - | C | C | C | C | N/A |
-| long | C | C | C | N/A | C | C | C | C | - | C | C | C | N/A |
-| short | C | C | C | N/A | C | C | C | C | C | - | C | C | N/A |
-| string | C | C | C | C | C | C | C | C | C | C | - | C | C |
-| timestamp | N/A | U | U | C | U | U | U | U | C | U | C | - | C |
-| timestamp_ntz | N/A | N/A | N/A | C | N/A | N/A | N/A | N/A | N/A | N/A | C | C | - |
+
+|               | binary | boolean | byte | date | decimal | double | float | integer | long | short | string | timestamp | timestamp_ntz |
+| ------------- | ------ | ------- | ---- | ---- | ------- | ------ | ----- | ------- | ---- | ----- | ------ | --------- | ------------- |
+| binary        | -      | N/A     | N/A  | N/A  | N/A     | N/A    | N/A   | N/A     | N/A  | N/A   | C      | N/A       | N/A           |
+| boolean       | N/A    | -       | C    | N/A  | C       | C      | C     | C       | C    | C     | C      | C         | N/A           |
+| byte          | C      | C       | -    | N/A  | C       | C      | C     | C       | C    | C     | C      | C         | N/A           |
+| date          | N/A    | C       | C    | -    | C       | C      | C     | C       | C    | C     | C      | C         | C             |
+| decimal       | N/A    | C       | C    | N/A  | -       | C      | C     | C       | C    | C     | C      | C         | N/A           |
+| double        | N/A    | C       | C    | N/A  | I       | -      | C     | C       | C    | C     | C      | C         | N/A           |
+| float         | N/A    | C       | C    | N/A  | I       | C      | -     | C       | C    | C     | C      | C         | N/A           |
+| integer       | C      | C       | C    | N/A  | C       | C      | C     | -       | C    | C     | C      | C         | N/A           |
+| long          | C      | C       | C    | N/A  | C       | C      | C     | C       | -    | C     | C      | C         | N/A           |
+| short         | C      | C       | C    | N/A  | C       | C      | C     | C       | C    | -     | C      | C         | N/A           |
+| string        | C      | C       | C    | C    | C       | C      | C     | C       | C    | C     | -      | C         | C             |
+| timestamp     | N/A    | U       | U    | C    | U       | U      | U     | U       | C    | U     | C      | -         | C             |
+| timestamp_ntz | N/A    | N/A     | N/A  | C    | N/A     | N/A    | N/A   | N/A     | N/A  | N/A   | C      | C         | -             |
 
 **Notes:**
+
 - **double -> decimal**: There can be rounding differences
 - **double -> string**: There can be differences in precision. For example, the input "1.4E-45" will produce 1.0E-45 instead of 1.4E-45
 - **float -> decimal**: There can be rounding differences
 - **float -> string**: There can be differences in precision. For example, the input "1.4E-45" will produce 1.0E-45 instead of 1.4E-45
 - **string -> date**: Only supports years between 262143 BC and 262142 AD
-<!-- prettier-ignore-end -->
-<!--END:CAST_LEGACY_TABLE-->
+  <!-- prettier-ignore-end -->
+  <!--END:CAST_LEGACY_TABLE-->
 
 ## Try Mode
 
 <!--BEGIN:CAST_TRY_TABLE-->
 <!-- prettier-ignore-start -->
-| | binary | boolean | byte | date | decimal | double | float | integer | long | short | string | timestamp | timestamp_ntz |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| binary | - | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | C | N/A | N/A |
-| boolean | N/A | - | C | N/A | C | C | C | C | C | C | C | U | N/A |
-| byte | U | C | - | N/A | C | C | C | C | C | C | C | C | N/A |
-| date | N/A | U | U | - | U | U | U | U | U | U | C | C | C |
-| decimal | N/A | C | C | N/A | - | C | C | C | C | C | C | C | N/A |
-| double | N/A | C | C | N/A | I | - | C | C | C | C | C | C | N/A |
-| float | N/A | C | C | N/A | I | C | - | C | C | C | C | C | N/A |
-| integer | U | C | C | N/A | C | C | C | - | C | C | C | C | N/A |
-| long | U | C | C | N/A | C | C | C | C | - | C | C | C | N/A |
-| short | U | C | C | N/A | C | C | C | C | C | - | C | C | N/A |
-| string | C | C | C | C | C | C | C | C | C | C | - | C | C |
-| timestamp | N/A | U | U | C | U | U | U | U | C | U | C | - | C |
-| timestamp_ntz | N/A | N/A | N/A | C | N/A | N/A | N/A | N/A | N/A | N/A | C | C | - |
+
+|               | binary | boolean | byte | date | decimal | double | float | integer | long | short | string | timestamp | timestamp_ntz |
+| ------------- | ------ | ------- | ---- | ---- | ------- | ------ | ----- | ------- | ---- | ----- | ------ | --------- | ------------- |
+| binary        | -      | N/A     | N/A  | N/A  | N/A     | N/A    | N/A   | N/A     | N/A  | N/A   | C      | N/A       | N/A           |
+| boolean       | N/A    | -       | C    | N/A  | C       | C      | C     | C       | C    | C     | C      | U         | N/A           |
+| byte          | U      | C       | -    | N/A  | C       | C      | C     | C       | C    | C     | C      | C         | N/A           |
+| date          | N/A    | U       | U    | -    | U       | U      | U     | U       | U    | U     | C      | C         | C             |
+| decimal       | N/A    | C       | C    | N/A  | -       | C      | C     | C       | C    | C     | C      | C         | N/A           |
+| double        | N/A    | C       | C    | N/A  | I       | -      | C     | C       | C    | C     | C      | C         | N/A           |
+| float         | N/A    | C       | C    | N/A  | I       | C      | -     | C       | C    | C     | C      | C         | N/A           |
+| integer       | U      | C       | C    | N/A  | C       | C      | C     | -       | C    | C     | C      | C         | N/A           |
+| long          | U      | C       | C    | N/A  | C       | C      | C     | C       | -    | C     | C      | C         | N/A           |
+| short         | U      | C       | C    | N/A  | C       | C      | C     | C       | C    | -     | C      | C         | N/A           |
+| string        | C      | C       | C    | C    | C       | C      | C     | C       | C    | C     | -      | C         | C             |
+| timestamp     | N/A    | U       | U    | C    | U       | U      | U     | U       | C    | U     | C      | -         | C             |
+| timestamp_ntz | N/A    | N/A     | N/A  | C    | N/A     | N/A    | N/A   | N/A     | N/A  | N/A   | C      | C         | -             |
 
 **Notes:**
+
 - **double -> decimal**: There can be rounding differences
 - **double -> string**: There can be differences in precision. For example, the input "1.4E-45" will produce 1.0E-45 instead of 1.4E-45
 - **float -> decimal**: There can be rounding differences
 - **float -> string**: There can be differences in precision. For example, the input "1.4E-45" will produce 1.0E-45 instead of 1.4E-45
 - **string -> date**: Only supports years between 262143 BC and 262142 AD
-<!-- prettier-ignore-end -->
-<!--END:CAST_TRY_TABLE-->
+  <!-- prettier-ignore-end -->
+  <!--END:CAST_TRY_TABLE-->
 
 ## ANSI Mode
 
 <!--BEGIN:CAST_ANSI_TABLE-->
 <!-- prettier-ignore-start -->
-| | binary | boolean | byte | date | decimal | double | float | integer | long | short | string | timestamp | timestamp_ntz |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| binary | - | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | C | N/A | N/A |
-| boolean | N/A | - | C | N/A | C | C | C | C | C | C | C | U | N/A |
-| byte | U | C | - | N/A | C | C | C | C | C | C | C | C | N/A |
-| date | N/A | U | U | - | U | U | U | U | U | U | C | C | C |
-| decimal | N/A | C | C | N/A | - | C | C | C | C | C | C | C | N/A |
-| double | N/A | C | C | N/A | I | - | C | C | C | C | C | C | N/A |
-| float | N/A | C | C | N/A | I | C | - | C | C | C | C | C | N/A |
-| integer | U | C | C | N/A | C | C | C | - | C | C | C | C | N/A |
-| long | U | C | C | N/A | C | C | C | C | - | C | C | C | N/A |
-| short | U | C | C | N/A | C | C | C | C | C | - | C | C | N/A |
-| string | C | C | C | C | C | C | C | C | C | C | - | C | C |
-| timestamp | N/A | U | U | C | U | U | U | U | C | U | C | - | C |
-| timestamp_ntz | N/A | N/A | N/A | C | N/A | N/A | N/A | N/A | N/A | N/A | C | C | - |
+
+|               | binary | boolean | byte | date | decimal | double | float | integer | long | short | string | timestamp | timestamp_ntz |
+| ------------- | ------ | ------- | ---- | ---- | ------- | ------ | ----- | ------- | ---- | ----- | ------ | --------- | ------------- |
+| binary        | -      | N/A     | N/A  | N/A  | N/A     | N/A    | N/A   | N/A     | N/A  | N/A   | C      | N/A       | N/A           |
+| boolean       | N/A    | -       | C    | N/A  | C       | C      | C     | C       | C    | C     | C      | U         | N/A           |
+| byte          | U      | C       | -    | N/A  | C       | C      | C     | C       | C    | C     | C      | C         | N/A           |
+| date          | N/A    | U       | U    | -    | U       | U      | U     | U       | U    | U     | C      | C         | C             |
+| decimal       | N/A    | C       | C    | N/A  | -       | C      | C     | C       | C    | C     | C      | C         | N/A           |
+| double        | N/A    | C       | C    | N/A  | I       | -      | C     | C       | C    | C     | C      | C         | N/A           |
+| float         | N/A    | C       | C    | N/A  | I       | C      | -     | C       | C    | C     | C      | C         | N/A           |
+| integer       | U      | C       | C    | N/A  | C       | C      | C     | -       | C    | C     | C      | C         | N/A           |
+| long          | U      | C       | C    | N/A  | C       | C      | C     | C       | -    | C     | C      | C         | N/A           |
+| short         | U      | C       | C    | N/A  | C       | C      | C     | C       | C    | -     | C      | C         | N/A           |
+| string        | C      | C       | C    | C    | C       | C      | C     | C       | C    | C     | -      | C         | C             |
+| timestamp     | N/A    | U       | U    | C    | U       | U      | U     | U       | C    | U     | C      | -         | C             |
+| timestamp_ntz | N/A    | N/A     | N/A  | C    | N/A     | N/A    | N/A   | N/A     | N/A  | N/A   | C      | C         | -             |
 
 **Notes:**
+
 - **double -> decimal**: There can be rounding differences
 - **double -> string**: There can be differences in precision. For example, the input "1.4E-45" will produce 1.0E-45 instead of 1.4E-45
 - **float -> decimal**: There can be rounding differences
 - **float -> string**: There can be differences in precision. For example, the input "1.4E-45" will produce 1.0E-45 instead of 1.4E-45
 - **string -> date**: Only supports years between 262143 BC and 262142 AD
-<!-- prettier-ignore-end -->
-<!--END:CAST_ANSI_TABLE-->
+  <!-- prettier-ignore-end -->
+  <!--END:CAST_ANSI_TABLE-->
 
 See the [tracking issue](https://github.com/apache/datafusion-comet/issues/286) for more details.


### PR DESCRIPTION
## Which issue does this PR close?

No tracking issue. Quick fix to unblock CI on \`branch-0.16\`.

## Rationale for this change

The \`Lint Java\` jobs on \`branch-0.16\` currently fail on every PR. The job runs:

\`\`\`
npx prettier "**/*.md" --write
./dev/ci/check-working-tree-clean.sh
\`\`\`

With the prettier version that npm installs today (\`3.8.3\`), the cast tables in \`docs/source/user-guide/latest/compatibility/expressions/cast.md\` are reformatted from compact to padded layout, even inside the \`<!-- prettier-ignore-start -->\` markers. Reproducible on a clean checkout of \`apache/branch-0.16\` with no other changes:

\`\`\`
$ git clone --branch branch-0.16 https://github.com/apache/datafusion-comet
$ npx prettier --check docs/source/user-guide/latest/compatibility/expressions/cast.md
[warn] docs/source/user-guide/latest/compatibility/expressions/cast.md
[warn] Code style issues found in the above file.
\`\`\`

This has been blocking #4265 (and will block any future backport PR to \`branch-0.16\`).

## What changes are included in this PR?

- Run \`prettier --write\` on \`docs/source/user-guide/latest/compatibility/expressions/cast.md\`. Pure cosmetic reformatting (compact tables to padded tables). No content change.

The underlying question of why prettier reformats inside the \`prettier-ignore\` markers can be addressed separately if needed; this PR just unblocks CI.

## How are these changes tested?

\`\`\`
$ npx prettier --check "docs/**/*.md"
All matched files use Prettier code style!
\`\`\`