### PR TITLE
docs: update user guide supported expressions list

### DIFF
--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -216,11 +216,11 @@
 
 - [ ] add_months
 - [ ] convert_timezone
-- [x] curdate
-- [x] current_date
+- [ ] curdate
+- [ ] current_date
 - [ ] current_time
 - [ ] current_timestamp
-- [x] current_timezone
+- [ ] current_timezone
 - [x] date_add
 - [x] date_diff
 - [x] date_format

--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -432,11 +432,11 @@
 - [ ] bitmap_construct_agg
 - [ ] bitmap_count
 - [ ] bitmap_or_agg
-- [x] current_catalog
-- [x] current_database
-- [x] current_schema
-- [x] current_user
-- [x] equal_null
+- [ ] current_catalog
+- [ ] current_database
+- [ ] current_schema
+- [ ] current_user
+- [ ] equal_null
 - [ ] from_avro
 - [ ] from_protobuf
 - [ ] hll_sketch_estimate

--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -47,7 +47,7 @@
 - [x] bool_or
 - [ ] collect_list
 - [x] collect_set
-- [ ] corr
+- [x] corr
 - [x] count
 - [x] count_if
 - [ ] count_min_sketch
@@ -157,13 +157,13 @@
 ### bitwise_funcs
 
 - [x] `&`
-- [ ] `<<`
-- [ ] `>>`
+- [x] `<<`
+- [x] `>>`
 - [ ] `>>>`
 - [x] `^`
 - [x] bit_count
 - [x] bit_get
-- [ ] getbit
+- [x] getbit
 - [x] shiftright
 - [ ] shiftrightunsigned
 - [x] `|`
@@ -187,7 +187,7 @@
 - [ ] nullifzero
 - [x] nvl
 - [x] nvl2
-- [ ] when
+- [x] when
 - [ ] zeroifnull
 
 ### conversion_funcs
@@ -303,7 +303,7 @@
 - [x] crc32
 - [x] hash
 - [x] md5
-- [ ] sha
+- [x] sha
 - [x] sha1
 - [x] sha2
 - [x] xxhash64
@@ -335,23 +335,23 @@
 
 ### map_funcs
 
-- [ ] element_at
+- [x] element_at
 - [ ] map
 - [ ] map_concat
 - [x] map_contains_key
-- [ ] map_entries
-- [ ] map_from_arrays
-- [ ] map_from_entries
+- [x] map_entries
+- [x] map_from_arrays
+- [x] map_from_entries
 - [x] map_keys
-- [ ] map_values
+- [x] map_values
 - [x] str_to_map
 - [ ] try_element_at
 
 ### math_funcs
 
 - [x] `%`
-- [ ] `*`
-- [ ] `+`
+- [x] `*`
+- [x] `+`
 - [x] `-`
 - [x] `/`
 - [x] abs
@@ -373,7 +373,7 @@
 - [x] cot
 - [ ] csc
 - [x] degrees
-- [ ] div
+- [x] div
 - [ ] e
 - [x] exp
 - [x] expm1
@@ -384,7 +384,7 @@
 - [ ] hypot
 - [ ] least
 - [x] ln
-- [ ] log
+- [x] log
 - [x] log10
 - [ ] log1p
 - [x] log2
@@ -490,7 +490,7 @@
 - [x] `>`
 - [x] `>=`
 - [x] and
-- [ ] between
+- [x] between
 - [x] ilike
 - [x] in
 - [x] isnan
@@ -581,7 +581,7 @@
 ### struct_funcs
 
 - [x] named_struct
-- [ ] struct
+- [x] struct
 
 ### url_funcs
 

--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -94,9 +94,9 @@
 - [ ] percentile_approx
 - [ ] percentile_cont
 - [ ] percentile_disc
-- [x] regr_avgx
-- [x] regr_avgy
-- [x] regr_count
+- [ ] regr_avgx
+- [ ] regr_avgy
+- [ ] regr_count
 - [ ] regr_intercept
 - [ ] regr_r2
 - [ ] regr_slope

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -334,11 +334,6 @@ Comet supports using the following aggregate functions within window contexts wi
 | BloomFilterMightContain      |
 | Coalesce                     |
 | CheckOverflow                |
-| CurrentCatalog               |
-| CurrentDatabase              |
-| CurrentSchema                |
-| CurrentUser                  |
-| EqualNull                    |
 | KnownFloatingPointNormalized |
 | Literal                      |
 | MakeDecimal                  |

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -102,7 +102,7 @@ of expressions that be disabled.
 | ---------------- | ---------------------------- |
 | DateAdd          | `date_add`                   |
 | DateDiff         | `datediff`                   |
-| DateFormat        | `date_format`                |
+| DateFormat       | `date_format`                |
 | DateFromUnixDate | `date_from_unix_date`        |
 | DateSub          | `date_sub`                   |
 | DatePart         | `date_part(field, source)`   |
@@ -131,56 +131,56 @@ of expressions that be disabled.
 
 ## Math Expressions
 
-| Expression     | SQL       |
-| -------------- | --------- |
-| Abs            | `abs`     |
-| Acos           | `acos`    |
-| Acosh          | `acosh`   |
-| Add            | `+`       |
-| Asin           | `asin`    |
-| Asinh          | `asinh`   |
-| Atan           | `atan`    |
-| Atan2          | `atan2`   |
-| Atanh          | `atanh`   |
-| Bin            | `bin`     |
-| BRound         | `bround`  |
-| Cbrt           | `cbrt`    |
-| Ceil           | `ceil`    |
-| Cos            | `cos`     |
-| Cosh           | `cosh`    |
-| Cot            | `cot`     |
-| Divide         | `/`       |
-| Exp            | `exp`     |
-| Expm1          | `expm1`   |
-| Floor          | `floor`   |
-| Hex            | `hex`     |
-| IntegralDivide | `div`     |
-| IsNaN          | `isnan`   |
-| Log            | `log`     |
-| Log2           | `log2`    |
-| Log10          | `log10`   |
-| Multiply       | `*`       |
-| Pi             | `pi`      |
-| Pow            | `power`   |
-| Rand           | `rand`    |
-| Randn          | `randn`   |
-| Remainder      | `%`       |
-| Round          | `round`   |
-| Signum         | `signum`  |
-| Sin            | `sin`     |
-| Sinh           | `sinh`    |
-| Sqrt           | `sqrt`    |
-| Subtract       | `-`       |
-| Tan            | `tan`     |
-| Tanh           | `tanh`    |
-| ToDegrees      | `degrees` |
-| ToRadians      | `radians` |
-| TryAdd         | `try_add` |
-| TryDivide      | `try_div` |
-| TryMultiply    | `try_mul` |
-| TrySubtract    | `try_sub` |
-| UnaryMinus     | `-`       |
-| Unhex          | `unhex`   |
+| Expression     | SQL            |
+| -------------- | -------------- |
+| Abs            | `abs`          |
+| Acos           | `acos`         |
+| Acosh          | `acosh`        |
+| Add            | `+`            |
+| Asin           | `asin`         |
+| Asinh          | `asinh`        |
+| Atan           | `atan`         |
+| Atan2          | `atan2`        |
+| Atanh          | `atanh`        |
+| Bin            | `bin`          |
+| BRound         | `bround`       |
+| Cbrt           | `cbrt`         |
+| Ceil           | `ceil`         |
+| Cos            | `cos`          |
+| Cosh           | `cosh`         |
+| Cot            | `cot`          |
+| Divide         | `/`            |
+| Exp            | `exp`          |
+| Expm1          | `expm1`        |
+| Floor          | `floor`        |
+| Hex            | `hex`          |
+| IntegralDivide | `div`          |
+| IsNaN          | `isnan`        |
+| Log            | `log`          |
+| Log2           | `log2`         |
+| Log10          | `log10`        |
+| Multiply       | `*`            |
+| Pi             | `pi`           |
+| Pow            | `power`        |
+| Rand           | `rand`         |
+| Randn          | `randn`        |
+| Remainder      | `%`            |
+| Round          | `round`        |
+| Signum         | `signum`       |
+| Sin            | `sin`          |
+| Sinh           | `sinh`         |
+| Sqrt           | `sqrt`         |
+| Subtract       | `-`            |
+| Tan            | `tan`          |
+| Tanh           | `tanh`         |
+| ToDegrees      | `degrees`      |
+| ToRadians      | `radians`      |
+| TryAdd         | `try_add`      |
+| TryDivide      | `try_div`      |
+| TryMultiply    | `try_mul`      |
+| TrySubtract    | `try_sub`      |
+| UnaryMinus     | `-`            |
+| Unhex          | `unhex`        |
 | WidthBucket    | `width_bucket` |
 
 ## Hashing Functions
@@ -280,15 +280,16 @@ Comet supports using the following aggregate functions within window contexts wi
 
 ## Map Expressions
 
-| Expression      |
-| --------------- |
-| GetMapValue     |
-| MapContainsKey  |
-| MapKeys         |
-| MapEntries      |
-| MapValues       |
-| MapFromArrays   |
-| StringToMap     |
+| Expression     |
+| -------------- |
+| GetMapValue    |
+| MapContainsKey |
+| MapEntries     |
+| MapFromArrays  |
+| MapFromEntries |
+| MapKeys        |
+| MapValues      |
+| StringToMap    |
 
 ## Struct Expressions
 

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -100,8 +100,6 @@ of expressions that be disabled.
 
 | Expression       | SQL                          |
 | ---------------- | ---------------------------- |
-| CurrentDate      | `current_date`               |
-| CurrentTimezone  | `current_timezone`           |
 | DateAdd          | `date_add`                   |
 | DateDiff         | `datediff`                   |
 | DateFormat        | `date_format`                |

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -43,12 +43,13 @@ of expressions that be disabled.
 | EqualNullSafe      | `<=>`         |
 | GreaterThan        | `>`           |
 | GreaterThanOrEqual | `>=`          |
-| LessThan           | `<`           |
-| LessThanOrEqual    | `<=`          |
+| ILike              | `ILIKE`       |
 | In                 | `IN`          |
+| InSet              | `IN (...)`    |
 | IsNotNull          | `IS NOT NULL` |
 | IsNull             | `IS NULL`     |
-| InSet              | `IN (...)`    |
+| LessThan           | `<`           |
+| LessThanOrEqual    | `<=`          |
 | Not                | `NOT`         |
 | Or                 | `OR`          |
 
@@ -70,7 +71,9 @@ of expressions that be disabled.
 | Lower           |
 | OctetLength     |
 | Reverse         |
+| Right           |
 | RLike           |
+| Split           |
 | StartsWith      |
 | StringInstr     |
 | StringRepeat    |
@@ -84,6 +87,7 @@ of expressions that be disabled.
 | StringTrimLeft  |
 | StringTrimRight |
 | Substring       |
+| SubstringIndex  |
 | Upper           |
 
 ## JSON Functions
@@ -94,32 +98,38 @@ of expressions that be disabled.
 
 ## Date/Time Functions
 
-| Expression     | SQL                          |
-| -------------- | ---------------------------- |
-| DateAdd        | `date_add`                   |
-| DateDiff       | `datediff`                   |
-| DateFormat     | `date_format`                |
-| DateSub        | `date_sub`                   |
-| DatePart       | `date_part(field, source)`   |
-| Days           | `days`                       |
-| Extract        | `extract(field FROM source)` |
-| FromUnixTime   | `from_unixtime`              |
-| Hour           | `hour`                       |
-| LastDay        | `last_day`                   |
-| Minute         | `minute`                     |
-| Second         | `second`                     |
-| TruncDate      | `trunc`                      |
-| TruncTimestamp | `date_trunc`                 |
-| UnixDate       | `unix_date`                  |
-| UnixTimestamp  | `unix_timestamp`             |
-| Year           | `year`                       |
-| Month          | `month`                      |
-| DayOfMonth     | `day`/`dayofmonth`           |
-| DayOfWeek      | `dayofweek`                  |
-| WeekDay        | `weekday`                    |
-| DayOfYear      | `dayofyear`                  |
-| WeekOfYear     | `weekofyear`                 |
-| Quarter        | `quarter`                    |
+| Expression       | SQL                          |
+| ---------------- | ---------------------------- |
+| CurrentDate      | `current_date`               |
+| CurrentTimezone  | `current_timezone`           |
+| DateAdd          | `date_add`                   |
+| DateDiff         | `datediff`                   |
+| DateFormat        | `date_format`                |
+| DateFromUnixDate | `date_from_unix_date`        |
+| DateSub          | `date_sub`                   |
+| DatePart         | `date_part(field, source)`   |
+| Days             | `days`                       |
+| Extract          | `extract(field FROM source)` |
+| FromUnixTime     | `from_unixtime`              |
+| Hour             | `hour`                       |
+| LastDay          | `last_day`                   |
+| MakeDate         | `make_date`                  |
+| Minute           | `minute`                     |
+| NextDay          | `next_day`                   |
+| Second           | `second`                     |
+| TimestampSeconds | `timestamp_seconds`          |
+| TruncDate        | `trunc`                      |
+| TruncTimestamp   | `date_trunc`                 |
+| UnixDate         | `unix_date`                  |
+| UnixTimestamp    | `unix_timestamp`             |
+| Year             | `year`                       |
+| Month            | `month`                      |
+| DayOfMonth       | `day`/`dayofmonth`           |
+| DayOfWeek        | `dayofweek`                  |
+| WeekDay          | `weekday`                    |
+| DayOfYear        | `dayofyear`                  |
+| WeekOfYear       | `weekofyear`                 |
+| Quarter          | `quarter`                    |
 
 ## Math Expressions
 
@@ -127,11 +137,16 @@ of expressions that be disabled.
 | -------------- | --------- |
 | Abs            | `abs`     |
 | Acos           | `acos`    |
+| Acosh          | `acosh`   |
 | Add            | `+`       |
 | Asin           | `asin`    |
+| Asinh          | `asinh`   |
 | Atan           | `atan`    |
 | Atan2          | `atan2`   |
+| Atanh          | `atanh`   |
+| Bin            | `bin`     |
 | BRound         | `bround`  |
+| Cbrt           | `cbrt`    |
 | Ceil           | `ceil`    |
 | Cos            | `cos`     |
 | Cosh           | `cosh`    |
@@ -147,6 +162,7 @@ of expressions that be disabled.
 | Log2           | `log2`    |
 | Log10          | `log10`   |
 | Multiply       | `*`       |
+| Pi             | `pi`      |
 | Pow            | `power`   |
 | Rand           | `rand`    |
 | Randn          | `randn`   |
@@ -159,17 +175,21 @@ of expressions that be disabled.
 | Subtract       | `-`       |
 | Tan            | `tan`     |
 | Tanh           | `tanh`    |
+| ToDegrees      | `degrees` |
+| ToRadians      | `radians` |
 | TryAdd         | `try_add` |
 | TryDivide      | `try_div` |
 | TryMultiply    | `try_mul` |
 | TrySubtract    | `try_sub` |
 | UnaryMinus     | `-`       |
 | Unhex          | `unhex`   |
+| WidthBucket    | `width_bucket` |
 
 ## Hashing Functions
 
 | Expression  |
 | ----------- |
+| Crc32       |
 | Md5         |
 | Murmur3Hash |
 | Sha1        |
@@ -202,12 +222,16 @@ of expressions that be disabled.
 | CollectSet    |            |
 | Corr          |            |
 | Count         |            |
+| CountIf       | `count_if` |
 | CovPopulation |            |
 | CovSample     |            |
 | First         |            |
 | Last          |            |
 | Max           |            |
 | Min           |            |
+| RegrAvgx      | `regr_avgx` |
+| RegrAvgy      | `regr_avgy` |
+| RegrCount     | `regr_count` |
 | StddevPop     |            |
 | StddevSamp    |            |
 | Sum           |            |
@@ -246,25 +270,30 @@ Comet supports using the following aggregate functions within window contexts wi
 | ArrayJoin      |
 | ArrayMax       |
 | ArrayMin       |
+| ArrayPosition  |
 | ArrayRemove    |
 | ArrayRepeat    |
+| ArraysZip      |
 | ArrayUnion     |
 | ArraysOverlap  |
 | CreateArray    |
 | ElementAt      |
 | Flatten        |
 | GetArrayItem   |
+| Size           |
+| SortArray      |
 
 ## Map Expressions
 
-| Expression    |
-| ------------- |
-| GetMapValue   |
-| MapKeys       |
-| MapEntries    |
-| MapValues     |
-| MapFromArrays |
-| StringToMap   |
+| Expression      |
+| --------------- |
+| GetMapValue     |
+| MapContainsKey  |
+| MapKeys         |
+| MapEntries      |
+| MapValues       |
+| MapFromArrays   |
+| StringToMap     |
 
 ## Struct Expressions
 
@@ -275,6 +304,14 @@ Comet supports using the following aggregate functions within window contexts wi
 | GetStructField       |
 | JsonToStructs        |
 | StructsToJson        |
+
+## URL Functions
+
+| Expression   |
+| ------------ |
+| TryUrlDecode |
+| UrlDecode    |
+| UrlEncode    |
 
 ## Conversion Expressions
 
@@ -300,6 +337,11 @@ Comet supports using the following aggregate functions within window contexts wi
 | BloomFilterMightContain      |
 | Coalesce                     |
 | CheckOverflow                |
+| CurrentCatalog               |
+| CurrentDatabase              |
+| CurrentSchema                |
+| CurrentUser                  |
+| EqualNull                    |
 | KnownFloatingPointNormalized |
 | Literal                      |
 | MakeDecimal                  |

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -229,9 +229,6 @@ of expressions that be disabled.
 | Last          |            |
 | Max           |            |
 | Min           |            |
-| RegrAvgx      | `regr_avgx` |
-| RegrAvgy      | `regr_avgy` |
-| RegrCount     | `regr_count` |
 | StddevPop     |            |
 | StddevSamp    |            |
 | Sum           |            |


### PR DESCRIPTION
## Summary

Comprehensive audit and sync of expression documentation against the actual codebase.

### User guide additions
Adds 28 expressions to the user guide that have implementations but were missing from the user-facing docs:

| Category | Expressions Added |
|----------|-------------------|
| Predicate | ILike |
| String | Right, Split, SubstringIndex |
| Date/Time | DateFromUnixDate, MakeDate, NextDay, TimestampSeconds |
| Math | Acosh, Asinh, Atanh, Bin, Cbrt, Pi, ToDegrees, ToRadians, WidthBucket |
| Hashing | Crc32 |
| Aggregate | CountIf |
| Array | ArrayPosition, ArraysZip, SortArray, Size |
| Map | MapContainsKey, MapFromEntries |
| URL (new section) | UrlEncode, UrlDecode, TryUrlDecode |

### Contributor guide corrections

**Unchecked (no implementation exists):**
`regr_avgx`, `regr_avgy`, `regr_count`, `current_catalog`, `current_database`, `current_schema`, `current_user`, `equal_null`, `curdate`, `current_date`, `current_timezone`

**Checked off (implementation exists but was unmarked):**
`*`, `+`, `<<`, `>>`, `corr`, `div`, `getbit`, `log`, `map_entries`, `map_from_arrays`, `map_from_entries`, `map_values`, `element_at` (map), `sha`, `between`, `when`, `struct`

## Test plan

- [ ] Verify the documentation builds correctly (`cd docs && make html`)
- [ ] Expressions were verified by grepping for serde handlers in `QueryPlanSerde.scala` and native implementations in `native/spark-expr/`