### PR TITLE
feat: Support Spark expression: current_time_zone

### DIFF
--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -220,7 +220,7 @@
 - [ ] current_date
 - [ ] current_time
 - [ ] current_timestamp
-- [ ] current_timezone
+- [x] current_timezone
 - [x] date_add
 - [x] date_diff
 - [x] date_format

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -100,6 +100,7 @@ of expressions that be disabled.
 
 | Expression       | SQL                          |
 | ---------------- | ---------------------------- |
+| CurrentTimeZone  | `current_timezone`           |
 | DateAdd          | `date_add`                   |
 | DateDiff         | `datediff`                   |
 | DateFormat       | `date_format`                |

--- a/spark/src/test/resources/sql-tests/expressions/datetime/current_timezone.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/current_timezone.sql
@@ -1,0 +1,40 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+statement
+CREATE TABLE test_current_timezone(id INT) USING parquet
+
+statement
+INSERT INTO test_current_timezone VALUES (1), (2), (3), (4), (NULL)
+
+query
+SELECT current_timezone()
+
+query
+SELECT current_timezone() IS NOT NULL
+
+query
+SELECT current_timezone() = current_timezone()
+
+query
+SELECT length(current_timezone()) > 0
+
+query
+SELECT id, current_timezone() IS NOT NULL FROM test_current_timezone
+
+query
+SELECT id FROM test_current_timezone WHERE current_timezone() = current_timezone()


### PR DESCRIPTION
## Which issue does this PR close?

Closes #3133 

## Rationale for this change
Spark's CurrentTimeZone expression is declared `Unevaluable`. It walks the plan, finds every CurrentTimeZone, reads `SQLConf.get.sessionLocalTimeZone` at plan time, and substitutes a Literal(<that-string>, StringType) in place of the expression, so Comet would only see a Literal(String).

We just need test and verify.

## What changes are included in this PR?
Add `current_timezone.sql`

## How are these changes tested?
run sql test in spark3.4/3.5/4.0 and prettier check
