### PR TITLE
ci: skip workflows for PRs tagged `[skip ci]` or labeled `skip-ci`

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze Actions
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze Actions
-    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
+    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/iceberg_spark_test.yml
+++ b/.github/workflows/iceberg_spark_test.yml
@@ -66,7 +66,7 @@ jobs:
   # Build native library once and share with all test jobs
   build-native:
     name: Build Native Library
-    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
+    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     container:
       image: amd64/rust

--- a/.github/workflows/iceberg_spark_test.yml
+++ b/.github/workflows/iceberg_spark_test.yml
@@ -66,6 +66,7 @@ jobs:
   # Build native library once and share with all test jobs
   build-native:
     name: Build Native Library
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
     runs-on: ubuntu-24.04
     container:
       image: amd64/rust

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -51,6 +51,7 @@ on:
 jobs:
   miri:
     name: "Miri"
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -51,7 +51,7 @@ on:
 jobs:
   miri:
     name: "Miri"
-    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
+    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr_benchmark_check.yml
+++ b/.github/workflows/pr_benchmark_check.yml
@@ -46,7 +46,7 @@ env:
 jobs:
   benchmark-check:
     name: Benchmark Compile & Lint Check
-    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
+    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     container:
       image: amd64/rust

--- a/.github/workflows/pr_benchmark_check.yml
+++ b/.github/workflows/pr_benchmark_check.yml
@@ -46,6 +46,7 @@ env:
 jobs:
   benchmark-check:
     name: Benchmark Compile & Lint Check
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
     runs-on: ubuntu-24.04
     container:
       image: amd64/rust

--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -63,7 +63,7 @@ jobs:
   # Fast lint check - gates all other jobs
   lint:
     name: Lint
-    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
+    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     container:
       image: amd64/rust

--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -63,6 +63,7 @@ jobs:
   # Fast lint check - gates all other jobs
   lint:
     name: Lint
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
     runs-on: ubuntu-24.04
     container:
       image: amd64/rust

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -59,7 +59,7 @@ jobs:
   # Fast lint check - gates all other jobs (runs on Linux for cost efficiency)
   lint:
     name: Lint
-    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
+    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-latest
     container:
       image: amd64/rust

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -59,6 +59,7 @@ jobs:
   # Fast lint check - gates all other jobs (runs on Linux for cost efficiency)
   lint:
     name: Lint
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
     runs-on: ubuntu-latest
     container:
       image: amd64/rust

--- a/.github/workflows/pr_markdown_format.yml
+++ b/.github/workflows/pr_markdown_format.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   prettier-check:
-    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
+    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr_markdown_format.yml
+++ b/.github/workflows/pr_markdown_format.yml
@@ -28,6 +28,7 @@ on:
 
 jobs:
   prettier-check:
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr_missing_suites.yml
+++ b/.github/workflows/pr_missing_suites.yml
@@ -30,6 +30,7 @@ on:
 
 jobs:
   check-missing-suites:
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr_missing_suites.yml
+++ b/.github/workflows/pr_missing_suites.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   check-missing-suites:
-    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
+    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr_rat_check.yml
+++ b/.github/workflows/pr_rat_check.yml
@@ -35,7 +35,7 @@ on:
 jobs:
   rat-check:
     name: RAT License Check
-    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
+    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr_rat_check.yml
+++ b/.github/workflows/pr_rat_check.yml
@@ -35,6 +35,7 @@ on:
 jobs:
   rat-check:
     name: RAT License Check
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr_title_check.yml
+++ b/.github/workflows/pr_title_check.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   check-pr-title:
-    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
+    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr_title_check.yml
+++ b/.github/workflows/pr_title_check.yml
@@ -27,6 +27,7 @@ on:
 
 jobs:
   check-pr-title:
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -73,6 +73,7 @@ jobs:
   # Build native library once and share with all test jobs
   build-native:
     name: Build Native Library
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
     runs-on: ubuntu-24.04
     container:
       image: amd64/rust

--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -73,7 +73,7 @@ jobs:
   # Build native library once and share with all test jobs
   build-native:
     name: Build Native Library
-    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
+    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     container:
       image: amd64/rust

--- a/.github/workflows/validate_workflows.yml
+++ b/.github/workflows/validate_workflows.yml
@@ -32,6 +32,7 @@ on:
 
 jobs:
   validate:
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/validate_workflows.yml
+++ b/.github/workflows/validate_workflows.yml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   validate:
-    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
+    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Which issue does this PR close?

N/A.

## Rationale for this change

Allow contributors to opt out of CI runs on work-in-progress PRs by adding `[skip ci]` to the PR title. Saves runner minutes for draft iterations where CI feedback is not yet needed. Push events on `main` are unaffected; GitHub already honors `[skip ci]` in commit messages for push triggers.

## What changes are included in this PR?

Adds a job-level `if:` gate to the entry job of every PR-triggered workflow:

```yaml
if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]') }}
```

Downstream jobs cascade-skip via their `needs:` chain. Affected workflows: `codeql`, `iceberg_spark_test`, `miri`, `pr_benchmark_check`, `pr_build_linux`, `pr_build_macos`, `pr_markdown_format`, `pr_missing_suites`, `pr_rat_check`, `pr_title_check`, `spark_sql_test`, `validate_workflows`.

Note: removing `[skip ci]` from the title alone will not re-trigger workflows. A new push (or close/reopen) is required. This avoids re-triggering on every description edit, which would happen if `edited` were added to `pull_request.types`.

## How are these changes tested?

YAML validity confirmed locally. Behavior verifiable by opening a follow-up PR with `[skip ci]` in the title and observing that all CI jobs are skipped.