### PR TITLE
feat: Wire DataFusion function Claude skill and `csc` 

### DIFF
--- a/.claude/skills/wire-datafusion-function/SKILL.md
+++ b/.claude/skills/wire-datafusion-function/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: wire-datafusion-function
+description: Use when wiring an existing DataFusion or datafusion-spark function into Comet for a Spark expression. Identifies the right wiring pattern (one-line passthrough, datafusion-spark UDF registration, or custom serde with input massaging / restrictions), applies the Scala serde, registers the UDF in jni_api when needed, and adds SQL file tests. Assumes the function already exists upstream — if not, switch to `implement-comet-expression`.
+argument-hint: <expression-name>
+---
+
+Wire Comet support for the `$ARGUMENTS` Spark expression by reusing an existing DataFusion or `datafusion-spark` function. **No native Rust implementation is written by this skill** — if upstream coverage is missing, stop and run `implement-comet-expression` instead.
+
+## Background reading
+
+- `docs/source/contributor-guide/adding_a_new_expression.md` — Scala serde, protobuf, support levels, SQL tests.
+- `docs/source/contributor-guide/sql-file-tests.md` — Comet SQL Tests format.
+- `spark/src/main/scala/org/apache/comet/serde/CometExpressionSerde.scala` — trait every serde implements.
+- `spark/src/main/scala/org/apache/comet/serde/CometScalarFunction.scala` — the one-line passthrough wrapper.
+- `spark/src/main/scala/org/apache/comet/serde/SupportLevel.scala` — `Compatible` / `Incompatible` / `Unsupported`.
+
+## Wiring patterns
+
+Pick the lightest pattern that satisfies the Spark contract. Steps below tell you which one to use.
+
+### Pattern A — One-line passthrough (cleanest)
+
+Spark expression maps directly to a function name resolvable at runtime. The function lives in either `datafusion-functions` (registered by default in `SessionContext`) or in `datafusion-spark` and is **already** registered in `register_datafusion_spark_function`. Single line in the right map of `QueryPlanSerde.scala`:
+
+```scala
+classOf[Acos] -> CometScalarFunction("acos"),                 // datafusion-functions built-in
+classOf[Crc32] -> CometScalarFunction("crc32"),               // datafusion-spark SparkCrc32 (already registered)
+classOf[DateAdd] -> CometScalarFunction[DateAdd]("date_add"), // see datetime.scala
+```
+
+### Pattern B — Pattern A plus a one-line UDF registration
+
+Same one-liner in `QueryPlanSerde.scala`, **plus** registering the new `datafusion-spark` UDF in `native/core/src/execution/jni_api.rs::register_datafusion_spark_function`:
+
+```rust
+session_ctx.register_udf(ScalarUDF::new_from_impl(SparkXyz::default()));
+```
+
+Function names must match — the Scala name passed to `CometScalarFunction("xyz")` must equal `SparkXyz::name()` in the upstream crate.
+
+### Pattern C — Custom `CometExpressionSerde`
+
+Use when the Spark contract requires any of:
+
+- preprocessing inputs (e.g. wrap with `nullIfNegative`, add `+0.0` to flip `-0.0`, cast),
+- setting an explicit return type or `fail_on_error` flag → use `scalarFunctionExprToProtoWithReturnType`,
+- restricting supported input types → implement `getSupportLevel` returning `Unsupported(notes)` / `Incompatible(notes)`,
+- foldable / literal-only argument checks (e.g. `Sha2.numBits` must be a literal),
+- documenting always-on differences via `getCompatibleNotes` / `getIncompatibleReasons` / `getUnsupportedReasons`.
+
+Examples to study before writing one: `CometCeil` / `CometFloor` (decimal scale fallback), `CometAtan2` (input massaging), `CometLog` (null-if-negative), `CometSha2` (literal-only argument), `CometAbs` (`getSupportLevel`).
+
+## Workflow
+
+### 1. Study the Spark master implementation
+
+Same as step 1 of `implement-comet-expression`. Shallow-clone if missing, then grep for the expression class. The class name is PascalCase (e.g. `Csc`, not `csc`); capitalize `$ARGUMENTS` before grepping, or use `-i`:
+
+```bash
+if [ ! -d /tmp/spark-master ]; then
+  git clone --depth 1 https://github.com/apache/spark.git /tmp/spark-master
+fi
+
+CLASS_NAME="$(printf '%s' "$ARGUMENTS" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')"
+find /tmp/spark-master/sql -name "*.scala" | \
+  xargs grep -l "case class ${CLASS_NAME}\b\|object ${CLASS_NAME}\b" 2>/dev/null
+```
+
+If the `git clone` is blocked (e.g. sandboxed environment), **stop and ask the user for an alternative source** — typically a local Spark clone path. Then point grep at that path instead. Do not silently skip Spark study — the Spark contract is the ground truth.
+
+Note `inputTypes`, `dataType`, `eval` / `nullSafeEval`, ANSI mode branches, `require` guards, and any foldable-only arguments. These define the Spark contract Comet must match.
+
+### 2. Find the upstream function
+
+Read the pinned `datafusion-spark` version from `native/Cargo.toml` rather than picking the first cached copy — `head -1` can land on an older release that lacks the function:
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+DF_SPARK_VER=$(awk -F'"' '/^datafusion-spark\b/ {print $2; exit}' "$REPO_ROOT/native/Cargo.toml")
+DF_SPARK=$(ls -d ~/.cargo/registry/src/*/datafusion-spark-${DF_SPARK_VER}/ 2>/dev/null | head -1)
+echo "Using datafusion-spark $DF_SPARK_VER at $DF_SPARK"
+
+DF_FUNCS_VER=$(awk -F'"' '/^datafusion = / {print $2; exit}' "$REPO_ROOT/native/Cargo.toml")
+DF_FUNCS=$(ls -d ~/.cargo/registry/src/*/datafusion-functions-${DF_FUNCS_VER}/ 2>/dev/null | head -1)
+
+grep -rin "fn name" "$DF_SPARK/src/function/" 2>/dev/null | grep -i "$ARGUMENTS"
+grep -rin "fn name" "$DF_FUNCS/src/" 2>/dev/null | grep -i "$ARGUMENTS"
+```
+
+If the cached crate directory does not exist (fresh checkout), run `cargo fetch` from `native/` first, or fall back to the latest cached version and verify the function exists in the pinned version's git tag before relying on it.
+
+Verify the candidate function's `Signature`, return type, and behavior matches Spark across all relevant edge cases (NULL, overflow, non-finite floats, decimal scale, locale, ANSI mode). If semantics diverge in a way the Scala serde can't bridge with preprocessing or restrictions → **stop and run `implement-comet-expression`** instead.
+
+For datafusion-spark candidates, also check whether the UDF is already pre-registered: see `register_datafusion_spark_function` in `native/core/src/execution/jni_api.rs`. If listed, you only need Pattern A. If missing, you need Pattern B.
+
+### 3. Pick the wiring pattern
+
+| Situation                                                                                             | Pattern |
+| ----------------------------------------------------------------------------------------------------- | ------- |
+| DF built-in (e.g. `acos`, `md5`, `replace`) matches Spark; or datafusion-spark UDF already registered | **A**   |
+| New `datafusion-spark` UDF, semantics already match Spark                                             | **B**   |
+| Inputs need preprocessing, restrictions, or explicit return type / failOnError                        | **C**   |
+
+When in doubt, start with the lightest pattern and escalate only if the Spark contract demands it.
+
+### 4. Apply the Scala wiring
+
+Add the entry to the matching map in `spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala`:
+
+- `mathExpressions`, `stringExpressions`, `arrayExpressions`, `mapExpressions`, `structExpressions`, `predicateExpressions`, `conditionalExpressions`, `bitwiseExpressions`, `temporalExpressions`, `hashExpressions`, `conversionExpressions`, `miscExpressions`.
+
+Confirm the Spark expression class is in scope. `QueryPlanSerde.scala` already imports `org.apache.spark.sql.catalyst.expressions._` (wildcard), so most expressions are picked up for free. For Pattern C, the topic file (`math.scala`, `strings.scala`, `datetime.scala`, `hash.scala`, `arrays.scala`, etc.) uses **explicit** imports — add the new class name to the existing `import org.apache.spark.sql.catalyst.expressions.{...}` line, and place the serde object alongside its peers.
+
+Helpers from `QueryPlanSerde`:
+
+- `scalarFunctionExprToProto(funcName, args*)` — basic call, `failOnError = false`, return type inferred from args.
+- `scalarFunctionExprToProtoWithReturnType(funcName, returnType, failOnError, args*)` — set explicit return type and/or `fail_on_error`.
+- `optExprWithInfo(optExpr, expr, children*)` — attaches the "why we couldn't convert" tag if any child failed; always wrap your final result.
+- `withInfo(expr, "reason")` — tag a fallback reason when returning `None`.
+
+For `getSupportLevel`, returning `Incompatible(Some("..."))` gates the function behind `spark.comet.expr.<exprConfigName>.allowIncompatible=true`. `Unsupported(notes)` always falls back to Spark.
+
+### 5. Apply the native registration (Pattern B only)
+
+In `native/core/src/execution/jni_api.rs::register_datafusion_spark_function`, add one line with the upstream import already in scope (or extend the imports). Keep the list grouped logically with neighboring entries.
+
+Pattern A and Pattern C **never** touch native code.
+
+### 6. Build and smoke-test
+
+Build the project (the user generally runs tests themselves — do not run them proactively unless asked):
+
+```bash
+make
+```
+
+If the user asks for a smoke test:
+
+```bash
+./mvnw test -Dsuites="org.apache.comet.CometSqlFileTestSuite $ARGUMENTS" -Dtest=none
+```
+
+### 7. Add SQL file tests
+
+Create `spark/src/test/resources/sql-tests/expressions/<category>/$ARGUMENTS.sql`. Coverage requirements (mandatory — do not skip):
+
+1. **Inspect the Spark source for accepted input datatypes.** Look at `inputTypes`, the parent class (`UnaryMathExpression`, `BinaryExpression`, `ImplicitCastInputTypes`, `ExpectsInputTypes`), and any `dataType` overrides. Add one column per supported type — e.g. for a numeric function: `ByteType`, `ShortType`, `IntegerType`, `LongType`, `FloatType`, `DoubleType`, `DecimalType` (varying precision/scale). For a string function: also cover `BinaryType` if accepted.
+2. **All `SELECT`s must read from a parquet table.** Do not write literal-only queries like `SELECT f(1.0), f(NULL)` — encode the values you want to test as rows in a parquet-backed table and query that. This exercises the real read path, not just the constant-folder.
+3. **Mix `NULL` into every column** so the kernel exercises the validity bitmap, not just the all-valid fast path.
+4. **Floating-point (`FloatType` / `DoubleType`)** columns must include: `NaN`, `+0.0`, `-0.0`, `-Infinity`, `+Infinity`. Use `cast('NaN' as double)`, `cast('Infinity' as double)`, `cast('-Infinity' as double)`.
+5. **Integer / decimal** columns must include each type's max and min (e.g. `127` / `-128` for byte, `2147483647` / `-2147483648` for int, `9223372036854775807` / `-9223372036854775808` for long, `Decimal(38, 0)` boundary for decimal) so overflow / wrap behavior is exercised.
+6. Cover the **Spark-specific edge cases identified in step 1** (negative scale, empty string, ANSI-mode error paths, etc.) — again, as rows in the parquet table.
+
+Use `query expect_fallback(...)` for inputs where the serde intentionally returns `None`. Format described in `docs/source/contributor-guide/sql-file-tests.md`.
+
+### 8. Update the documentation
+
+Two files are hand-curated (not regenerated by `make`) and must be updated for every newly wired expression:
+
+- `docs/source/user-guide/latest/expressions.md` — add a row to the matching category table (`## Math Expressions`, `## String Expressions`, etc.) in alphabetical order: `| <ExpressionClass> | \`<sql_name>\` |`.
+- `docs/source/contributor-guide/spark_expressions_support.md` — flip the entry from `- [ ] <name>` to `- [x] <name>` in the matching category section.
+
+Per-category compatibility pages under `docs/source/user-guide/latest/compatibility/expressions/*.md` are auto-generated by `GenerateDocs.scala` from `getCompatibleNotes` / `getIncompatibleReasons` / `getUnsupportedReasons`. Do not hand-edit those — `make` regenerates them.
+
+### 9. Run the audit skill
+
+Run `audit-comet-expression` on `$ARGUMENTS`. It compares against Spark 3.4.3, 3.5.8, and 4.0.1 and produces a prioritized gap list — usually missing test coverage. Iterate on tests until the user is satisfied.
+
+### 10. Final checks
+
+```bash
+make format
+cd native && cargo clippy --all-targets --workspace -- -D warnings
+```
+
+### 11. Open the PR
+
+Fill in every section of `.github/pull_request_template.md`. In "What changes are included in this PR?", note that the `wire-datafusion-function` skill was used and call out which upstream function (DataFusion built-in or `datafusion-spark::function::...`) is being wired.

--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -371,7 +371,7 @@
 - [x] cos
 - [x] cosh
 - [x] cot
-- [ ] csc
+- [x] csc
 - [x] degrees
 - [x] div
 - [ ] e

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -149,6 +149,7 @@ of expressions that be disabled.
 | Cos            | `cos`          |
 | Cosh           | `cosh`         |
 | Cot            | `cot`          |
+| Csc            | `csc`          |
 | Divide         | `/`            |
 | Exp            | `exp`          |
 | Expm1          | `expm1`        |

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -57,6 +57,7 @@ use datafusion_spark::function::map::map_from_entries::MapFromEntries;
 use datafusion_spark::function::map::str_to_map::SparkStrToMap;
 use datafusion_spark::function::math::expm1::SparkExpm1;
 use datafusion_spark::function::math::hex::SparkHex;
+use datafusion_spark::function::math::trigonometry::SparkCsc;
 use datafusion_spark::function::math::width_bucket::SparkWidthBucket;
 use datafusion_spark::function::string::char::CharFunc;
 use datafusion_spark::function::string::concat::SparkConcat;
@@ -591,6 +592,7 @@ fn register_datafusion_spark_function(session_ctx: &SessionContext) {
     session_ctx.register_udf(ScalarUDF::new_from_impl(SparkUrlDecode::default()));
     session_ctx.register_udf(ScalarUDF::new_from_impl(SparkUrlEncode::default()));
     session_ctx.register_udf(ScalarUDF::new_from_impl(SparkTryUrlDecode::default()));
+    session_ctx.register_udf(ScalarUDF::new_from_impl(SparkCsc::default()));
 }
 
 /// Prepares arrow arrays for output.

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -104,6 +104,7 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
     classOf[Ceil] -> CometCeil,
     classOf[Cos] -> CometScalarFunction("cos"),
     classOf[Cosh] -> CometScalarFunction("cosh"),
+    classOf[Csc] -> CometScalarFunction("csc"),
     classOf[Divide] -> CometDivide,
     classOf[Exp] -> CometScalarFunction("exp"),
     classOf[Expm1] -> CometScalarFunction("expm1"),

--- a/spark/src/test/resources/sql-tests/expressions/math/csc.sql
+++ b/spark/src/test/resources/sql-tests/expressions/math/csc.sql
@@ -1,0 +1,25 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+statement
+CREATE TABLE test_csc(d double) USING parquet
+
+statement
+INSERT INTO test_csc VALUES (0.0), (-0.0), (1.5707963267948966), (-1.5707963267948966), (3.141592653589793), (NULL), (cast('NaN' as double)), (cast('Infinity' as double)), (cast('-Infinity' as double))
+
+query tolerance=1e-6
+SELECT csc(d) FROM test_csc


### PR DESCRIPTION

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part #4150

## Rationale for this change

  Spark `csc(x) = 1 / sin(x)` was unsupported in Comet, falling back to Spark. The upstream `datafusion-spark` crate (53.1.0) ships a Spark-compatible `SparkCsc` implementation, so we can wire it
  directly with no native Rust written in this repo.

  This PR also adds a new Claude Code skill that codifies the wiring workflow used here, so future contributors can apply the same recipe consistently.

  ## What changes are included in this PR?

  **Wire Spark `Csc` to `datafusion-spark`:**

  - `spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala` — register `classOf[Csc] -> CometScalarFunction("csc")` in `mathExpressions`.
  - `native/core/src/execution/jni_api.rs` — register `SparkCsc` in `register_datafusion_spark_function`.
  - `docs/source/user-guide/latest/expressions.md` — add `Csc` to the Math Expressions table.
  - `docs/source/contributor-guide/spark_expressions_support.md` — flip `csc` checkbox to supported.

  Upstream function: `datafusion_spark::function::math::trigonometry::SparkCsc`. Wiring follows Pattern B (one-line Scala passthrough + one-line UDF registration).

  **New Claude Code skill `wire-datafusion-function`:**

  - `.claude/skills/wire-datafusion-function/SKILL.md` — project-level skill that walks contributors through wiring an existing DataFusion or `datafusion-spark` function into Comet. Documents the three
  wiring patterns (passthrough, UDF registration, custom serde with restrictions), the SQL-test coverage requirements (parquet-backed inputs, NULLs, FP edge cases, integer/decimal min/max), and the
  hand-curated docs that must be updated. Complements the existing `implement-comet-expression` skill — used here to scaffold the csc wiring.


