### PR TITLE
feat: add native support for substring_index expression

### DIFF
--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -563,7 +563,7 @@
 - [x] startswith
 - [x] substr
 - [x] substring
-- [ ] substring_index
+- [x] substring_index
 - [ ] to_binary
 - [ ] to_char
 - [ ] to_number

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -198,6 +198,7 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
       classOf[Left] -> CometLeft,
       classOf[Right] -> CometRight,
       classOf[Substring] -> CometSubstring,
+      classOf[SubstringIndex] -> CometSubstringIndex,
       classOf[Upper] -> CometUpper)
 
   private val bitwiseExpressions: Map[Class[_ <: Expression], CometExpressionSerde[_]] = Map(

--- a/spark/src/main/scala/org/apache/comet/serde/strings.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/strings.scala
@@ -21,7 +21,7 @@ package org.apache.comet.serde
 
 import java.util.Locale
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Concat, ConcatWs, Expression, GetJsonObject, If, InitCap, IsNull, Left, Length, Like, Literal, Lower, RegExpReplace, Right, RLike, StringLPad, StringRepeat, StringRPad, StringSplit, Substring, Upper}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Concat, ConcatWs, Expression, GetJsonObject, If, InitCap, IsNull, Left, Length, Like, Literal, Lower, RegExpReplace, Right, RLike, StringLPad, StringRepeat, StringRPad, StringSplit, Substring, SubstringIndex, Upper}
 import org.apache.spark.sql.types.{BinaryType, DataTypes, LongType, StringType}
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -126,6 +126,22 @@ object CometSubstring extends CometExpressionSerde[Substring] {
         withInfo(expr, "Substring pos and len must be literals")
         None
     }
+  }
+}
+
+object CometSubstringIndex extends CometExpressionSerde[SubstringIndex] {
+
+  override def convert(
+      expr: SubstringIndex,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] = {
+    val strExpr = exprToProtoInternal(expr.strExpr, inputs, binding)
+    val delimExpr = exprToProtoInternal(expr.delimExpr, inputs, binding)
+    val countCast = Cast(expr.countExpr, LongType)
+    val countExpr = exprToProtoInternal(countCast, inputs, binding)
+    val optExpr =
+      scalarFunctionExprToProto("substring_index", strExpr, delimExpr, countExpr)
+    optExprWithInfo(optExpr, expr, expr.strExpr, expr.delimExpr, expr.countExpr)
   }
 }
 

--- a/spark/src/test/resources/sql-tests/expressions/string/substring_index.sql
+++ b/spark/src/test/resources/sql-tests/expressions/string/substring_index.sql
@@ -1,0 +1,119 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- ConfigMatrix: parquet.enable.dictionary=false,true
+
+statement
+CREATE TABLE test_substring_index(s string, delim string, cnt int) USING parquet
+
+statement
+INSERT INTO test_substring_index VALUES
+  ('www.apache.org', '.', 1),
+  ('www.apache.org', '.', 2),
+  ('www.apache.org', '.', 3),
+  ('www.apache.org', '.', -1),
+  ('www.apache.org', '.', -2),
+  ('www.apache.org', '.', -3),
+  ('www.apache.org', '.', 0),
+  ('hello', '.', 1),
+  ('', '.', 1),
+  ('www.apache.org', '', 1),
+  (NULL, '.', 1),
+  ('www.apache.org', NULL, 1),
+  ('www.apache.org', '.', NULL)
+
+-- all columns
+query
+SELECT substring_index(s, delim, cnt) FROM test_substring_index
+
+-- literal arguments
+query
+SELECT substring_index('www.apache.org', '.', 1),
+       substring_index('www.apache.org', '.', 2),
+       substring_index('www.apache.org', '.', -1),
+       substring_index('www.apache.org', '.', -2),
+       substring_index('www.apache.org', '.', 0)
+
+-- NULL literal arguments
+query
+SELECT substring_index(NULL, '.', 1),
+       substring_index('www.apache.org', NULL, 1),
+       substring_index('www.apache.org', '.', NULL)
+
+-- column string, literal delimiter and count
+query
+SELECT substring_index(s, '.', 1) FROM test_substring_index
+
+-- literal string, column delimiter and count
+query
+SELECT substring_index('www.apache.org', delim, cnt) FROM test_substring_index
+
+-- count exceeds number of delimiters (returns full string)
+query
+SELECT substring_index('www.apache.org', '.', 10),
+       substring_index('www.apache.org', '.', -10)
+
+-- multi-character delimiter
+query
+SELECT substring_index('one::two::three', '::', 1),
+       substring_index('one::two::three', '::', 2),
+       substring_index('one::two::three', '::', -1),
+       substring_index('one::two::three', '::', -2)
+
+-- delimiter not found
+query
+SELECT substring_index('hello world', 'xyz', 1),
+       substring_index('hello world', 'xyz', -1)
+
+-- empty string input
+query
+SELECT substring_index('', '.', 1),
+       substring_index('', '.', -1)
+
+-- empty delimiter
+query
+SELECT substring_index('www.apache.org', '', 1),
+       substring_index('www.apache.org', '', -1)
+
+-- multibyte UTF-8 characters
+query
+SELECT substring_index('a.b.c', '.', 2),
+       substring_index('中文.测试.数据', '.', 1),
+       substring_index('中文.测试.数据', '.', -1),
+       substring_index('中文.测试.数据', '.', 2)
+
+-- delimiter at start of string
+query
+SELECT substring_index('.www.apache.org', '.', 1),
+       substring_index('.www.apache.org', '.', 2),
+       substring_index('.www.apache.org', '.', -1)
+
+-- delimiter at end of string
+query
+SELECT substring_index('www.apache.org.', '.', -1),
+       substring_index('www.apache.org.', '.', 3),
+       substring_index('www.apache.org.', '.', -2)
+
+-- delimiter equals the full string
+query
+SELECT substring_index('abc', 'abc', 1),
+       substring_index('abc', 'abc', -1)
+
+-- large count values
+query
+SELECT substring_index('www.apache.org', '.', 2147483647),
+       substring_index('www.apache.org', '.', -2147483647)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

`substring_index` is a commonly used Spark string function that was not yet supported natively by Comet, causing fallback to Spark execution.

## What changes are included in this PR?

Adds native support for the `substring_index(str, delim, count)` expression by delegating to DataFusion's built-in `substr_index` function (aliased as `substring_index`), which has identical semantics to Spark. The only adaptation needed is casting the `count` argument from `IntegerType` to `LongType` to match DataFusion's function signature.

Changes:
- Added `CometSubstringIndex` serde in `strings.scala`
- Registered in `QueryPlanSerde.stringExpressions` map
- Added comprehensive Comet SQL Test covering column/literal arguments, NULL propagation, empty strings, multi-character delimiters, multibyte UTF-8, boundary delimiters, large count values, and dictionary encoding via ConfigMatrix
- Marked `substring_index` as supported in the expressions support doc

The `implement-comet-expression` skill was used to scaffold this implementation.

## How are these changes tested?

Comet SQL Test at `spark/src/test/resources/sql-tests/expressions/string/substring_index.sql` with `ConfigMatrix: parquet.enable.dictionary=false,true` (2 test configurations). Covers:
- All-column, all-literal, and mixed column/literal argument combinations
- NULL in each argument position
- Empty string and empty delimiter
- Positive, negative, and zero count
- Count exceeding number of delimiters
- Multi-character delimiters
- Delimiter not found in string
- Multibyte UTF-8 characters (Chinese)
- Delimiter at start/end of string
- Delimiter equal to the full string
- Large count values (INT_MAX, -INT_MAX)