### PR TITLE
docs: show child links on Expression Compatibility page

### DIFF
--- a/docs/source/user-guide/latest/compatibility/expressions/index.md
+++ b/docs/source/user-guide/latest/compatibility/expressions/index.md
@@ -26,8 +26,7 @@ the [Comet Supported Expressions Guide](../../expressions.md) for more informati
 Compatibility notes are grouped by expression category:
 
 ```{toctree}
-:maxdepth: 1
-:hidden:
+:maxdepth: 2
 
 aggregate
 array


### PR DESCRIPTION
## Summary

- The Expression Compatibility index page uses a `:hidden:` toctree, so the page body ends after "Compatibility notes are grouped by expression category:" with no visible links to the nine category sub-pages (aggregate, array, cast, datetime, map, math, misc, string, struct).
- The top-level user-guide toctree uses `:maxdepth: 1`, so those category pages also don't appear in the sidebar nav.
- Drop `:hidden:` and raise `:maxdepth:` to 2 on `compatibility/expressions/index.md` so Sphinx renders the linked list inline.

## Test plan

- [ ] Build docs locally and confirm the Expression Compatibility page now shows links to each category sub-page.