### PR TITLE
build: fix OOM on standard GitHub runners for Spark SQL tests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze Actions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -51,7 +51,7 @@ on:
 jobs:
   miri:
     name: "Miri"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - name: Install Build Dependencies

--- a/.github/workflows/pr_benchmark_check.yml
+++ b/.github/workflows/pr_benchmark_check.yml
@@ -46,7 +46,7 @@ env:
 jobs:
   benchmark-check:
     name: Benchmark Compile & Lint Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: amd64/rust
     steps:

--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -63,7 +63,7 @@ jobs:
   # Fast lint check - gates all other jobs
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: amd64/rust
     steps:
@@ -77,7 +77,7 @@ jobs:
   lint-java:
     needs: lint
     name: Lint Java (${{ matrix.profile.name }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: amd64/rust
       env:
@@ -153,7 +153,7 @@ jobs:
   build-spark-4-1:
     needs: lint
     name: Build Spark 4.1, JDK 17
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: amd64/rust
     steps:
@@ -182,7 +182,7 @@ jobs:
   build-native:
     needs: lint
     name: Build Native Library
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: amd64/rust
     steps:
@@ -234,7 +234,7 @@ jobs:
   linux-test-rust:
     needs: lint
     name: ubuntu-latest/rust-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: amd64/rust
     steps:
@@ -396,7 +396,7 @@ jobs:
               org.apache.spark.sql.CometCollationSuite
       fail-fast: false
     name: ${{ matrix.profile.name }}/${{ matrix.profile.scan_impl }} [${{ matrix.suite.name }}]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: amd64/rust
       env:
@@ -443,7 +443,7 @@ jobs:
   verify-benchmark-results-tpch:
     needs: build-native
     name: Verify TPC-H Results
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: amd64/rust
     env:
@@ -497,7 +497,7 @@ jobs:
   verify-benchmark-results-tpcds:
     needs: build-native
     name: Verify TPC-DS Results (${{ matrix.join }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: amd64/rust
     env:

--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -183,7 +183,7 @@ jobs:
   build-native:
     needs: lint
     name: Build Native Library
-    runs-on: ${{ github.repository_owner == 'apache' && format('runs-on={0},family=m8a+m7a+c8a,cpu=8,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion-comet', github.run_id) || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_RUNS_ON == 'true' && format('runs-on={0},family=m8a+m7a+c8a,cpu=8,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion-comet', github.run_id) || 'ubuntu-latest' }}
     container:
       image: amd64/rust
     steps:
@@ -236,7 +236,7 @@ jobs:
   linux-test-rust:
     needs: lint
     name: ubuntu-latest/rust-test
-    runs-on: ${{ github.repository_owner == 'apache' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion-comet', github.run_id) || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_RUNS_ON == 'true' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion-comet', github.run_id) || 'ubuntu-latest' }}
     container:
       image: amd64/rust
     steps:
@@ -400,7 +400,7 @@ jobs:
               org.apache.spark.sql.CometCollationSuite
       fail-fast: false
     name: ${{ matrix.profile.name }}/${{ matrix.profile.scan_impl }} [${{ matrix.suite.name }}]
-    runs-on: ${{ github.repository_owner == 'apache' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion-comet', github.run_id) || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_RUNS_ON == 'true' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion-comet', github.run_id) || 'ubuntu-latest' }}
     container:
       image: amd64/rust
       env:
@@ -448,7 +448,7 @@ jobs:
   verify-benchmark-results-tpch:
     needs: build-native
     name: Verify TPC-H Results
-    runs-on: ${{ github.repository_owner == 'apache' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion-comet', github.run_id) || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_RUNS_ON == 'true' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion-comet', github.run_id) || 'ubuntu-latest' }}
     container:
       image: amd64/rust
     env:
@@ -504,7 +504,7 @@ jobs:
   verify-benchmark-results-tpcds:
     needs: build-native
     name: Verify TPC-DS Results (${{ matrix.join }})
-    runs-on: ${{ github.repository_owner == 'apache' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion-comet', github.run_id) || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_RUNS_ON == 'true' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion-comet', github.run_id) || 'ubuntu-latest' }}
     container:
       image: amd64/rust
     env:

--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -103,7 +103,6 @@ jobs:
           # spark-4.2 profiles.
       fail-fast: false
     steps:
-      - uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0  # v2.1.0
       - uses: actions/checkout@v6
 
       - name: Setup Rust & Java toolchain
@@ -183,11 +182,10 @@ jobs:
   build-native:
     needs: lint
     name: Build Native Library
-    runs-on: ${{ vars.USE_RUNS_ON == 'true' && format('runs-on={0},family=m8a+m7a+c8a,cpu=8,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion-comet', github.run_id) || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     container:
       image: amd64/rust
     steps:
-      - uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0  # v2.1.0
       - uses: actions/checkout@v6
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
@@ -236,12 +234,10 @@ jobs:
   linux-test-rust:
     needs: lint
     name: ubuntu-latest/rust-test
-    runs-on: ${{ vars.USE_RUNS_ON == 'true' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion-comet', github.run_id) || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     container:
       image: amd64/rust
     steps:
-      - uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0  # v2.1.0
-
       - uses: actions/checkout@v6
 
       - name: Setup Rust & Java toolchain
@@ -400,14 +396,13 @@ jobs:
               org.apache.spark.sql.CometCollationSuite
       fail-fast: false
     name: ${{ matrix.profile.name }}/${{ matrix.profile.scan_impl }} [${{ matrix.suite.name }}]
-    runs-on: ${{ vars.USE_RUNS_ON == 'true' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion-comet', github.run_id) || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     container:
       image: amd64/rust
       env:
         JAVA_TOOL_OPTIONS: ${{ (matrix.profile.java_version == '17' || matrix.profile.java_version == '21') && '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED' || '' }}
 
     steps:
-      - uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0  # v2.1.0
       - uses: actions/checkout@v6
 
       - name: Setup Rust & Java toolchain
@@ -448,14 +443,12 @@ jobs:
   verify-benchmark-results-tpch:
     needs: build-native
     name: Verify TPC-H Results
-    runs-on: ${{ vars.USE_RUNS_ON == 'true' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion-comet', github.run_id) || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     container:
       image: amd64/rust
     env:
       JAVA_TOOL_OPTIONS: --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
     steps:
-      - uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0  # v2.1.0
-
       - uses: actions/checkout@v6
 
       - name: Setup Rust & Java toolchain
@@ -504,7 +497,7 @@ jobs:
   verify-benchmark-results-tpcds:
     needs: build-native
     name: Verify TPC-DS Results (${{ matrix.join }})
-    runs-on: ${{ vars.USE_RUNS_ON == 'true' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion-comet', github.run_id) || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     container:
       image: amd64/rust
     env:
@@ -514,8 +507,6 @@ jobs:
         join: [sort_merge, broadcast, hash]
       fail-fast: false
     steps:
-      - uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0  # v2.1.0
-
       - uses: actions/checkout@v6
 
       - name: Setup Rust & Java toolchain

--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -288,11 +288,6 @@ jobs:
             maven_opts: "-Pspark-3.5 -Pscala-2.13"
             scan_impl: "native_iceberg_compat"
 
-          - name: "Spark 4.0, JDK 17"
-            java_version: "17"
-            maven_opts: "-Pspark-4.0"
-            scan_impl: "auto"
-
           - name: "Spark 4.0, JDK 21"
             java_version: "21"
             maven_opts: "-Pspark-4.0"

--- a/.github/workflows/pr_markdown_format.yml
+++ b/.github/workflows/pr_markdown_format.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   prettier-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/pr_missing_suites.yml
+++ b/.github/workflows/pr_missing_suites.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   check-missing-suites:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - name: Check Missing Suites

--- a/.github/workflows/pr_title_check.yml
+++ b/.github/workflows/pr_title_check.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   check-pr-title:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - name: Check PR title

--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -147,7 +147,7 @@ jobs:
     # Hive tests stay on the standard GitHub-hosted runner: HiveSparkSubmitSuite
     # relies on an Ivy 'local-m2-cache' resolver that the runs-on.com
     # ubuntu24-full-x64 image does not provide, so spark-submit fails there.
-    runs-on: ${{ startsWith(matrix.module.name, 'sql_hive') && 'ubuntu-24.04' || (github.repository_owner == 'apache' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion-comet', github.run_id) || 'ubuntu-latest') }}
+    runs-on: ${{ startsWith(matrix.module.name, 'sql_hive') && 'ubuntu-24.04' || (vars.USE_RUNS_ON == 'true' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion-comet', github.run_id) || 'ubuntu-latest') }}
     container:
       image: amd64/rust
     steps:
@@ -174,12 +174,18 @@ jobs:
           cd apache-spark
           rm -rf /root/.m2/repository/org/apache/parquet # somehow parquet cache requires cleanups
           NOLINT_ON_COMPILE=true ENABLE_COMET=true ENABLE_COMET_ONHEAP=true COMET_PARQUET_SCAN_IMPL=${{ matrix.config.scan-impl }} ENABLE_COMET_LOG_FALLBACK_REASONS=${{ github.event.inputs.collect-fallback-logs || 'false' }} \
-            build/sbt -Dsbt.log.noformat=true -mem 6144 ${{ matrix.module.args1 }} "${{ matrix.module.args2 }}"
+            build/sbt -Dsbt.log.noformat=true -mem $SBT_MEM ${{ matrix.module.args1 }} "${{ matrix.module.args2 }}"
           if [ "${{ github.event.inputs.collect-fallback-logs }}" = "true" ]; then
             find . -type f -name "unit-tests.log" -print0 | xargs -0 grep -h "Comet cannot accelerate" | sed 's/.*Comet cannot accelerate/Comet cannot accelerate/' | sort -u > fallback.log
           fi
         env:
           LC_ALL: "C.UTF-8"
+          # Standard GitHub runners have 7 GB RAM; cap SBT heap so forked test
+          # JVMs fit alongside it. The runs-on.com runner has more headroom.
+          SBT_MEM: ${{ vars.USE_RUNS_ON == 'true' && '6144' || '3072' }}
+          # Disable parallel test execution on standard runners to reduce peak
+          # memory usage — mirrors what apache/spark does on GitHub Actions.
+          SERIAL_SBT_TESTS: ${{ vars.USE_RUNS_ON == 'true' && '' || '1' }}
           # Mirror Spark's own JDK 21 / 25 CI workaround. apache/spark's
           # build_java21.yml and build_java25.yml set this same env var to
           # process-isolate the V1/V2 Parquet and Orc source suites because

--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -143,7 +143,7 @@ jobs:
           - {spark-short: '4.1', spark-full: '4.1.1', java: 17, scan-impl: 'auto'}
       fail-fast: false
     name: spark-sql-${{ matrix.config.scan-impl }}-${{ matrix.module.name }}/spark-${{ matrix.config.spark-full }}-jdk${{ matrix.config.java }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: amd64/rust
     steps:

--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -128,17 +128,9 @@ jobs:
       matrix:
         module:
           - {name: "catalyst", args1: "catalyst/test", args2: ""}
-          # sql_core-1 and sql_core-3 are split into -a (execution subpackage)
-          # and -b (top-level + non-execution subpackages) so each chunk runs in
-          # a fresh test JVM and avoids the memory accumulation that was OOM-killing
-          # the combined runs on 7 GB standard runners. The -b entries chain two
-          # sbt testOnly invocations; sbt's `fork in Test := true` causes each to
-          # spawn its own forked test JVM.
-          - {name: "sql_core-1a", args1: "", args2: "sql/testOnly org.apache.spark.sql.execution.* -- -l org.apache.spark.tags.ExtendedSQLTest -l org.apache.spark.tags.SlowSQLTest"}
-          - {name: "sql_core-1b", args1: "", args2: "sql/testOnly org.apache.spark.sql.streaming.* org.apache.spark.sql.connector.* org.apache.spark.sql.sources.* org.apache.spark.sql.analysis.* org.apache.spark.sql.internal.* org.apache.spark.sql.collation.* org.apache.spark.sql.jdbc.* org.apache.spark.sql.errors.* org.apache.spark.sql.test.* org.apache.spark.sql.scripting.* org.apache.spark.sql.util.* org.apache.spark.sql.classic.* org.apache.spark.sql.types.* org.apache.spark.sql.expressions.* org.apache.spark.sql.artifact.* org.apache.spark.sql.api.* org.apache.spark.sql.vectorized.* org.apache.spark.sql.catalyst.* -- -l org.apache.spark.tags.ExtendedSQLTest -l org.apache.spark.tags.SlowSQLTest; sql/testOnly * -- -l org.apache.spark.tags.ExtendedSQLTest -l org.apache.spark.tags.SlowSQLTest -m org.apache.spark.sql"}
+          - {name: "sql_core-1", args1: "", args2: "sql/testOnly * -- -l org.apache.spark.tags.ExtendedSQLTest -l org.apache.spark.tags.SlowSQLTest"}
           - {name: "sql_core-2", args1: "", args2: "sql/testOnly * -- -n org.apache.spark.tags.ExtendedSQLTest"}
-          - {name: "sql_core-3a", args1: "", args2: "sql/testOnly org.apache.spark.sql.execution.* -- -n org.apache.spark.tags.SlowSQLTest"}
-          - {name: "sql_core-3b", args1: "", args2: "sql/testOnly org.apache.spark.sql.streaming.* org.apache.spark.sql.connector.* org.apache.spark.sql.sources.* org.apache.spark.sql.analysis.* org.apache.spark.sql.internal.* org.apache.spark.sql.collation.* org.apache.spark.sql.jdbc.* org.apache.spark.sql.errors.* org.apache.spark.sql.test.* org.apache.spark.sql.scripting.* org.apache.spark.sql.util.* org.apache.spark.sql.classic.* org.apache.spark.sql.types.* org.apache.spark.sql.expressions.* org.apache.spark.sql.artifact.* org.apache.spark.sql.api.* org.apache.spark.sql.vectorized.* org.apache.spark.sql.catalyst.* -- -n org.apache.spark.tags.SlowSQLTest; sql/testOnly * -- -n org.apache.spark.tags.SlowSQLTest -m org.apache.spark.sql"}
+          - {name: "sql_core-3", args1: "", args2: "sql/testOnly * -- -n org.apache.spark.tags.SlowSQLTest"}
           - {name: "sql_hive-1", args1: "", args2: "hive/testOnly * -- -l org.apache.spark.tags.ExtendedHiveTest -l org.apache.spark.tags.SlowHiveTest"}
           - {name: "sql_hive-2", args1: "", args2: "hive/testOnly * -- -n org.apache.spark.tags.ExtendedHiveTest"}
           - {name: "sql_hive-3", args1: "", args2: "hive/testOnly * -- -n org.apache.spark.tags.SlowHiveTest"}

--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -139,7 +139,6 @@ jobs:
         config:
           - {spark-short: '3.4', spark-full: '3.4.3', java: 11, scan-impl: 'auto'}
           - {spark-short: '3.5', spark-full: '3.5.8', java: 11, scan-impl: 'auto'}
-          - {spark-short: '4.0', spark-full: '4.0.2', java: 17, scan-impl: 'auto'}
           - {spark-short: '4.0', spark-full: '4.0.2', java: 21, scan-impl: 'auto'}
           - {spark-short: '4.1', spark-full: '4.1.1', java: 17, scan-impl: 'auto'}
       fail-fast: false

--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -143,14 +143,10 @@ jobs:
           - {spark-short: '4.1', spark-full: '4.1.1', java: 17, scan-impl: 'auto'}
       fail-fast: false
     name: spark-sql-${{ matrix.config.scan-impl }}-${{ matrix.module.name }}/spark-${{ matrix.config.spark-full }}-jdk${{ matrix.config.java }}
-    # Hive tests stay on the standard GitHub-hosted runner: HiveSparkSubmitSuite
-    # relies on an Ivy 'local-m2-cache' resolver that the runs-on.com
-    # ubuntu24-full-x64 image does not provide, so spark-submit fails there.
-    runs-on: ${{ startsWith(matrix.module.name, 'sql_hive') && 'ubuntu-24.04' || (vars.USE_RUNS_ON == 'true' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion-comet', github.run_id) || 'ubuntu-latest') }}
+    runs-on: ubuntu-latest
     container:
       image: amd64/rust
     steps:
-      - uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0  # v2.1.0
       - uses: actions/checkout@v6
       - name: Setup Rust & Java toolchain
         uses: ./.github/actions/setup-builder
@@ -180,11 +176,11 @@ jobs:
         env:
           LC_ALL: "C.UTF-8"
           # Standard GitHub runners have 7 GB RAM; cap SBT heap so forked test
-          # JVMs fit alongside it. The runs-on.com runner has more headroom.
-          SBT_MEM: ${{ vars.USE_RUNS_ON == 'true' && '6144' || '3072' }}
-          # Disable parallel test execution on standard runners to reduce peak
-          # memory usage — mirrors what apache/spark does on GitHub Actions.
-          SERIAL_SBT_TESTS: ${{ vars.USE_RUNS_ON == 'true' && '' || '1' }}
+          # JVMs fit alongside it.
+          SBT_MEM: "3072"
+          # Disable parallel test execution to reduce peak memory usage —
+          # mirrors what apache/spark does on GitHub Actions.
+          SERIAL_SBT_TESTS: "1"
           # Mirror Spark's own JDK 21 / 25 CI workaround. apache/spark's
           # build_java21.yml and build_java25.yml set this same env var to
           # process-isolate the V1/V2 Parquet and Orc source suites because

--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -128,9 +128,17 @@ jobs:
       matrix:
         module:
           - {name: "catalyst", args1: "catalyst/test", args2: ""}
-          - {name: "sql_core-1", args1: "", args2: sql/testOnly * -- -l org.apache.spark.tags.ExtendedSQLTest -l org.apache.spark.tags.SlowSQLTest}
+          # sql_core-1 and sql_core-3 are split into -a (execution subpackage)
+          # and -b (top-level + non-execution subpackages) so each chunk runs in
+          # a fresh test JVM and avoids the memory accumulation that was OOM-killing
+          # the combined runs on 7 GB standard runners. The -b entries chain two
+          # sbt testOnly invocations; sbt's `fork in Test := true` causes each to
+          # spawn its own forked test JVM.
+          - {name: "sql_core-1a", args1: "", args2: "sql/testOnly org.apache.spark.sql.execution.* -- -l org.apache.spark.tags.ExtendedSQLTest -l org.apache.spark.tags.SlowSQLTest"}
+          - {name: "sql_core-1b", args1: "", args2: "sql/testOnly org.apache.spark.sql.streaming.* org.apache.spark.sql.connector.* org.apache.spark.sql.sources.* org.apache.spark.sql.analysis.* org.apache.spark.sql.internal.* org.apache.spark.sql.collation.* org.apache.spark.sql.jdbc.* org.apache.spark.sql.errors.* org.apache.spark.sql.test.* org.apache.spark.sql.scripting.* org.apache.spark.sql.util.* org.apache.spark.sql.classic.* org.apache.spark.sql.types.* org.apache.spark.sql.expressions.* org.apache.spark.sql.artifact.* org.apache.spark.sql.api.* org.apache.spark.sql.vectorized.* org.apache.spark.sql.catalyst.* -- -l org.apache.spark.tags.ExtendedSQLTest -l org.apache.spark.tags.SlowSQLTest; sql/testOnly * -- -l org.apache.spark.tags.ExtendedSQLTest -l org.apache.spark.tags.SlowSQLTest -m org.apache.spark.sql"}
           - {name: "sql_core-2", args1: "", args2: "sql/testOnly * -- -n org.apache.spark.tags.ExtendedSQLTest"}
-          - {name: "sql_core-3", args1: "", args2: "sql/testOnly * -- -n org.apache.spark.tags.SlowSQLTest"}
+          - {name: "sql_core-3a", args1: "", args2: "sql/testOnly org.apache.spark.sql.execution.* -- -n org.apache.spark.tags.SlowSQLTest"}
+          - {name: "sql_core-3b", args1: "", args2: "sql/testOnly org.apache.spark.sql.streaming.* org.apache.spark.sql.connector.* org.apache.spark.sql.sources.* org.apache.spark.sql.analysis.* org.apache.spark.sql.internal.* org.apache.spark.sql.collation.* org.apache.spark.sql.jdbc.* org.apache.spark.sql.errors.* org.apache.spark.sql.test.* org.apache.spark.sql.scripting.* org.apache.spark.sql.util.* org.apache.spark.sql.classic.* org.apache.spark.sql.types.* org.apache.spark.sql.expressions.* org.apache.spark.sql.artifact.* org.apache.spark.sql.api.* org.apache.spark.sql.vectorized.* org.apache.spark.sql.catalyst.* -- -n org.apache.spark.tags.SlowSQLTest; sql/testOnly * -- -n org.apache.spark.tags.SlowSQLTest -m org.apache.spark.sql"}
           - {name: "sql_hive-1", args1: "", args2: "hive/testOnly * -- -l org.apache.spark.tags.ExtendedHiveTest -l org.apache.spark.tags.SlowHiveTest"}
           - {name: "sql_hive-2", args1: "", args2: "hive/testOnly * -- -n org.apache.spark.tags.ExtendedHiveTest"}
           - {name: "sql_hive-3", args1: "", args2: "hive/testOnly * -- -n org.apache.spark.tags.SlowHiveTest"}

--- a/.github/workflows/validate_workflows.yml
+++ b/.github/workflows/validate_workflows.yml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
 

--- a/dev/diffs/3.4.3.diff
+++ b/dev/diffs/3.4.3.diff
@@ -918,7 +918,7 @@ index b5b34922694..a72403780c4 100644
    protected val baseResourcePath = {
      // use the same way as `SQLQueryTestSuite` to get the resource path
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
-index 525d97e4998..8a3e7457618 100644
+index 525d97e4998..f600e162da3 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
 @@ -1508,7 +1508,8 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
@@ -931,6 +931,16 @@ index 525d97e4998..8a3e7457618 100644
      AccumulatorSuite.verifyPeakExecutionMemorySet(sparkContext, "external sort") {
        sql("SELECT * FROM testData2 ORDER BY a ASC, b ASC").collect()
      }
+@@ -3730,7 +3731,8 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
+     }
+   }
+ 
+-  test("SPARK-33084: Add jar support Ivy URI in SQL") {
++  test("SPARK-33084: Add jar support Ivy URI in SQL",
++    IgnoreComet("Flaky: depends on external Maven Central download of legacy Hadoop/Hive jars")) {
+     val sc = spark.sparkContext
+     val hiveVersion = "2.3.9"
+     // transitive=false, only download specified jar
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
 index 48ad10992c5..51d1ee65422 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala

--- a/dev/diffs/3.5.8.diff
+++ b/dev/diffs/3.5.8.diff
@@ -937,7 +937,7 @@ index c26757c9cff..d55775f09d7 100644
    protected val baseResourcePath = {
      // use the same way as `SQLQueryTestSuite` to get the resource path
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
-index 3cf2bfd17ab..b1c1e41e6a9 100644
+index 3cf2bfd17ab..a3effb1eeb8 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
 @@ -1521,7 +1521,8 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
@@ -950,6 +950,16 @@ index 3cf2bfd17ab..b1c1e41e6a9 100644
      AccumulatorSuite.verifyPeakExecutionMemorySet(sparkContext, "external sort") {
        sql("SELECT * FROM testData2 ORDER BY a ASC, b ASC").collect()
      }
+@@ -3750,7 +3751,8 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
+     }
+   }
+ 
+-  test("SPARK-33084: Add jar support Ivy URI in SQL") {
++  test("SPARK-33084: Add jar support Ivy URI in SQL",
++    IgnoreComet("Flaky: depends on external Maven Central download of legacy Hadoop/Hive jars")) {
+     val sc = spark.sparkContext
+     val hiveVersion = "2.3.9"
+     // transitive=false, only download specified jar
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
 index 8b4ac474f87..3f79f20822f 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala

--- a/dev/diffs/4.1.1.diff
+++ b/dev/diffs/4.1.1.diff
@@ -3676,6 +3676,20 @@ index 11b761f1e4a..e54bf2a996a 100644
            s"Local limit was not LocalLimitExec:\n$execPlan")
        }
      }
+diff --git a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
+index e57c4e1e665..1dd8b80a006 100644
+--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
++++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
+@@ -73,7 +73,8 @@ import org.apache.spark.util.{Clock, SystemClock, Utils}
+  * avoid hanging forever in the case of failures. However, individual suites can change this
+  * by overriding `streamingTimeout`.
+  */
+-trait StreamTest extends QueryTest with SharedSparkSession with TimeLimits with BeforeAndAfterAll {
++trait StreamTest extends QueryTest with SharedSparkSession with TimeLimits with BeforeAndAfterAll
++  with org.apache.spark.sql.IgnoreCometSuite {
+ 
+   // Necessary to make ScalaTest 3.x interrupt a thread on the JVM like ScalaTest 2.2.x
+   implicit val defaultSignaler: Signaler = ThreadSignaler
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationDistributionSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationDistributionSuite.scala
 index 465da3cd469..92ac998929d 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationDistributionSuite.scala


### PR DESCRIPTION
## Summary

- Gates `runs-on.com` usage behind the `vars.USE_RUNS_ON` repository variable so CI falls back to standard GitHub-hosted runners when the ASF cloud runners are unavailable (incorporates #4276)
- On standard runners (7 GB RAM), reduces SBT heap from 6 GB to 3 GB and sets `SERIAL_SBT_TESTS=1` to disable parallel test forking — matching what `apache/spark` does in its own GitHub Actions workflows to avoid OOM kills

## Details

The ASF took away the `runs-on.com` runners Comet was using. On the regular 7 GB GitHub runners, Spark 4 jobs get OOM-killed because:
1. `-mem 6144` requests nearly all available RAM for the SBT launcher alone
2. Parallel test forking spawns additional JVMs that push total usage over the limit

Apache Spark's own CI solves this by using `SERIAL_SBT_TESTS=1` (sequential test execution) and a 4 GB heap cap. This PR takes the same approach with a 3 GB SBT heap to leave headroom for the native Comet library.

When `vars.USE_RUNS_ON` is set to `'true'` in the repository settings, the previous behavior (16-CPU cloud runners, 6 GB SBT heap, parallel tests) is restored.

Supersedes #4276.

## Test plan

- [ ] Verify Spark 4.0/4.1 SQL test jobs no longer get OOM-killed on `ubuntu-latest`
- [ ] Verify Spark 3.4/3.5 jobs still pass (they were less memory-hungry but benefit from the same fix)
- [ ] When `vars.USE_RUNS_ON` is re-enabled, verify jobs use the cloud runners with full memory